### PR TITLE
Add Matthias and Hanno as maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,4 @@
 [//]: # (SPDX-License-Identifier: CC-BY-4.0)
-[//]: # (TODO Update list of maintainers)
 
 # Maintainers
 
@@ -7,5 +6,5 @@
 
 | Name                    | GitHub                                    | Chat           | Affliation
 |-------------------------|-------------------------------------------|----------------|----------------------
-| Nigel Jones             | [planetf1](https://github.com/planetf1)   | planetf1       | IBM
-
+| Hanno Becker            | [hanno-becker](https://github.com/hanno-becker) |              | AWS                  |
+| Matthias J. Kannwischer | [mkannwischer](https://github.com/mkannwischer) | matthiaskannwischer | Chelpis Quantum Tech |


### PR DESCRIPTION
Forgot to set the maintainers when this was created from the template. This adds https://github.com/hanno-becker and myself. 

@cothan, do you also want to be included here? Suggest an edit please in case you want to maintain this repo. 