### PR TITLE
Wrap up Nix configuration, setup arm64 github runner

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.3; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.3/direnvrc" "sha256-0EVQVNSRQWsln+rgPW3mXVmnF5sfcmKEYOmOSfLYxHg="
+fi
+
+use flake

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -3,11 +3,21 @@
 name: Setup nix
 description: Setup nix
 
+inputs:
+  script:
+    description: The script to be run in the nix shell
+    required: false
+
 runs:
   using: composite
   steps:
-    - uses: nixbuild/nix-quick-install-action@v27
-      with: {load_nixConfig: false}
+    - uses: DeterminateSystems/nix-installer-action@v11
     - name: Prepare nix dev shell
       shell: nix develop .#ci -c bash -e {0}
       run: |
+    - name: Dependency check
+      shell: nix develop .#ci -c bash -e {0}
+      if: inputs.script != ''
+      env:
+        INPUT_SCRIPT: ${{ inputs.script }}
+      run: eval "$INPUT_SCRIPT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
     branches: ["main"]
 jobs:
   build_test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup nix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup nix
         uses: ./.github/actions/setup-nix
+        with:
+          script: |
+            echo "Architecture: $(uname -m)"
+            astyle --version
+            gcc --version
       - name: Lint
         shell: nix develop .#ci -c bash -e {0}
         run: |
@@ -28,16 +33,16 @@ jobs:
         shell: nix develop .#ci -c bash -e {0}
         run: |
           make kat;
-          ./checksum.sh ./test/gen_KAT512  ec4ac397e595ac7457cb7d8830921faf3290898a10d7dd3864aab89ea61fe9a3
-          ./checksum.sh ./test/gen_KAT768  9a0826ad3c5232dfd3b21bc4801408655c565a491b760f509b2ee2cd7180babe
-          ./checksum.sh ./test/gen_KAT1024 6dafb867599b750a6a831b03e494cf41dea748c78a0e275e7b268bbb893cf37d
+          checksum ./test/gen_KAT512  ec4ac397e595ac7457cb7d8830921faf3290898a10d7dd3864aab89ea61fe9a3
+          checksum ./test/gen_KAT768  9a0826ad3c5232dfd3b21bc4801408655c565a491b760f509b2ee2cd7180babe
+          checksum ./test/gen_KAT1024 6dafb867599b750a6a831b03e494cf41dea748c78a0e275e7b268bbb893cf37d
       - name: Compare gen_NISTKAT with known hash
         shell: nix develop .#ci -c bash -e {0}
         run: |
           make nistkat;
-          ./checksum.sh ./test/gen_NISTKAT512  4b88ac7643ff60209af1175e025f354272e88df827a0ce1c056e403629b88e04
-          ./checksum.sh ./test/gen_NISTKAT768  21b4a1e1ea34a13c26a9da5eeb9325afb5ca11596ca6f3704c3f2637e3ea7524
-          ./checksum.sh ./test/gen_NISTKAT1024 6471398b0a728ee1ef39e93bb89b526fbf59587a3662edadbcfc6c88a512cd71
+          checksum ./test/gen_NISTKAT512  4b88ac7643ff60209af1175e025f354272e88df827a0ce1c056e403629b88e04
+          checksum ./test/gen_NISTKAT768  21b4a1e1ea34a13c26a9da5eeb9325afb5ca11596ca6f3704c3f2637e3ea7524
+          checksum ./test/gen_NISTKAT1024 6471398b0a728ee1ef39e93bb89b526fbf59587a3662edadbcfc6c88a512cd71
       - name: Clean up
         shell: nix develop .#ci -c bash -e {0}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,18 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           script: |
-            echo "Architecture: $(uname -m)"
-            astyle --version
-            gcc --version
+            cat >> $GITHUB_STEP_SUMMARY << EOF
+              ## Setup
+              Architecture: $(uname -m)
+              - $(nix --version)
+              - $(astyle --version)
+              - $(${{ matrix.cross_prefix }}gcc --version | grep -m1 "")
+              - $(bash --version | grep -m1 "")
+            EOF
       - name: Lint
         shell: nix develop .#ci -c bash -e {0}
         run: |
+          echo "## Lint & Checks" >> $GITHUB_STEP_SUMMARY
           lint
       - name: Build targets
         shell: nix develop .#ci -c bash -e {0}
@@ -33,17 +39,19 @@ jobs:
         shell: nix develop .#ci -c bash -e {0}
         run: |
           make kat;
-          checksum ./test/gen_KAT512  ec4ac397e595ac7457cb7d8830921faf3290898a10d7dd3864aab89ea61fe9a3
-          checksum ./test/gen_KAT768  9a0826ad3c5232dfd3b21bc4801408655c565a491b760f509b2ee2cd7180babe
-          checksum ./test/gen_KAT1024 6dafb867599b750a6a831b03e494cf41dea748c78a0e275e7b268bbb893cf37d
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+            ## KAT tests
+            $(checksum ./test/gen_KAT512  ec4ac397e595ac7457cb7d8830921faf3290898a10d7dd3864aab89ea61fe9a3)
+            $(checksum ./test/gen_KAT768  9a0826ad3c5232dfd3b21bc4801408655c565a491b760f509b2ee2cd7180babe)
+            $(checksum ./test/gen_KAT1024 6dafb867599b750a6a831b03e494cf41dea748c78a0e275e7b268bbb893cf37d)
+          EOF
       - name: Compare gen_NISTKAT with known hash
         shell: nix develop .#ci -c bash -e {0}
         run: |
           make nistkat;
-          checksum ./test/gen_NISTKAT512  4b88ac7643ff60209af1175e025f354272e88df827a0ce1c056e403629b88e04
-          checksum ./test/gen_NISTKAT768  21b4a1e1ea34a13c26a9da5eeb9325afb5ca11596ca6f3704c3f2637e3ea7524
-          checksum ./test/gen_NISTKAT1024 6471398b0a728ee1ef39e93bb89b526fbf59587a3662edadbcfc6c88a512cd71
-      - name: Clean up
-        shell: nix develop .#ci -c bash -e {0}
-        run: |
-          make clean
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+            ## NISTKAT tests
+            $(checksum ./test/gen_NISTKAT512  4b88ac7643ff60209af1175e025f354272e88df827a0ce1c056e403629b88e04)
+            $(checksum ./test/gen_NISTKAT768  21b4a1e1ea34a13c26a9da5eeb9325afb5ca11596ca6f3704c3f2637e3ea7524)
+            $(checksum ./test/gen_NISTKAT1024 6471398b0a728ee1ef39e93bb89b526fbf59587a3662edadbcfc6c88a512cd71)
+          EOF

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # (TODO customize .gitignore for project)
 
+.direnv
 .vscode
 .idea
 test/test_kyber512

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-CC ?= /usr/bin/cc
+CC ?= gcc
 INCLUDE_FIPS202 = -I fips202
 INCLUDE_MLKEM = -I mlkem
 INCLUDE_RANDOM = -I randombytes

--- a/flake.nix
+++ b/flake.nix
@@ -12,32 +12,36 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, nixpkgs, ... }:
+  outputs = inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [ ];
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-      perSystem = { pkgs, system, inputs', ... }:
+      perSystem = { pkgs, ... }:
         let
-          core = with pkgs; [
-            # formatter & linters
-            astyle # 3.4.10
-            nixpkgs-fmt
-            shfmt
-          ];
+          core = builtins.attrValues {
+            inherit (pkgs)
+              gcc13
+
+              # formatter & linters
+              astyle# 3.4.10
+              nixpkgs-fmt
+              shfmt;
+          };
         in
         {
-          devShells.default = with pkgs; mkShellNoCC {
-            packages = core ++ [
-              direnv
-              nix-direnv
-            ];
+          devShells.default = pkgs.mkShellNoCC {
+            packages = core ++ builtins.attrValues {
+              inherit (pkgs)
+                direnv
+                nix-direnv;
+            };
 
             shellHook = ''
               export PATH=$PWD/scripts:$PWD/scripts/ci:$PATH
             '';
           };
 
-          devShells.ci = with pkgs; mkShellNoCC {
+          devShells.ci = pkgs.mkShellNoCC {
             packages = core;
             shellHook = ''
               export PATH=$PWD/scripts:$PWD/scripts/ci:$PATH
@@ -53,4 +57,3 @@
       };
     };
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -16,17 +16,21 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [ ];
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-      perSystem = { pkgs, ... }:
+      perSystem = { pkgs, system, ... }:
         let
-          core = builtins.attrValues {
-            inherit (pkgs)
-              gcc13
+          # NOTE: For installing pkgs specific for aarch64 (not sure if there is any better way of doing this)
+          aarch64-system = "aarch64-" + pkgs.lib.lists.last (pkgs.lib.strings.splitString "-" system);
+          aarch64-pkgs = inputs.nixpkgs.legacyPackages.${aarch64-system};
+          core = builtins.attrValues
+            {
+              inherit (pkgs)
+                # formatter & linters
+                astyle# 3.4.10
+                nixpkgs-fmt
+                shfmt;
+            }
+          ++ [ (aarch64-pkgs.gcc13.override { propagateDoc = true; isGNU = true; }) ];
 
-              # formatter & linters
-              astyle# 3.4.10
-              nixpkgs-fmt
-              shfmt;
-          };
         in
         {
           devShells.default = pkgs.mkShellNoCC {

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -6,9 +6,9 @@
 output_hash=$(./$1 | sha256sum | awk '{ print $1 }')
 
 if [[ ${output_hash} == "${2}" ]]; then
-  echo "${1} Hashes match."
+  echo "${1#*_} Hashes match."
   exit 0
 else
-  echo "${1} Hashes do not match: ${output_hash} vs ${2}"
+  echo "${1#*_} Hashes do not match: ${output_hash} vs ${2}"
   exit 1
 fi

--- a/scripts/checksum
+++ b/scripts/checksum
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 
 # This script executes a binary file, captures its output, then generates and compares its SHA-256 hash with a provided one.

--- a/scripts/ci/lint
+++ b/scripts/ci/lint
@@ -8,19 +8,30 @@ set -o pipefail
 
 # consts
 ROOT="$(realpath "$(dirname "$0")"/../../)"
+GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-/dev/stdout}
 
 checkerr()
 {
-  if [[ $? == 127 ]]; then
-    SUCCESS=false
-    return
+  local code=$?
+  local title="$1"
+  local out="$2"
+  local success=true
+  if [[ $code == 127 ]]; then
+    success=false
   fi
 
-  if [[ ${#1} != 0 ]]; then
-    echo "$1" | while read -r file line; do
+  if [[ ${#out} != 0 ]]; then
+    echo "$out" | while read -r file line; do
       echo "::error file=$file,line=${line:-1},title=Format error::$file require to be formatted"
     done
+    success=false
+  fi
+
+  if $success; then
+    echo ":white_check_mark: $title" >>"$GITHUB_STEP_SUMMARY"
+  else
     SUCCESS=false
+    echo ":x: $title" >>"$GITHUB_STEP_SUMMARY"
   fi
 }
 
@@ -28,15 +39,15 @@ checkerr()
 SUCCESS=true
 
 echo "::group::Linting nix files with nixpkgs-fmt"
-checkerr "$(nixpkgs-fmt --check "$ROOT")"
+checkerr "Lint nix" "$(nixpkgs-fmt --check "$ROOT")"
 echo "::endgroup::"
 
 echo "::group::Linting shell scripts with shfmt"
-checkerr "$(shfmt -s -l -i 2 -ci -fn $(shfmt -f $(git grep -l '' :/)))"
+checkerr "Lint shell" "$(shfmt -s -l -i 2 -ci -fn $(shfmt -f $(git grep -l '' :/)))"
 echo "::endgroup::"
 
 echo "::group::Linting c files with astyle"
-checkerr "$(astyle $(git ls-files ":/*.c" ":/*.h") --options="$ROOT/.astylerc" --dry-run --formatted | awk '{print $2}')"
+checkerr "Lint C" "$(astyle $(git ls-files ":/*.c" ":/*.h") --options="$ROOT/.astylerc" --dry-run --formatted | awk '{print $2}')"
 echo "::endgroup::"
 
 check-eol-dry-run()
@@ -49,17 +60,25 @@ check-eol-dry-run()
   done
 }
 echo "::group::Checking eol"
-checkerr "$(check-eol-dry-run)"
+checkerr "Check eol" "$(check-eol-dry-run)"
 echo "::endgroup::"
 
 check-spdx()
 {
+  local success=true
   for file in $(git ls-files -- ":/" ":/!:*LICENSE*" ":/!:.git*" ":/!:flake.lock"); do
     if [[ $(grep "SPDX-License-Identifier:" $file | wc -l) == 0 ]]; then
-      echo "$file is missing SPDX License header"
-      SUCCESS=false
+      echo "::error file=$file,line=${line:-1},title=Missing license header error::$file is missing SPDX License header"
+      success=false
     fi
   done
+
+  if $success; then
+    echo ":white_check_mark: Check SPDX" >>"$GITHUB_STEP_SUMMARY"
+  else
+    SUCCESS=false
+    echo ":x: Check SPDX" >>"$GITHUB_STEP_SUMMARY"
+  fi
 }
 echo "::group::Checking SPDX headers"
 check-spdx


### PR DESCRIPTION
[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->
I've specifically specified to install arm64 gcc in nix

I've set macos-latest as our GitHub runner for now, according to the [official document](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), `macos-latest` is currently using M1 CPU with 7 GB RAM, which should help #38 for now. 

But as https://github.com/pq-code-package/mlkem-c-aarch64/issues/27 mentioned, we still would like a build system that support cross compilation and testing in qemu in the future

The `checksum.sh` script is moved under `scripts/` folder, and renamed as `checksum` for convenience. In the nix shell, `checksum` should be available instead of typing the whole path. 

In the ci action for setting up nix, I switched to use `DeterminateSystems/nix-installer-action` instead, as `nixbuild/nix-quick-install-action` currently doesn't support installing `nix` on macOS.

I've also added a summary for workflows, since I'm a bit lazy to jump into ci steps to see what's going on everytime :joy:

- **refactor nix configuration**
- **use macos-latest(arm64) as ci runner**
- **Add summary for github action**


<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
