### PR TITLE
Build CBMC from source and add to nix CI cache

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -13,6 +13,8 @@ runs:
   steps:
     - uses: DeterminateSystems/nix-installer-action@v12
     - uses: nix-community/cache-nix-action@v5
+      with: 
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
     - name: Prepare nix dev shell
       shell: nix develop .#ci -c bash -e {0}
       run: |

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -11,7 +11,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: DeterminateSystems/nix-installer-action@v11
+    - uses: DeterminateSystems/nix-installer-action@v12
+    - uses: nix-community/cache-nix-action@v5
     - name: Prepare nix dev shell
       shell: nix develop .#ci -c bash -e {0}
       run: |

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -12,9 +12,7 @@ runs:
   using: composite
   steps:
     - uses: DeterminateSystems/nix-installer-action@v12
-    - uses: nix-community/cache-nix-action@v5
-      with: 
-        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+    - uses: DeterminateSystems/magic-nix-cache-action@main
     - name: Prepare nix dev shell
       shell: nix develop .#ci -c bash -e {0}
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,8 @@
             version = "731338d5d82ac86fc447015e0bd24cdf7a74c442";
             src = pkgs.fetchFromGitHub {
               owner = "diffblue";
-              repo = "cbmc";
-              rev = "731338d5d82ac86fc447015e0bd24cdf7a74c442";
+              repo = old.pname;
+              rev = "${version}";
               hash = "sha256-fDLSo5EeHyPTliAqFp+5mfaB0iZXIMXeMyF21fjl5k4=";
             };
           });

--- a/flake.nix
+++ b/flake.nix
@@ -27,14 +27,24 @@
               hash = "sha256-eKYQq9OelOD5E+nuXNoehbtizWM1U97LngDT2SAQGc4=";
             };
           });
+          cbmc = pkgs.cbmc.overrideAttrs (old: rec {
+            version = "731338d5d82ac86fc447015e0bd24cdf7a74c442";
+            src = pkgs.fetchFromGitHub {
+              owner = "diffblue";
+              repo = "cbmc";
+              rev = "731338d5d82ac86fc447015e0bd24cdf7a74c442";
+              hash = "sha256-fDLSo5EeHyPTliAqFp+5mfaB0iZXIMXeMyF21fjl5k4=";
+            };
+          });
+
           core = builtins.attrValues
             {
               litani = litani; # 1.29.0
               cbmc-viewer = cbmc-viewer; # 3.8
               astyle = astyle;
+              cbmc = cbmc;
 
               inherit (pkgs)
-                cbmc# 5.95.1
                 ninja# 1.11.1
 
                 # formatter & linters


### PR DESCRIPTION
This PR is building CBMC from sources. Right now it's pinned to the `cbmc-5.95.1` tag (https://github.com/diffblue/cbmc/commit/731338d5d82ac86fc447015e0bd24cdf7a74c442), but we can update it to other commits when needed. 

The build requires around 10 minutes on my machine and in CI.

To make this feasible in the CI, the dependency builds are cached in the Github Action Cache using https://github.com/DeterminateSystems/magic-nix-cache. This means it should only take 10 minutes once, and then consecutive builds should be as fast as loading it from the package manager. 
I tested here by re-running the CI jobs and it seems to work fine.
If we see any CI performance degradation in other PRs, I'll need to look more into the configuration of https://github.com/DeterminateSystems/magic-nix-cache

