### PR TITLE
Use ubuntu-latest for lint job instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        system: [pqcp-arm64]
+        system: [ubuntu-latest]
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->
I think it makes more sense to run a normal job like linting on standard GitHub-hosted runner instead of a runner for special purpose like `pqcp-arm64`.

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
