### PR TITLE
Add nix instructions for developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ All the development and build dependencies are specified in [flake.nix](flake.ni
     - Running `nix develop` will execute a bash shell with the development environment specified in [flake.nix](flake.nix).
     - Alternatively, you can enable `direnv` by using `direnv allow`, allowing it to handle the environment setup for you.
 
-    - As flake is still an experimental feature of nix, --experimental-features 'nix-command flakes' is needed when running the nix command. Alternatively, add the following to your `~/.config/nix/nix.conf` or `/etc/nix/nix.conf`:
+    - As flake is still an experimental feature of nix, `--experimental-features 'nix-command flakes'` is needed when running the nix command. Alternatively, add the following to your `~/.config/nix/nix.conf` or `/etc/nix/nix.conf`:
 ```
 experimental-features = nix-command flakes
 ```
 
-- If you are not using nix, please ensure you have installed the same version as specified in [flake.nix](flake.nix).
+- If you are not using nix, please ensure you have installed the same versions as specified in [flake.nix](flake.nix).
 
 ### Development scripts
 After running `nix develop` you should automatically have a number of support scripts in your PATH:

--- a/README.md
+++ b/README.md
@@ -46,19 +46,23 @@ The current code is compatible with the [`standard` branch of the official MLKEM
 
 ### Environment Setup
 
-All the develop and build dependencies are specified in [flake.nix](flake.nix). 
+All the development and build dependencies are specified in [flake.nix](flake.nix). We recommend installing them using [nix](https://nixos.org/download/).
 
-- Setup with nix,
+- **Setup with nix**
     - Running `nix develop` will execute a bash shell with the development environment specified in [flake.nix](flake.nix).
     - Alternatively, you can enable `direnv` by using `direnv allow`, allowing it to handle the environment setup for you.
 
-    - As flake is still an experimental feature of nix, --experimental-features 'nix-command flakes' is needed for nix command. Alternatively, add the following to your `~/.config/nix/nix.conf` or `/etc/nix/nix.conf`:
+    - As flake is still an experimental feature of nix, --experimental-features 'nix-command flakes' is needed when running the nix command. Alternatively, add the following to your `~/.config/nix/nix.conf` or `/etc/nix/nix.conf`:
 ```
 experimental-features = nix-command flakes
 ```
 
 - If you are not using nix, please ensure you have installed the same version as specified in [flake.nix](flake.nix).
 
+### Development scripts
+After running `nix development` you should automatically have a number of support scripts in your PATH:
+
+- [`format`](scripts/format) formats all files. The format is enforced by our CI, so you should run this script prior to committing.
 
 ## Call for contributors
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ experimental-features = nix-command flakes
 - If you are not using nix, please ensure you have installed the same version as specified in [flake.nix](flake.nix).
 
 ### Development scripts
-After running `nix development` you should automatically have a number of support scripts in your PATH:
+After running `nix develop` you should automatically have a number of support scripts in your PATH:
 
 - [`format`](scripts/format) formats all files. The format is enforced by our CI, so you should run this script prior to committing.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ Once we have the first stable version, this notice will be removed.
 
 The current code is compatible with the [`standard` branch of the official MLKEM repository](https://github.com/pq-crystals/kyber/tree/standard).
 
+
+## Development
+
+### Environment Setup
+
+All the develop and build dependencies are specified in [flake.nix](flake.nix). 
+
+- Setup with nix,
+    - Running `nix develop` will execute a bash shell with the development environment specified in [flake.nix](flake.nix).
+    - Alternatively, you can enable `direnv` by using `direnv allow`, allowing it to handle the environment setup for you.
+
+    - As flake is still an experimental feature of nix, --experimental-features 'nix-command flakes' is needed for nix command. Alternatively, add the following to your `~/.config/nix/nix.conf` or `/etc/nix/nix.conf`:
+```
+experimental-features = nix-command flakes
+```
+
+- If you are not using nix, please ensure you have installed the same version as specified in [flake.nix](flake.nix).
+
+
 ## Call for contributors
 
 We are actively seeking contributors who can help us build **mlkem-c-aarch64**.


### PR DESCRIPTION
The instructions for setting up using `nix` were not copied over when the nix setup was taken from https://github.com/pq-code-package/mlkem-c-embedded. I added them now. 

@hanno-becker does this contain all the information you were missing?