### PR TITLE
Contract-based proofs of poly.c scalar_[de]compress_q*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SOURCESKECCAK = $(SOURCES) fips202/keccakf1600.c fips202/fips202.c mlkem/symmetr
 SOURCESKECCAKRANDOM = $(SOURCESKECCAK) randombytes/randombytes.c
 SOURCESNISTKATS = $(SOURCESKECCAK) test/nistrng/aes.c test/nistrng/rng.c
 
-HEADERS = mlkem/params.h mlkem/kem.h mlkem/indcpa.h mlkem/polyvec.h mlkem/poly.h mlkem/ntt.h mlkem/cbd.h mlkem/reduce.c mlkem/verify.h mlkem/symmetric.h
+HEADERS = mlkem/params.h mlkem/kem.h mlkem/indcpa.h mlkem/polyvec.h mlkem/poly.h mlkem/ntt.h mlkem/cbd.h mlkem/reduce.h mlkem/verify.h mlkem/symmetric.h
 HEADERSKECCAK = $(HEADERS) fips202/keccakf1600.h fips202/fips202.h
 HEADERSKECCAKRANDOM = $(HEADERSKECCAK) randombytes/randombytes.h
 HEADERNISTKATS = $(HEADERSKECCAK) test/nistrng/aes.h test/nistrng/randombytes.h

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -515,6 +515,8 @@ COMMA :=,
 # Set C compiler defines
 
 CBMCFLAGS += --object-bits $(CBMC_OBJECT_BITS)
+
+# --object_bits is removed in goto-cc 6.0.0
 COMPILE_FLAGS += --object-bits $(CBMC_OBJECT_BITS)
 
 DEFINES += -DCBMC=1

--- a/cbmc/proofs/poly_compress/Makefile
+++ b/cbmc/proofs/poly_compress/Makefile
@@ -7,7 +7,7 @@ HARNESS_FILE = poly_compress_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = $(KYBER_NAMESPACE)poly_compress
+PROOF_UID = poly_compress
 
 DEFINES +=
 INCLUDES +=
@@ -18,7 +18,7 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
 
-CHECK_FUNCTION_CONTRACTS=$(PROOF_UID)
+CHECK_FUNCTION_CONTRACTS=$(KYBER_NAMESPACE)poly_compress
 USE_FUNCTION_CONTRACTS = $(KYBER_NAMESPACE)scalar_compress_q_16 $(KYBER_NAMESPACE)scalar_compress_q_32
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1

--- a/cbmc/proofs/poly_compress/Makefile
+++ b/cbmc/proofs/poly_compress/Makefile
@@ -18,20 +18,12 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
 
-CHECK_FUNCTION_CONTRACTS=$(KYBER_NAMESPACE)poly_compress
-USE_FUNCTION_CONTRACTS = $(KYBER_NAMESPACE)scalar_compress_q_16 $(KYBER_NAMESPACE)scalar_compress_q_32
-APPLY_LOOP_CONTRACTS=on
-USE_DYNAMIC_FRAMES=1
-
-# SMT backend for proving with contracts and quantifiers
-# To be re-enabled when CBMC Issue #8303 is fixed.
-# CBMCFLAGS=--smt2
-
-# Uncomment this to see what commands litani is running...
-VERBOSE=on
+# UNWINDSET += $(KYBER_NAMESPACE)poly_compress.0:9
+# UNWINDSET += $(KYBER_NAMESPACE)poly_compress.1:33
 
 FUNCTION_NAME = $(KYBER_NAMESPACE)poly_compress
 
+USE_FUNCTION_CONTRACTS = $(KYBER_NAMESPACE)scalar_compress_q_16 $(KYBER_NAMESPACE)scalar_compress_q_32
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/proofs/poly_compress/Makefile
+++ b/cbmc/proofs/poly_compress/Makefile
@@ -7,7 +7,7 @@ HARNESS_FILE = poly_compress_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = poly_compress
+PROOF_UID = $(KYBER_NAMESPACE)poly_compress
 
 DEFINES +=
 INCLUDES +=
@@ -18,12 +18,20 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
 
-# UNWINDSET += $(KYBER_NAMESPACE)poly_compress.0:9
-# UNWINDSET += $(KYBER_NAMESPACE)poly_compress.1:33
+CHECK_FUNCTION_CONTRACTS=$(PROOF_UID)
+USE_FUNCTION_CONTRACTS = $(KYBER_NAMESPACE)scalar_compress_q_16 $(KYBER_NAMESPACE)scalar_compress_q_32
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# SMT backend for proving with contracts and quantifiers
+# To be re-enabled when CBMC Issue #8303 is fixed.
+# CBMCFLAGS=--smt2
+
+# Uncomment this to see what commands litani is running...
+VERBOSE=on
 
 FUNCTION_NAME = $(KYBER_NAMESPACE)poly_compress
 
-USE_FUNCTION_CONTRACTS = $(KYBER_NAMESPACE)scalar_compress_q_16 $(KYBER_NAMESPACE)scalar_compress_q_32
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/proofs/scalar_compress_q_16/Makefile
+++ b/cbmc/proofs/scalar_compress_q_16/Makefile
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+include ../Makefile_params.common
+
 HARNESS_ENTRY = harness
 HARNESS_FILE = scalar_compress_q_16_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = scalar_compress_q_16
+PROOF_UID = $(KYBER_NAMESPACE)scalar_compress_q_16
 
 DEFINES +=
 INCLUDES +=
@@ -16,8 +18,17 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
 
-# Disable unsigned overflow check for Barret reduction
-CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK =
+CHECK_FUNCTION_CONTRACTS=$(PROOF_UID)
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# SMT backend for proving with contracts and quantifiers
+# To be re-enabled when CBMC Issue #8303 is fixed.
+# CBMCFLAGS=--smt2
+
+# Uncomment this to see what commands litani is running...
+#VERBOSE=on
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/proofs/scalar_compress_q_16/Makefile
+++ b/cbmc/proofs/scalar_compress_q_16/Makefile
@@ -7,7 +7,7 @@ HARNESS_FILE = scalar_compress_q_16_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = $(KYBER_NAMESPACE)scalar_compress_q_16
+PROOF_UID = scalar_compress_q_16
 
 DEFINES +=
 INCLUDES +=
@@ -18,7 +18,7 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
 
-CHECK_FUNCTION_CONTRACTS=$(PROOF_UID)
+CHECK_FUNCTION_CONTRACTS=$(KYBER_NAMESPACE)scalar_compress_q_16
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1

--- a/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
+++ b/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
@@ -24,9 +24,6 @@
 void harness(void) {
     int32_t u;
 
-    __CPROVER_assume(0 <= u && u < KYBER_Q);
+    /* Contracts for this function are in poly.h */
     uint32_t d = scalar_compress_q_16(u);
-    __CPROVER_assert(d < 16, "compression bound failed");
-    __CPROVER_assert(d == (((uint32_t) u * 16 + KYBER_Q / 2) / KYBER_Q) % 16,
-                     "compression expression failed");
 }

--- a/cbmc/proofs/scalar_compress_q_32/Makefile
+++ b/cbmc/proofs/scalar_compress_q_32/Makefile
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+include ../Makefile_params.common
+
 HARNESS_ENTRY = harness
 HARNESS_FILE = scalar_compress_q_32_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = scalar_compress_q_32
+PROOF_UID = $(KYBER_NAMESPACE)scalar_compress_q_32
 
 DEFINES +=
 INCLUDES +=
@@ -16,8 +18,17 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
 
-# Disable unsigned overflow check for Barret reduction
-CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK =
+CHECK_FUNCTION_CONTRACTS=$(PROOF_UID)
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# SMT backend for proving with contracts and quantifiers
+# To be re-enabled when CBMC Issue #8303 is fixed.
+# CBMCFLAGS=--smt2
+
+# Uncomment this to see what commands litani is running...
+#VERBOSE=on
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/proofs/scalar_compress_q_32/Makefile
+++ b/cbmc/proofs/scalar_compress_q_32/Makefile
@@ -7,7 +7,7 @@ HARNESS_FILE = scalar_compress_q_32_harness
 
 # This should be a unique identifier for this proof, and will appear on the
 # Litani dashboard. It can be human-readable and contain spaces if you wish.
-PROOF_UID = $(KYBER_NAMESPACE)scalar_compress_q_32
+PROOF_UID = scalar_compress_q_32
 
 DEFINES +=
 INCLUDES +=
@@ -18,7 +18,7 @@ UNWINDSET +=
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
 
-CHECK_FUNCTION_CONTRACTS=$(PROOF_UID)
+CHECK_FUNCTION_CONTRACTS=$(KYBER_NAMESPACE)scalar_compress_q_32
 USE_FUNCTION_CONTRACTS=
 APPLY_LOOP_CONTRACTS=on
 USE_DYNAMIC_FRAMES=1

--- a/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
+++ b/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
@@ -24,9 +24,6 @@
 void harness(void) {
     int32_t u;
 
-    __CPROVER_assume(0 <= u && u < KYBER_Q);
+    /* Contracts for this function are in poly.h */
     uint32_t d = scalar_compress_q_32(u);
-    __CPROVER_assert(d < 32, "compression bound failed");
-    __CPROVER_assert(d == (((uint32_t) u * 32 + KYBER_Q / 2) / KYBER_Q) % 32,
-                     "compression expression failed");
 }

--- a/cbmc/proofs/scalar_decompress_q_16/Makefile
+++ b/cbmc/proofs/scalar_decompress_q_16/Makefile
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+include ../Makefile_params.common
+
 HARNESS_ENTRY = harness
 HARNESS_FILE = scalar_decompress_q_16_harness
 
@@ -15,6 +17,18 @@ UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(KYBER_NAMESPACE)scalar_decompress_q_16
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# SMT backend for proving with contracts and quantifiers
+# To be re-enabled when CBMC Issue #8303 is fixed.
+# CBMCFLAGS=--smt2
+
+# Uncomment this to see what commands litani is running...
+#VERBOSE=on
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
@@ -25,9 +25,7 @@ void harness(void) {
     // Check that decompression followed by compression is the identity
     uint32_t c0, c1, d;
 
-    __CPROVER_assume(c0 < 16);
     d = scalar_decompress_q_16(c0);
-    __CPROVER_assert(d < KYBER_Q, "scalar_decompress_q_16 bound");
     c1 = scalar_compress_q_16(d);
     __CPROVER_assert(c0 == c1, "scalar_compress_q_16 o scalar_decompress_q_16 != id");
 }

--- a/cbmc/proofs/scalar_decompress_q_32/Makefile
+++ b/cbmc/proofs/scalar_decompress_q_32/Makefile
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+include ../Makefile_params.common
+
 HARNESS_ENTRY = harness
 HARNESS_FILE = scalar_decompress_q_32_harness
 
@@ -15,6 +17,18 @@ UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
+
+CHECK_FUNCTION_CONTRACTS=$(KYBER_NAMESPACE)scalar_decompress_q_32
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# SMT backend for proving with contracts and quantifiers
+# To be re-enabled when CBMC Issue #8303 is fixed.
+# CBMCFLAGS=--smt2
+
+# Uncomment this to see what commands litani is running...
+#VERBOSE=on
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will

--- a/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
@@ -25,9 +25,7 @@ void harness(void) {
     // Check that decompression followed by compression is the identity
     uint32_t c0, c1, d;
 
-    __CPROVER_assume(c0 < 32);
     d = scalar_decompress_q_32(c0);
-    __CPROVER_assert(d < KYBER_Q, "scalar_decompress_q_32 bound");
     c1 = scalar_compress_q_32(d);
     __CPROVER_assert(c0 == c1, "scalar_compress_q_32 o scalar_decompress_q_32 != id");
 }

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef CBMC
-#define __CPROVER_requires(...)
+#define __CPROVER_assert(...)
+#define __CPROVER_assigns(...)
+#define __CPROVER_decreases(...)
 #define __CPROVER_ensures(...)
+#define __CPROVER_loop_invariant(...)
+#define __CPROVER_requires(...)
 #endif

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -17,8 +17,7 @@
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  ************************************************************/
-uint32_t scalar_compress_q_16(int32_t u)
-{
+uint32_t scalar_compress_q_16(int32_t u) {
     uint32_t d0 = (uint32_t) u;
     d0 <<= 4;
     d0 +=  1665;
@@ -43,8 +42,7 @@ uint32_t scalar_compress_q_16(int32_t u)
  * Arguments: - u: Unsigned canonical modulus modulo 16
  *                 to be decompressed.
  ************************************************************/
-uint32_t scalar_decompress_q_16(uint32_t u)
-{
+uint32_t scalar_decompress_q_16(uint32_t u) {
     return ((u * KYBER_Q) + 8) / 16;
 }
 
@@ -56,8 +54,7 @@ uint32_t scalar_decompress_q_16(uint32_t u)
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  ************************************************************/
-uint32_t scalar_compress_q_32(int32_t u)
-{
+uint32_t scalar_compress_q_32(int32_t u) {
     uint32_t d0 = (uint32_t) u;
     d0 <<= 5;
     d0 +=  1664;
@@ -82,8 +79,7 @@ uint32_t scalar_compress_q_32(int32_t u)
  * Arguments: - u: Unsigned canonical modulus modulo 32
  *                 to be decompressed.
  ************************************************************/
-uint32_t scalar_decompress_q_32(uint32_t u)
-{
+uint32_t scalar_decompress_q_32(uint32_t u) {
     return ((u * KYBER_Q) + 16) / 32;
 }
 
@@ -103,12 +99,12 @@ void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a) {
 
     #if (KYBER_POLYCOMPRESSEDBYTES == 128)
     for (i = 0; i < KYBER_N / 8; i++)
-    __CPROVER_assigns(i, j, u, t, r)
-    /* Stronger loop invariant here TBD */
+        __CPROVER_assigns(i, j, u, t, r)
+        /* Stronger loop invariant here TBD */
     {
         for (j = 0; j < 8; j++)
-        __CPROVER_assigns(j, u, t)
-        /* Stronger loop invariant here TBD */
+            __CPROVER_assigns(j, u, t)
+            /* Stronger loop invariant here TBD */
         {
             // map to positive standard representatives
             u  = a->coeffs[8 * i + j];

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -44,10 +44,6 @@ uint32_t scalar_compress_q_16(int32_t u)
  *                 to be decompressed.
  ************************************************************/
 uint32_t scalar_decompress_q_16(uint32_t u)
-/* INDENT-OFF */
-__CPROVER_requires(0 <= u && u < 16)
-__CPROVER_ensures(__CPROVER_return_value < KYBER_Q)
-/* INDENT-ON */
 {
     return ((u * KYBER_Q) + 8) / 16;
 }
@@ -87,10 +83,6 @@ uint32_t scalar_compress_q_32(int32_t u)
  *                 to be decompressed.
  ************************************************************/
 uint32_t scalar_decompress_q_32(uint32_t u)
-/* INDENT-OFF */
-__CPROVER_requires(0 <= u && u < 32)
-__CPROVER_ensures(__CPROVER_return_value < KYBER_Q)
-/* INDENT-ON */
 {
     return ((u * KYBER_Q) + 16) / 32;
 }

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -18,13 +18,33 @@ typedef struct {
 #define scalar_compress_q_32   KYBER_NAMESPACE(scalar_compress_q_32)
 #define scalar_decompress_q_32 KYBER_NAMESPACE(scalar_decompress_q_32)
 
-uint32_t scalar_compress_q_16   (int32_t);
+uint32_t scalar_compress_q_16   (int32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < KYBER_Q)
+__CPROVER_ensures(__CPROVER_return_value < 16)
+__CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 16 + KYBER_Q / 2) / KYBER_Q) % 16);
+/* INDENT-ON */
+
 uint32_t scalar_decompress_q_16 (uint32_t);
-uint32_t scalar_compress_q_32   (int32_t);
+
+uint32_t scalar_compress_q_32   (int32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < KYBER_Q)
+__CPROVER_ensures(__CPROVER_return_value < 32)
+__CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 32 + KYBER_Q / 2) / KYBER_Q) % 32);
+/* INDENT-ON */
+
 uint32_t scalar_decompress_q_32 (uint32_t);
 
 #define poly_compress KYBER_NAMESPACE(poly_compress)
-void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a);
+void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)
+/* INDENT-OFF */
+__CPROVER_requires(__CPROVER_is_fresh(r, KYBER_POLYCOMPRESSEDBYTES))
+__CPROVER_requires(__CPROVER_forall { unsigned i; (i < KYBER_N) ==> ( -KYBER_Q <= a->coeffs[i] && a->coeffs[i] < KYBER_Q ) })
+__CPROVER_assigns(__CPROVER_object_whole(r));
+/* INDENT-ON */
+
+
 #define poly_decompress KYBER_NAMESPACE(poly_decompress)
 void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES]);
 

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -45,13 +45,7 @@ __CPROVER_ensures(__CPROVER_return_value < KYBER_Q);
 /* INDENT-ON */
 
 #define poly_compress KYBER_NAMESPACE(poly_compress)
-void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)
-/* INDENT-OFF */
-__CPROVER_requires(__CPROVER_is_fresh(r, KYBER_POLYCOMPRESSEDBYTES))
-__CPROVER_requires(__CPROVER_forall { unsigned i; (i < KYBER_N) ==> ( -KYBER_Q <= a->coeffs[i] && a->coeffs[i] < KYBER_Q ) })
-__CPROVER_assigns(__CPROVER_object_whole(r));
-/* INDENT-ON */
-
+void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a);
 
 #define poly_decompress KYBER_NAMESPACE(poly_decompress)
 void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES]);

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "params.h"
+#include "cbmc.h"
 
 /*
  * Elements of R_q = Z_q[X]/(X^n + 1). Represents polynomial

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -25,7 +25,11 @@ __CPROVER_ensures(__CPROVER_return_value < 16)
 __CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 16 + KYBER_Q / 2) / KYBER_Q) % 16);
 /* INDENT-ON */
 
-uint32_t scalar_decompress_q_16 (uint32_t);
+uint32_t scalar_decompress_q_16 (uint32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < 16)
+__CPROVER_ensures(__CPROVER_return_value < KYBER_Q);
+/* INDENT-ON */
 
 uint32_t scalar_compress_q_32   (int32_t u)
 /* INDENT-OFF */
@@ -34,7 +38,11 @@ __CPROVER_ensures(__CPROVER_return_value < 32)
 __CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 32 + KYBER_Q / 2) / KYBER_Q) % 32);
 /* INDENT-ON */
 
-uint32_t scalar_decompress_q_32 (uint32_t);
+uint32_t scalar_decompress_q_32 (uint32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < 32)
+__CPROVER_ensures(__CPROVER_return_value < KYBER_Q);
+/* INDENT-ON */
 
 #define poly_compress KYBER_NAMESPACE(poly_compress)
 void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)


### PR DESCRIPTION
This PR adds contract based CBMC proofs of four functions in mlkem/poly.c
 scalar_compress_q_16
 scalar_compress_q_32
 scalar_decompress_q_16
 scalar_decompress_q_32

No functional change.