### PR TITLE
Add Keccak X4 interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ NISTFLAGS += -Wno-unused-result -O3 -fomit-frame-pointer
 RM = /bin/rm
 
 SOURCES = mlkem/kem.c mlkem/indcpa.c mlkem/polyvec.c mlkem/poly.c mlkem/ntt.c mlkem/cbd.c mlkem/reduce.c mlkem/verify.c
-SOURCESKECCAK = $(SOURCES) fips202/keccakf1600.c fips202/fips202.c mlkem/symmetric-shake.c
+SOURCESKECCAK = $(SOURCES) fips202/keccakf1600.c fips202/fips202.c fips202/fips202x4.c mlkem/symmetric-shake.c
 SOURCESKECCAKRANDOM = $(SOURCESKECCAK) randombytes/randombytes.c
 SOURCESNISTKATS = $(SOURCESKECCAK) test/nistrng/aes.c test/nistrng/rng.c
 SOURCESBENCH = $(SOURCESKECCAKRANDOM) test/hal.c
 
-HEADERS = mlkem/params.h mlkem/kem.h mlkem/indcpa.h mlkem/polyvec.h mlkem/poly.h mlkem/ntt.h mlkem/cbd.h mlkem/reduce.h mlkem/verify.h mlkem/symmetric.h
-HEADERSKECCAK = $(HEADERS) fips202/keccakf1600.h fips202/fips202.h
+HEADERS = mlkem/params.h mlkem/kem.h mlkem/indcpa.h mlkem/polyvec.h mlkem/poly.h mlkem/ntt.h mlkem/cbd.h mlkem/reduce.c mlkem/verify.h mlkem/symmetric.h
+HEADERSKECCAK = $(HEADERS) fips202/keccakf1600.h fips202/fips202.h fips202/fips202x4.h
 HEADERSKECCAKRANDOM = $(HEADERSKECCAK) randombytes/randombytes.h
 HEADERNISTKATS = $(HEADERSKECCAK) test/nistrng/aes.h test/nistrng/randombytes.h
 HEADERSBENCH = $(HEADERSKECCAKRANDOM) test/hal.h

--- a/fips202/fips202x4.c
+++ b/fips202/fips202x4.c
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <string.h>
+#include "fips202x4.h"
+#include "fips202.h"
+#include "keccakf1600.h"
+
+#define KECCAK_CTX 25
+
+static void keccak_absorb_x4(uint64_t *s, uint32_t r,
+                             const uint8_t *in0,
+                             const uint8_t *in1,
+                             const uint8_t *in2,
+                             const uint8_t *in3,
+                             size_t inlen,
+                             uint8_t p)
+{
+
+    while (inlen >= r)
+    {
+
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 0, in0, 0, r);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 1, in1, 0, r);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 2, in2, 0, r);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 3, in3, 0, r);
+
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 0);
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 1);
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 2);
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 3);
+
+        in0 += r;
+        in1 += r;
+        in2 += r;
+        in3 += r;
+        inlen -= r;
+    }
+
+    if (inlen > 0)
+    {
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 0, in0, 0, inlen);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 1, in1, 0, inlen);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 2, in2, 0, inlen);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 3, in3, 0, inlen);
+    }
+
+    if (inlen == r - 1)
+    {
+        p |= 128;
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 0, &p, inlen, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 1, &p, inlen, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 2, &p, inlen, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 3, &p, inlen, 1);
+    }
+    else
+    {
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 0, &p, inlen, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 1, &p, inlen, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 2, &p, inlen, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 3, &p, inlen, 1);
+        p = 128;
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 0, &p, r - 1, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 1, &p, r - 1, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 2, &p, r - 1, 1);
+        KeccakF1600_StateXORBytes(s + KECCAK_CTX * 3, &p, r - 1, 1);
+    }
+}
+
+static void keccak_squeezeblocks_x4(uint8_t *out0,
+                                    uint8_t *out1,
+                                    uint8_t *out2,
+                                    uint8_t *out3,
+                                    size_t nblocks,
+                                    uint64_t *s,
+                                    uint32_t r)
+{
+
+    while (nblocks > 0)
+    {
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 0);
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 1);
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 2);
+        KeccakF1600_StatePermute(s + KECCAK_CTX * 3);
+
+        KeccakF1600_StateExtractBytes(s + KECCAK_CTX * 0, out0, 0, r);
+        KeccakF1600_StateExtractBytes(s + KECCAK_CTX * 1, out1, 0, r);
+        KeccakF1600_StateExtractBytes(s + KECCAK_CTX * 2, out2, 0, r);
+        KeccakF1600_StateExtractBytes(s + KECCAK_CTX * 3, out3, 0, r);
+
+        out0 += r;
+        out1 += r;
+        out2 += r;
+        out3 += r;
+        nblocks--;
+    }
+}
+
+uint64_t *keccakx_get_lane_state(keccakx4_state *state, size_t index)
+{
+    if (index >= KECCAK_WAY)
+    {
+        return NULL;
+    }
+
+    return state->ctx + index * KECCAK_CTX;
+}
+
+void shake128x4_absorb(keccakx4_state *state,
+                       const uint8_t *in0,
+                       const uint8_t *in1,
+                       const uint8_t *in2,
+                       const uint8_t *in3,
+                       size_t inlen)
+{
+    memset(state->ctx, 0, sizeof(state->ctx));
+
+    keccak_absorb_x4(state->ctx, SHAKE128_RATE, in0, in1, in2, in3, inlen, 0x1F);
+}
+
+void shake256x4_absorb(keccakx4_state *state,
+                       const uint8_t *in0,
+                       const uint8_t *in1,
+                       const uint8_t *in2,
+                       const uint8_t *in3,
+                       size_t inlen)
+{
+    memset(state->ctx, 0, sizeof(state->ctx));
+
+    keccak_absorb_x4(state->ctx, SHAKE256_RATE, in0, in1, in2, in3, inlen, 0x1F);
+}
+
+
+void shake128x4_squeezeblocks(uint8_t *out0,
+                              uint8_t *out1,
+                              uint8_t *out2,
+                              uint8_t *out3,
+                              size_t nblocks,
+                              keccakx4_state *state)
+{
+    keccak_squeezeblocks_x4(out0, out1, out2, out3, nblocks, state->ctx, SHAKE128_RATE);
+}
+
+void shake256x4_squeezeblocks(uint8_t *out0,
+                              uint8_t *out1,
+                              uint8_t *out2,
+                              uint8_t *out3,
+                              size_t nblocks,
+                              keccakx4_state *state)
+{
+    keccak_squeezeblocks_x4(out0, out1, out2, out3, nblocks, state->ctx, SHAKE256_RATE);
+}
+
+void shake256x4_squeezeblocks_single(uint8_t *out,
+                                     size_t nblocks,
+                                     size_t index,
+                                     keccakx4_state *state)
+{
+    uint64_t *ctx = keccakx_get_lane_state(state, index);
+    while (nblocks > 0)
+    {
+        KeccakF1600_StatePermute(ctx);
+        KeccakF1600_StateExtractBytes(ctx, out, 0, SHAKE128_RATE);
+        out += SHAKE128_RATE;
+        nblocks--;
+    }
+}
+
+void shake256x4(uint8_t *out0,
+                uint8_t *out1,
+                uint8_t *out2,
+                uint8_t *out3,
+                size_t outlen,
+                uint8_t *in0,
+                uint8_t *in1,
+                uint8_t *in2,
+                uint8_t *in3,
+                size_t inlen)
+{
+    keccakx4_state statex;
+    size_t nblocks = outlen/SHAKE256_RATE;
+    uint8_t tmp[KECCAK_WAY][SHAKE256_RATE];
+
+    shake256x4_absorb(&statex, in0, in1, in2, in3, inlen);
+
+    shake256x4_squeezeblocks(out0, out1, out2, out3, nblocks, &statex);
+
+    out0 += nblocks * SHAKE256_RATE;
+    out1 += nblocks * SHAKE256_RATE;
+    out2 += nblocks * SHAKE256_RATE;
+    out3 += nblocks * SHAKE256_RATE;
+
+    outlen -= nblocks * SHAKE256_RATE;
+
+    if (outlen)
+    {
+        shake256x4_squeezeblocks(tmp[0], tmp[1], tmp[2], tmp[3], 1, &statex);
+        memcpy(out0, tmp[0], outlen);
+        memcpy(out1, tmp[1], outlen);
+        memcpy(out2, tmp[2], outlen);
+        memcpy(out3, tmp[3], outlen);
+    }
+}

--- a/fips202/fips202x4.h
+++ b/fips202/fips202x4.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef FIPS_202X4_H
+#define FIPS_202X4_H
+
+#ifndef KECCAK_WAY
+#define KECCAK_WAY 4
+#endif
+
+#include <stdint.h>
+
+typedef struct
+{
+    uint64_t ctx[25 * KECCAK_WAY];
+} keccakx4_state;
+
+uint64_t *keccakx_get_lane_state(keccakx4_state *state, size_t index);
+
+void shake128x4_absorb(keccakx4_state *state,
+                       const uint8_t *in0,
+                       const uint8_t *in1,
+                       const uint8_t *in2,
+                       const uint8_t *in3,
+                       size_t inlen);
+
+void shake256x4_absorb(keccakx4_state *state,
+                       const uint8_t *in0,
+                       const uint8_t *in1,
+                       const uint8_t *in2,
+                       const uint8_t *in3,
+                       size_t inlen);
+
+
+void shake128x4_squeezeblocks(uint8_t *out0,
+                              uint8_t *out1,
+                              uint8_t *out2,
+                              uint8_t *out3,
+                              size_t nblocks,
+                              keccakx4_state *state);
+
+void shake256x4_squeezeblocks(uint8_t *out0,
+                              uint8_t *out1,
+                              uint8_t *out2,
+                              uint8_t *out3,
+                              size_t nblocks,
+                              keccakx4_state *state);
+
+/*
+ * Squeezes a single lane in Keccak 4-way
+ */
+void shake256x4_squeezeblocks_single(uint8_t *out,
+                                     size_t nblocks,
+                                     size_t index,
+                                     keccakx4_state *state);
+
+void shake256x4(uint8_t *out0,
+                uint8_t *out1,
+                uint8_t *out2,
+                uint8_t *out3,
+                size_t outlen,
+                uint8_t *in0,
+                uint8_t *in1,
+                uint8_t *in2,
+                uint8_t *in3,
+                size_t inlen);
+
+#endif

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -75,8 +75,41 @@ void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *r);
 #define poly_getnoise_eta1 KYBER_NAMESPACE(poly_getnoise_eta1)
 void poly_getnoise_eta1(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce);
 
+#define poly_getnoise_eta1_4x KYBER_NAMESPACE(poly_getnoise_eta1_4x)
+void poly_getnoise_eta1_4x(poly *r0,
+                           poly *r1,
+                           poly *r2,
+                           poly *r3,
+                           const uint8_t seed[KYBER_SYMBYTES],
+                           uint8_t nonce0,
+                           uint8_t nonce1,
+                           uint8_t nonce2,
+                           uint8_t nonce3);
+
 #define poly_getnoise_eta2 KYBER_NAMESPACE(poly_getnoise_eta2)
 void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce);
+
+#define poly_getnoise_eta2_4x KYBER_NAMESPACE(poly_getnoise_eta2_4x)
+void poly_getnoise_eta2_4x(poly *r0,
+                           poly *r1,
+                           poly *r2,
+                           poly *r3,
+                           const uint8_t seed[KYBER_SYMBYTES],
+                           uint8_t nonce0,
+                           uint8_t nonce1,
+                           uint8_t nonce2,
+                           uint8_t nonce3);
+
+#define poly_getnoise_eta1122_4x KYBER_NAMESPACE(poly_getnoise_eta1122_4x)
+void poly_getnoise_eta1122_4x(poly *r0,
+                              poly *r1,
+                              poly *r2,
+                              poly *r3,
+                              const uint8_t seed[KYBER_SYMBYTES],
+                              uint8_t nonce0,
+                              uint8_t nonce1,
+                              uint8_t nonce2,
+                              uint8_t nonce3);
 
 #define poly_ntt KYBER_NAMESPACE(poly_ntt)
 void poly_ntt(poly *r);

--- a/mlkem/symmetric-shake.c
+++ b/mlkem/symmetric-shake.c
@@ -52,7 +52,7 @@ void kyber_shake256_prf(uint8_t *out, size_t outlen, const uint8_t key[KYBER_SYM
 }
 
 /*************************************************
-* Name:        kyber_shake256_prf
+* Name:        kyber_shake256_rkprf
 *
 * Description: Usage of SHAKE256 as a PRF, concatenates secret and public input
 *              and then generates outlen bytes of SHAKE256 output


### PR DESCRIPTION
# Add Keccak X4 interface. 

Potential optimization: 

- **Multiple Pass Squeezing**: Currently, if `rej_uniform` fails to sample the full vector size, it continues by squeezing a single Keccak lane. By rewriting this logic to append single Keccak calls into a single Keccak X-way call, CPU cycles can be saved. For simplicity, it is currently implemented as a single pass.

### Next Steps:

- Add Keccak_X4 assembly to replace the `keccak_absorb_x4keccak_squeezeblocks_x4` in `fips202x.c`.

Fixes #35