### PR TITLE
Reformat with bsd style and NO pad-oper otions for compatibility with CBMC

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
---style=google 
+--style=bsd
 --indent=spaces
 --indent-preproc-define
 --indent-preproc-cond
---pad-oper 
---pad-comma 
+--pad-comma
 --pad-header
---align-pointer=name 
---add-braces 
+--align-pointer=name
+--add-braces
 --convert-tabs
---mode=c 
+--mode=c
 --suffix=none
 --lineend=linux

--- a/cbmc/proofs/poly_compress/poly_compress_harness.c
+++ b/cbmc/proofs/poly_compress/poly_compress_harness.c
@@ -21,7 +21,8 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void) {
+void harness(void)
+{
     poly r;
     uint8_t a[KYBER_POLYCOMPRESSEDBYTES];
 

--- a/cbmc/proofs/poly_decompress/poly_decompress_harness.c
+++ b/cbmc/proofs/poly_decompress/poly_decompress_harness.c
@@ -21,7 +21,8 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void) {
+void harness(void)
+{
     poly r;
     uint8_t a[KYBER_POLYCOMPRESSEDBYTES];
 

--- a/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
+++ b/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
@@ -21,7 +21,8 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void) {
+void harness(void)
+{
     int32_t u;
 
     /* Contracts for this function are in poly.h */

--- a/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
+++ b/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
@@ -21,7 +21,8 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void) {
+void harness(void)
+{
     int32_t u;
 
     /* Contracts for this function are in poly.h */

--- a/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
@@ -21,7 +21,8 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void) {
+void harness(void)
+{
     // Check that decompression followed by compression is the identity
     uint32_t c0, c1, d;
 

--- a/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
@@ -21,7 +21,8 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void) {
+void harness(void)
+{
     // Check that decompression followed by compression is the identity
     uint32_t c0, c1, d;
 

--- a/fips202/fips202.c
+++ b/fips202/fips202.c
@@ -32,22 +32,28 @@
 static void keccak_absorb(uint64_t *s,
                           uint32_t r,
                           const uint8_t *m, size_t mlen,
-                          uint8_t p) {
-    while (mlen >= r) {
+                          uint8_t p)
+{
+    while (mlen >= r)
+    {
         KeccakF1600_StateXORBytes(s, m, 0, r);
         KeccakF1600_StatePermute(s);
         mlen -= r;
         m += r;
     }
 
-    if (mlen > 0) {
+    if (mlen > 0)
+    {
         KeccakF1600_StateXORBytes(s, m, 0, mlen);
     }
 
-    if (mlen == r - 1) {
+    if (mlen == r - 1)
+    {
         p |= 128;
         KeccakF1600_StateXORBytes(s, &p, mlen, 1);
-    } else {
+    }
+    else
+    {
         KeccakF1600_StateXORBytes(s, &p, mlen, 1);
         p = 128;
         KeccakF1600_StateXORBytes(s, &p, r - 1, 1);
@@ -68,8 +74,10 @@ static void keccak_absorb(uint64_t *s,
  **************************************************/
 static void keccak_squeezeblocks(uint8_t *h, size_t nblocks,
                                  uint64_t *s,
-                                 uint32_t r) {
-    while (nblocks > 0) {
+                                 uint32_t r)
+{
+    while (nblocks > 0)
+    {
         KeccakF1600_StatePermute(s);
         KeccakF1600_StateExtractBytes(s, h, 0, r);
         h += r;
@@ -87,10 +95,12 @@ static void keccak_squeezeblocks(uint8_t *h, size_t nblocks,
  *                26th value represents either the number of absorbed bytes
  *                that have not been permuted, or not-yet-squeezed bytes.
  **************************************************/
-static void keccak_inc_init(uint64_t *s_inc) {
+static void keccak_inc_init(uint64_t *s_inc)
+{
     size_t i;
 
-    for (i = 0; i < 25; ++i) {
+    for (i = 0; i < 25; ++i)
+    {
         s_inc[i] = 0;
     }
     s_inc[25] = 0;
@@ -110,9 +120,11 @@ static void keccak_inc_init(uint64_t *s_inc) {
  *              - size_t mlen: length of input in bytes
  **************************************************/
 static void keccak_inc_absorb(uint64_t *s_inc, uint32_t r, const uint8_t *m,
-                              size_t mlen) {
+                              size_t mlen)
+{
     /* Recall that s_inc[25] is the non-absorbed bytes xored into the state */
-    while (mlen + s_inc[25] >= r) {
+    while (mlen + s_inc[25] >= r)
+    {
 
         KeccakF1600_StateXORBytes(s_inc, m, s_inc[25], r - s_inc[25]);
         mlen -= (size_t)(r - s_inc[25]);
@@ -139,13 +151,17 @@ static void keccak_inc_absorb(uint64_t *s_inc, uint32_t r, const uint8_t *m,
  *              - uint8_t p: domain-separation byte for different
  *                                 Keccak-derived functions
  **************************************************/
-static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p) {
+static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p)
+{
     /* After keccak_inc_absorb, we are guaranteed that s_inc[25] < r,
        so we can always use one more byte for p in the current state. */
-    if (s_inc[25] == r - 1) {
+    if (s_inc[25] == r - 1)
+    {
         p |= 128;
         KeccakF1600_StateXORBytes(s_inc, &p, s_inc[25], 1);
-    } else {
+    }
+    else
+    {
         KeccakF1600_StateXORBytes(s_inc, &p, s_inc[25], 1);
         p = 128;
         KeccakF1600_StateXORBytes(s_inc, &p, r - 1, 1);
@@ -167,11 +183,15 @@ static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p) {
  *              - uint32_t r: rate in bytes (e.g., 168 for SHAKE128)
  **************************************************/
 static void keccak_inc_squeeze(uint8_t *h, size_t outlen,
-                               uint64_t *s_inc, uint32_t r) {
+                               uint64_t *s_inc, uint32_t r)
+{
     size_t len;
-    if (outlen < s_inc[25]) {
+    if (outlen < s_inc[25])
+    {
         len = outlen;
-    } else {
+    }
+    else
+    {
         len = s_inc[25];
     }
 
@@ -181,12 +201,16 @@ static void keccak_inc_squeeze(uint8_t *h, size_t outlen,
     s_inc[25] -= len;
 
     /* Then squeeze the remaining necessary blocks */
-    while (outlen > 0) {
+    while (outlen > 0)
+    {
         KeccakF1600_StatePermute(s_inc);
 
-        if (outlen < r) {
+        if (outlen < r)
+        {
             len = outlen;
-        } else {
+        }
+        else
+        {
             len = r;
         }
         KeccakF1600_StateExtractBytes(s_inc, h, 0, len);
@@ -196,19 +220,23 @@ static void keccak_inc_squeeze(uint8_t *h, size_t outlen,
     }
 }
 
-void shake256_inc_init(shake256incctx *state) {
+void shake256_inc_init(shake256incctx *state)
+{
     keccak_inc_init(state->ctx);
 }
 
-void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen) {
+void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen)
+{
     keccak_inc_absorb(state->ctx, SHAKE256_RATE, input, inlen);
 }
 
-void shake256_inc_finalize(shake256incctx *state) {
+void shake256_inc_finalize(shake256incctx *state)
+{
     keccak_inc_finalize(state->ctx, SHAKE256_RATE, 0x1F);
 }
 
-void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state) {
+void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state)
+{
     keccak_inc_squeeze(output, outlen, state->ctx, SHAKE256_RATE);
 }
 
@@ -222,9 +250,11 @@ void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state)
  *              - const uint8_t *input: pointer to input to be absorbed into state
  *              - size_t inlen:         length of input in bytes
  **************************************************/
-void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen) {
+void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen)
+{
     int i;
-    for (i = 0; i < 25; i++) {
+    for (i = 0; i < 25; i++)
+    {
         state->ctx[i] = 0;
     }
 
@@ -242,7 +272,8 @@ void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen) {
  *              - size_t nblocks:      number of blocks to be squeezed (written to output)
  *              - shake128ctx *state:  pointer to in/output Keccak state
  **************************************************/
-void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state) {
+void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
+{
     keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE128_RATE);
 }
 
@@ -257,7 +288,8 @@ void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
  *              - size_t inlen:         length of input in bytes
  **************************************************/
 void shake256(uint8_t *output, size_t outlen,
-              const uint8_t *input, size_t inlen) {
+              const uint8_t *input, size_t inlen)
+{
     shake256incctx state;
 
     keccak_inc_init(state.ctx);
@@ -279,7 +311,8 @@ void shake256(uint8_t *output, size_t outlen,
  *              - const uint8_t *input: pointer to input
  *              - size_t inlen:         length of input in bytes
  **************************************************/
-void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen) {
+void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen)
+{
     uint64_t ctx[26];
     keccak_inc_init(ctx);
 
@@ -300,7 +333,8 @@ void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen) {
  *              - const uint8_t *input: pointer to input
  *              - size_t inlen:         length of input in bytes
  **************************************************/
-void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen) {
+void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen)
+{
     uint64_t ctx[26];
     keccak_inc_init(ctx);
 

--- a/fips202/fips202.h
+++ b/fips202/fips202.h
@@ -12,22 +12,26 @@
 #define SHA3_512_RATE 72
 
 // Context for incremental API
-typedef struct {
+typedef struct
+{
     uint64_t ctx[26];
 } shake128incctx;
 
 // Context for non-incremental API
-typedef struct {
+typedef struct
+{
     uint64_t ctx[25];
 } shake128ctx;
 
 // Context for incremental API
-typedef struct {
+typedef struct
+{
     uint64_t ctx[26];
 } shake256incctx;
 
 // Context for non-incremental API
-typedef struct {
+typedef struct
+{
     uint64_t ctx[25];
 } shake256ctx;
 

--- a/fips202/keccakf1600.c
+++ b/fips202/keccakf1600.c
@@ -14,7 +14,8 @@
 #define NROUNDS 24
 #define ROL(a, offset) ((a << offset) ^ (a >> (64-offset)))
 
-static const uint64_t KeccakF_RoundConstants[NROUNDS] = {
+static const uint64_t KeccakF_RoundConstants[NROUNDS] =
+{
     (uint64_t)0x0000000000000001ULL,
     (uint64_t)0x0000000000008082ULL,
     (uint64_t)0x800000000000808aULL,
@@ -41,21 +42,26 @@ static const uint64_t KeccakF_RoundConstants[NROUNDS] = {
     (uint64_t)0x8000000080008008ULL
 };
 
-void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data, unsigned int offset, unsigned int length) {
+void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data, unsigned int offset, unsigned int length)
+{
     unsigned int i;
-    for (i = 0; i < length; i++) {
+    for (i = 0; i < length; i++)
+    {
         data[i] = state[(offset + i) >> 3] >> (8 * ((offset + i) & 0x07));
     }
 }
 
-void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data, unsigned int offset, unsigned int length) {
+void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data, unsigned int offset, unsigned int length)
+{
     unsigned int i;
-    for (i = 0; i < length; i++) {
+    for (i = 0; i < length; i++)
+    {
         state[(offset + i) >> 3] ^= (uint64_t)data[i] << (8 * ((offset + i) & 0x07));
     }
 }
 
-void KeccakF1600_StatePermute(uint64_t *state) {
+void KeccakF1600_StatePermute(uint64_t *state)
+{
     int round;
 
     uint64_t Aba, Abe, Abi, Abo, Abu;
@@ -98,7 +104,8 @@ void KeccakF1600_StatePermute(uint64_t *state) {
     Aso = state[23];
     Asu = state[24];
 
-    for ( round = 0; round < NROUNDS; round += 2 ) {
+    for ( round = 0; round < NROUNDS; round += 2 )
+    {
         //    prepareTheta
         BCa = Aba ^ Aga ^ Aka ^ Ama ^ Asa;
         BCe = Abe ^ Age ^ Ake ^ Ame ^ Ase;

--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -13,7 +13,8 @@
 *
 * Returns 32-bit unsigned integer loaded from x
 **************************************************/
-static uint32_t load32_littleendian(const uint8_t x[4]) {
+static uint32_t load32_littleendian(const uint8_t x[4])
+{
     uint32_t r;
     r  = (uint32_t)x[0];
     r |= (uint32_t)x[1] << 8;
@@ -34,7 +35,8 @@ static uint32_t load32_littleendian(const uint8_t x[4]) {
 * Returns 32-bit unsigned integer loaded from x (most significant byte is zero)
 **************************************************/
 #if KYBER_ETA1 == 3
-static uint32_t load24_littleendian(const uint8_t x[3]) {
+static uint32_t load24_littleendian(const uint8_t x[3])
+{
     uint32_t r;
     r  = (uint32_t)x[0];
     r |= (uint32_t)x[1] << 8;
@@ -53,17 +55,20 @@ static uint32_t load24_littleendian(const uint8_t x[3]) {
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *buf: pointer to input byte array
 **************************************************/
-static void cbd2(poly *r, const uint8_t buf[2 * KYBER_N / 4]) {
+static void cbd2(poly *r, const uint8_t buf[2 * KYBER_N / 4])
+{
     unsigned int i, j;
     uint32_t t, d;
     int16_t a, b;
 
-    for (i = 0; i < KYBER_N / 8; i++) {
+    for (i = 0; i < KYBER_N / 8; i++)
+    {
         t  = load32_littleendian(buf + 4 * i);
         d  = t & 0x55555555;
         d += (t >> 1) & 0x55555555;
 
-        for (j = 0; j < 8; j++) {
+        for (j = 0; j < 8; j++)
+        {
             a = (d >> (4 * j + 0)) & 0x3;
             b = (d >> (4 * j + 2)) & 0x3;
             r->coeffs[8 * i + j] = a - b;
@@ -83,18 +88,21 @@ static void cbd2(poly *r, const uint8_t buf[2 * KYBER_N / 4]) {
 *              - const uint8_t *buf: pointer to input byte array
 **************************************************/
 #if KYBER_ETA1 == 3
-static void cbd3(poly *r, const uint8_t buf[3 * KYBER_N / 4]) {
+static void cbd3(poly *r, const uint8_t buf[3 * KYBER_N / 4])
+{
     unsigned int i, j;
     uint32_t t, d;
     int16_t a, b;
 
-    for (i = 0; i < KYBER_N / 4; i++) {
+    for (i = 0; i < KYBER_N / 4; i++)
+    {
         t  = load24_littleendian(buf + 3 * i);
         d  = t & 0x00249249;
         d += (t >> 1) & 0x00249249;
         d += (t >> 2) & 0x00249249;
 
-        for (j = 0; j < 4; j++) {
+        for (j = 0; j < 4; j++)
+        {
             a = (d >> (6 * j + 0)) & 0x7;
             b = (d >> (6 * j + 3)) & 0x7;
             r->coeffs[4 * i + j] = a - b;
@@ -103,7 +111,8 @@ static void cbd3(poly *r, const uint8_t buf[3 * KYBER_N / 4]) {
 }
 #endif
 
-void poly_cbd_eta1(poly *r, const uint8_t buf[KYBER_ETA1 * KYBER_N / 4]) {
+void poly_cbd_eta1(poly *r, const uint8_t buf[KYBER_ETA1 * KYBER_N / 4])
+{
     #if KYBER_ETA1 == 2
     cbd2(r, buf);
     #elif KYBER_ETA1 == 3
@@ -113,7 +122,8 @@ void poly_cbd_eta1(poly *r, const uint8_t buf[KYBER_ETA1 * KYBER_N / 4]) {
     #endif
 }
 
-void poly_cbd_eta2(poly *r, const uint8_t buf[KYBER_ETA2 * KYBER_N / 4]) {
+void poly_cbd_eta2(poly *r, const uint8_t buf[KYBER_ETA2 * KYBER_N / 4])
+{
     #if KYBER_ETA2 == 2
     cbd2(r, buf);
     #else

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -23,7 +23,8 @@
 **************************************************/
 static void pack_pk(uint8_t r[KYBER_INDCPA_PUBLICKEYBYTES],
                     polyvec *pk,
-                    const uint8_t seed[KYBER_SYMBYTES]) {
+                    const uint8_t seed[KYBER_SYMBYTES])
+{
     polyvec_tobytes(r, pk);
     memcpy(r + KYBER_POLYVECBYTES, seed, KYBER_SYMBYTES);
 }
@@ -40,7 +41,8 @@ static void pack_pk(uint8_t r[KYBER_INDCPA_PUBLICKEYBYTES],
 **************************************************/
 static void unpack_pk(polyvec *pk,
                       uint8_t seed[KYBER_SYMBYTES],
-                      const uint8_t packedpk[KYBER_INDCPA_PUBLICKEYBYTES]) {
+                      const uint8_t packedpk[KYBER_INDCPA_PUBLICKEYBYTES])
+{
     polyvec_frombytes(pk, packedpk);
     memcpy(seed, packedpk + KYBER_POLYVECBYTES, KYBER_SYMBYTES);
 }
@@ -53,7 +55,8 @@ static void unpack_pk(polyvec *pk,
 * Arguments:   - uint8_t *r: pointer to output serialized secret key
 *              - polyvec *sk: pointer to input vector of polynomials (secret key)
 **************************************************/
-static void pack_sk(uint8_t r[KYBER_INDCPA_SECRETKEYBYTES], polyvec *sk) {
+static void pack_sk(uint8_t r[KYBER_INDCPA_SECRETKEYBYTES], polyvec *sk)
+{
     polyvec_tobytes(r, sk);
 }
 
@@ -65,7 +68,8 @@ static void pack_sk(uint8_t r[KYBER_INDCPA_SECRETKEYBYTES], polyvec *sk) {
 * Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret key)
 *              - const uint8_t *packedsk: pointer to input serialized secret key
 **************************************************/
-static void unpack_sk(polyvec *sk, const uint8_t packedsk[KYBER_INDCPA_SECRETKEYBYTES]) {
+static void unpack_sk(polyvec *sk, const uint8_t packedsk[KYBER_INDCPA_SECRETKEYBYTES])
+{
     polyvec_frombytes(sk, packedsk);
 }
 
@@ -80,7 +84,8 @@ static void unpack_sk(polyvec *sk, const uint8_t packedsk[KYBER_INDCPA_SECRETKEY
 *              poly *pk: pointer to the input vector of polynomials b
 *              poly *v: pointer to the input polynomial v
 **************************************************/
-static void pack_ciphertext(uint8_t r[KYBER_INDCPA_BYTES], polyvec *b, poly *v) {
+static void pack_ciphertext(uint8_t r[KYBER_INDCPA_BYTES], polyvec *b, poly *v)
+{
     polyvec_compress(r, b);
     poly_compress(r + KYBER_POLYVECCOMPRESSEDBYTES, v);
 }
@@ -95,7 +100,8 @@ static void pack_ciphertext(uint8_t r[KYBER_INDCPA_BYTES], polyvec *b, poly *v) 
 *              - poly *v: pointer to the output polynomial v
 *              - const uint8_t *c: pointer to the input serialized ciphertext
 **************************************************/
-static void unpack_ciphertext(polyvec *b, poly *v, const uint8_t c[KYBER_INDCPA_BYTES]) {
+static void unpack_ciphertext(polyvec *b, poly *v, const uint8_t c[KYBER_INDCPA_BYTES])
+{
     polyvec_decompress(b, c);
     poly_decompress(v, c + KYBER_POLYVECCOMPRESSEDBYTES);
 }
@@ -116,20 +122,24 @@ static void unpack_ciphertext(polyvec *b, poly *v, const uint8_t c[KYBER_INDCPA_
 static unsigned int rej_uniform(int16_t *r,
                                 unsigned int len,
                                 const uint8_t *buf,
-                                unsigned int buflen) {
+                                unsigned int buflen)
+{
     unsigned int ctr, pos;
     uint16_t val0, val1;
 
     ctr = pos = 0;
-    while (ctr < len && pos + 3 <= buflen) {
+    while (ctr < len && pos + 3 <= buflen)
+    {
         val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
         val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;
         pos += 3;
 
-        if (val0 < KYBER_Q) {
+        if (val0 < KYBER_Q)
+        {
             r[ctr++] = val0;
         }
-        if (ctr < len && val1 < KYBER_Q) {
+        if (ctr < len && val1 < KYBER_Q)
+        {
             r[ctr++] = val1;
         }
     }
@@ -154,17 +164,23 @@ static unsigned int rej_uniform(int16_t *r,
 **************************************************/
 #define GEN_MATRIX_NBLOCKS ((12*KYBER_N/8*(1 << 12)/KYBER_Q + XOF_BLOCKBYTES)/XOF_BLOCKBYTES)
 // Not static for benchmarking
-void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES], int transposed) {
+void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES], int transposed)
+{
     unsigned int ctr, i, j, k;
     unsigned int buflen, off;
     uint8_t buf[GEN_MATRIX_NBLOCKS * XOF_BLOCKBYTES + 2];
     xof_state state;
 
-    for (i = 0; i < KYBER_K; i++) {
-        for (j = 0; j < KYBER_K; j++) {
-            if (transposed) {
+    for (i = 0; i < KYBER_K; i++)
+    {
+        for (j = 0; j < KYBER_K; j++)
+        {
+            if (transposed)
+            {
                 xof_absorb(&state, seed, i, j);
-            } else {
+            }
+            else
+            {
                 xof_absorb(&state, seed, j, i);
             }
 
@@ -172,9 +188,11 @@ void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES], int transposed) 
             buflen = GEN_MATRIX_NBLOCKS * XOF_BLOCKBYTES;
             ctr = rej_uniform(a[i].vec[j].coeffs, KYBER_N, buf, buflen);
 
-            while (ctr < KYBER_N) {
+            while (ctr < KYBER_N)
+            {
                 off = buflen % 3;
-                for (k = 0; k < off; k++) {
+                for (k = 0; k < off; k++)
+                {
                     buf[k] = buf[buflen - off + k];
                 }
                 xof_squeezeblocks(buf + off, 1, &state);
@@ -200,7 +218,8 @@ void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES], int transposed) 
 **************************************************/
 void indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES],
-                           const uint8_t coins[KYBER_SYMBYTES]) {
+                           const uint8_t coins[KYBER_SYMBYTES])
+{
     unsigned int i;
     uint8_t buf[2 * KYBER_SYMBYTES];
     const uint8_t *publicseed = buf;
@@ -212,10 +231,12 @@ void indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
 
     gen_a(a, publicseed);
 
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_getnoise_eta1(&skpv.vec[i], noiseseed, nonce++);
     }
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_getnoise_eta1(&e.vec[i], noiseseed, nonce++);
     }
 
@@ -223,7 +244,8 @@ void indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
     polyvec_ntt(&e);
 
     // matrix-vector multiplication
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         polyvec_basemul_acc_montgomery(&pkpv.vec[i], &a[i], &skpv);
         poly_tomont(&pkpv.vec[i]);
     }
@@ -254,7 +276,8 @@ void indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
 void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
                 const uint8_t m[KYBER_INDCPA_MSGBYTES],
                 const uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
-                const uint8_t coins[KYBER_SYMBYTES]) {
+                const uint8_t coins[KYBER_SYMBYTES])
+{
     unsigned int i;
     uint8_t seed[KYBER_SYMBYTES];
     uint8_t nonce = 0;
@@ -265,10 +288,12 @@ void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
     poly_frommsg(&k, m);
     gen_at(at, seed);
 
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_getnoise_eta1(sp.vec + i, coins, nonce++);
     }
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_getnoise_eta2(ep.vec + i, coins, nonce++);
     }
     poly_getnoise_eta2(&epp, coins, nonce++);
@@ -276,7 +301,8 @@ void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
     polyvec_ntt(&sp);
 
     // matrix-vector multiplication
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         polyvec_basemul_acc_montgomery(&b.vec[i], &at[i], &sp);
     }
 
@@ -309,7 +335,8 @@ void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
 **************************************************/
 void indcpa_dec(uint8_t m[KYBER_INDCPA_MSGBYTES],
                 const uint8_t c[KYBER_INDCPA_BYTES],
-                const uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES]) {
+                const uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES])
+{
     polyvec b, skpv;
     poly v, mp;
 

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -25,7 +25,8 @@
 **************************************************/
 int crypto_kem_keypair_derand(uint8_t *pk,
                               uint8_t *sk,
-                              const uint8_t *coins) {
+                              const uint8_t *coins)
+{
     indcpa_keypair_derand(pk, sk, coins);
     memcpy(sk + KYBER_INDCPA_SECRETKEYBYTES, pk, KYBER_PUBLICKEYBYTES);
     hash_h(sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);
@@ -48,7 +49,8 @@ int crypto_kem_keypair_derand(uint8_t *pk,
 * Returns 0 (success)
 **************************************************/
 int crypto_kem_keypair(uint8_t *pk,
-                       uint8_t *sk) {
+                       uint8_t *sk)
+{
     uint8_t coins[2 * KYBER_SYMBYTES];
     randombytes(coins, 2 * KYBER_SYMBYTES);
     crypto_kem_keypair_derand(pk, sk, coins);
@@ -75,7 +77,8 @@ int crypto_kem_keypair(uint8_t *pk,
 int crypto_kem_enc_derand(uint8_t *ct,
                           uint8_t *ss,
                           const uint8_t *pk,
-                          const uint8_t *coins) {
+                          const uint8_t *coins)
+{
     uint8_t buf[2 * KYBER_SYMBYTES];
     /* Will contain key, coins */
     uint8_t kr[2 * KYBER_SYMBYTES];
@@ -110,7 +113,8 @@ int crypto_kem_enc_derand(uint8_t *ct,
 **************************************************/
 int crypto_kem_enc(uint8_t *ct,
                    uint8_t *ss,
-                   const uint8_t *pk) {
+                   const uint8_t *pk)
+{
     uint8_t coins[KYBER_SYMBYTES];
     randombytes(coins, KYBER_SYMBYTES);
     crypto_kem_enc_derand(ct, ss, pk, coins);
@@ -136,7 +140,8 @@ int crypto_kem_enc(uint8_t *ct,
 **************************************************/
 int crypto_kem_dec(uint8_t *ss,
                    const uint8_t *ct,
-                   const uint8_t *sk) {
+                   const uint8_t *sk)
+{
     int fail;
     uint8_t buf[2 * KYBER_SYMBYTES];
     /* Will contain key, coins */

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -37,7 +37,8 @@ void init_ntt() {
 }
 */
 
-const int16_t zetas[128] = {
+const int16_t zetas[128] =
+{
     -1044,  -758,  -359, -1517,  1493,  1422,   287,   202,
     -171,   622,  1577,   182,   962, -1202, -1474,  1468,
     573, -1325,   264,   383,  -829,  1458, -1602,  -130,
@@ -66,7 +67,8 @@ const int16_t zetas[128] = {
 *
 * Returns 16-bit integer congruent to a*b*R^{-1} mod q
 **************************************************/
-static int16_t fqmul(int16_t a, int16_t b) {
+static int16_t fqmul(int16_t a, int16_t b)
+{
     return montgomery_reduce((int32_t)a * b);
 }
 
@@ -78,15 +80,19 @@ static int16_t fqmul(int16_t a, int16_t b) {
 *
 * Arguments:   - int16_t r[256]: pointer to input/output vector of elements of Zq
 **************************************************/
-void ntt(int16_t r[256]) {
+void ntt(int16_t r[256])
+{
     unsigned int len, start, j, k;
     int16_t t, zeta;
 
     k = 1;
-    for (len = 128; len >= 2; len >>= 1) {
-        for (start = 0; start < 256; start = j + len) {
+    for (len = 128; len >= 2; len >>= 1)
+    {
+        for (start = 0; start < 256; start = j + len)
+        {
             zeta = zetas[k++];
-            for (j = start; j < start + len; j++) {
+            for (j = start; j < start + len; j++)
+            {
                 t = fqmul(zeta, r[j + len]);
                 r[j + len] = r[j] - t;
                 r[j] = r[j] + t;
@@ -104,16 +110,20 @@ void ntt(int16_t r[256]) {
 *
 * Arguments:   - int16_t r[256]: pointer to input/output vector of elements of Zq
 **************************************************/
-void invntt(int16_t r[256]) {
+void invntt(int16_t r[256])
+{
     unsigned int start, len, j, k;
     int16_t t, zeta;
     const int16_t f = 1441; // mont^2/128
 
     k = 127;
-    for (len = 2; len <= 128; len <<= 1) {
-        for (start = 0; start < 256; start = j + len) {
+    for (len = 2; len <= 128; len <<= 1)
+    {
+        for (start = 0; start < 256; start = j + len)
+        {
             zeta = zetas[k--];
-            for (j = start; j < start + len; j++) {
+            for (j = start; j < start + len; j++)
+            {
                 t = r[j];
                 r[j] = barrett_reduce(t + r[j + len]);
                 r[j + len] = r[j + len] - t;
@@ -122,7 +132,8 @@ void invntt(int16_t r[256]) {
         }
     }
 
-    for (j = 0; j < 256; j++) {
+    for (j = 0; j < 256; j++)
+    {
         r[j] = fqmul(r[j], f);
     }
 }
@@ -138,7 +149,8 @@ void invntt(int16_t r[256]) {
 *              - const int16_t b[2]: pointer to the second factor
 *              - int16_t zeta: integer defining the reduction polynomial
 **************************************************/
-void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta) {
+void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta)
+{
     r[0]  = fqmul(a[1], b[1]);
     r[0]  = fqmul(r[0], zeta);
     r[0] += fqmul(a[0], b[0]);

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -17,7 +17,8 @@
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  ************************************************************/
-uint32_t scalar_compress_q_16(int32_t u) {
+uint32_t scalar_compress_q_16(int32_t u)
+{
     uint32_t d0 = (uint32_t) u;
     d0 <<= 4;
     d0 +=  1665;
@@ -42,7 +43,8 @@ uint32_t scalar_compress_q_16(int32_t u) {
  * Arguments: - u: Unsigned canonical modulus modulo 16
  *                 to be decompressed.
  ************************************************************/
-uint32_t scalar_decompress_q_16(uint32_t u) {
+uint32_t scalar_decompress_q_16(uint32_t u)
+{
     return ((u * KYBER_Q) + 8) / 16;
 }
 
@@ -54,7 +56,8 @@ uint32_t scalar_decompress_q_16(uint32_t u) {
  * Arguments: - u: Unsigned canonical modulus modulo q
  *                 to be compressed.
  ************************************************************/
-uint32_t scalar_compress_q_32(int32_t u) {
+uint32_t scalar_compress_q_32(int32_t u)
+{
     uint32_t d0 = (uint32_t) u;
     d0 <<= 5;
     d0 +=  1664;
@@ -79,7 +82,8 @@ uint32_t scalar_compress_q_32(int32_t u) {
  * Arguments: - u: Unsigned canonical modulus modulo 32
  *                 to be decompressed.
  ************************************************************/
-uint32_t scalar_decompress_q_32(uint32_t u) {
+uint32_t scalar_decompress_q_32(uint32_t u)
+{
     return ((u * KYBER_Q) + 16) / 32;
 }
 
@@ -92,7 +96,8 @@ uint32_t scalar_decompress_q_32(uint32_t u) {
 *                            (of length KYBER_POLYCOMPRESSEDBYTES)
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a) {
+void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)
+{
     unsigned int i, j;
     int32_t u;
     uint8_t t[8];
@@ -120,8 +125,10 @@ void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a) {
         r += 4;
     }
     #elif (KYBER_POLYCOMPRESSEDBYTES == 160)
-    for (i = 0; i < KYBER_N / 8; i++) {
-        for (j = 0; j < 8; j++) {
+    for (i = 0; i < KYBER_N / 8; i++)
+    {
+        for (j = 0; j < 8; j++)
+        {
             // map to positive standard representatives
             u  = a->coeffs[8 * i + j];
             u += (u >> 15) & KYBER_Q;
@@ -173,7 +180,8 @@ __CPROVER_forall {
     unsigned int i;
 
     #if (KYBER_POLYCOMPRESSEDBYTES == 128)
-    for (i = 0; i < KYBER_N / 2; i++) {
+    for (i = 0; i < KYBER_N / 2; i++)
+    {
         // REF-CHANGE: Hoist scalar decompression into separate function
         r->coeffs[2 * i + 0] = scalar_decompress_q_16((a[0] >> 0) & 0xF);
         r->coeffs[2 * i + 1] = scalar_decompress_q_16((a[0] >> 4) & 0xF);
@@ -182,7 +190,8 @@ __CPROVER_forall {
     #elif (KYBER_POLYCOMPRESSEDBYTES == 160)
     unsigned int j;
     uint8_t t[8];
-    for (i = 0; i < KYBER_N / 8; i++) {
+    for (i = 0; i < KYBER_N / 8; i++)
+    {
         // REF-CHANGE: Explicitly truncate to avoid warning about
         // implicit truncation in CBMC.
         t[0] = 0x1F &  (a[0] >> 0);
@@ -195,7 +204,8 @@ __CPROVER_forall {
         t[7] = 0x1F &  (a[4] >> 3);
         a += 5;
 
-        for (j = 0; j < 8; j++) {
+        for (j = 0; j < 8; j++)
+        {
             // REF-CHANGE: Truncation happened before
             r->coeffs[8 * i + j] = ((uint32_t) t[j] * KYBER_Q + 16) >> 5;
         }
@@ -214,11 +224,13 @@ __CPROVER_forall {
 *                            (needs space for KYBER_POLYBYTES bytes)
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a) {
+void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a)
+{
     unsigned int i;
     uint16_t t0, t1;
 
-    for (i = 0; i < KYBER_N / 2; i++) {
+    for (i = 0; i < KYBER_N / 2; i++)
+    {
         // map to positive standard representatives
         t0  = a->coeffs[2 * i];
         t0 += ((int16_t)t0 >> 15) & KYBER_Q;
@@ -240,9 +252,11 @@ void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a) {
 *              - const uint8_t *a: pointer to input byte array
 *                                  (of KYBER_POLYBYTES bytes)
 **************************************************/
-void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]) {
+void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES])
+{
     unsigned int i;
-    for (i = 0; i < KYBER_N / 2; i++) {
+    for (i = 0; i < KYBER_N / 2; i++)
+    {
         r->coeffs[2 * i]   = ((a[3 * i + 0] >> 0) | ((uint16_t)a[3 * i + 1] << 8)) & 0xFFF;
         r->coeffs[2 * i + 1] = ((a[3 * i + 1] >> 4) | ((uint16_t)a[3 * i + 2] << 4)) & 0xFFF;
     }
@@ -256,15 +270,18 @@ void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]) {
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *msg: pointer to input message
 **************************************************/
-void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES]) {
+void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES])
+{
     unsigned int i, j;
 
     #if (KYBER_INDCPA_MSGBYTES != KYBER_N/8)
 #error "KYBER_INDCPA_MSGBYTES must be equal to KYBER_N/8 bytes!"
     #endif
 
-    for (i = 0; i < KYBER_N / 8; i++) {
-        for (j = 0; j < 8; j++) {
+    for (i = 0; i < KYBER_N / 8; i++)
+    {
+        for (j = 0; j < 8; j++)
+        {
             r->coeffs[8 * i + j] = 0;
             cmov_int16(r->coeffs + 8 * i + j, ((KYBER_Q + 1) / 2), (msg[i] >> j) & 1);
         }
@@ -279,13 +296,16 @@ void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES]) {
 * Arguments:   - uint8_t *msg: pointer to output message
 *              - const poly *a: pointer to input polynomial
 **************************************************/
-void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a) {
+void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a)
+{
     unsigned int i, j;
     uint32_t t;
 
-    for (i = 0; i < KYBER_N / 8; i++) {
+    for (i = 0; i < KYBER_N / 8; i++)
+    {
         msg[i] = 0;
-        for (j = 0; j < 8; j++) {
+        for (j = 0; j < 8; j++)
+        {
             t  = a->coeffs[8 * i + j];
             // t += ((int16_t)t >> 15) & KYBER_Q;
             // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
@@ -311,7 +331,8 @@ void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a) {
 *                                     (of length KYBER_SYMBYTES bytes)
 *              - uint8_t nonce: one-byte input nonce
 **************************************************/
-void poly_getnoise_eta1(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce) {
+void poly_getnoise_eta1(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce)
+{
     uint8_t buf[KYBER_ETA1 * KYBER_N / 4];
     prf(buf, sizeof(buf), seed, nonce);
     poly_cbd_eta1(r, buf);
@@ -329,7 +350,8 @@ void poly_getnoise_eta1(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t non
 *                                     (of length KYBER_SYMBYTES bytes)
 *              - uint8_t nonce: one-byte input nonce
 **************************************************/
-void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce) {
+void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce)
+{
     uint8_t buf[KYBER_ETA2 * KYBER_N / 4];
     prf(buf, sizeof(buf), seed, nonce);
     poly_cbd_eta2(r, buf);
@@ -344,7 +366,8 @@ void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t non
 *
 * Arguments:   - uint16_t *r: pointer to in/output polynomial
 **************************************************/
-void poly_ntt(poly *r) {
+void poly_ntt(poly *r)
+{
     ntt(r->coeffs);
     poly_reduce(r);
 }
@@ -358,7 +381,8 @@ void poly_ntt(poly *r) {
 *
 * Arguments:   - uint16_t *a: pointer to in/output polynomial
 **************************************************/
-void poly_invntt_tomont(poly *r) {
+void poly_invntt_tomont(poly *r)
+{
     invntt(r->coeffs);
 }
 
@@ -371,9 +395,11 @@ void poly_invntt_tomont(poly *r) {
 *              - const poly *a: pointer to first input polynomial
 *              - const poly *b: pointer to second input polynomial
 **************************************************/
-void poly_basemul_montgomery(poly *r, const poly *a, const poly *b) {
+void poly_basemul_montgomery(poly *r, const poly *a, const poly *b)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_N / 4; i++) {
+    for (i = 0; i < KYBER_N / 4; i++)
+    {
         basemul(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i], zetas[64 + i]);
         basemul(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2], -zetas[64 + i]);
     }
@@ -387,10 +413,12 @@ void poly_basemul_montgomery(poly *r, const poly *a, const poly *b) {
 *
 * Arguments:   - poly *r: pointer to input/output polynomial
 **************************************************/
-void poly_tomont(poly *r) {
+void poly_tomont(poly *r)
+{
     unsigned int i;
     const int16_t f = (1ULL << 32) % KYBER_Q;
-    for (i = 0; i < KYBER_N; i++) {
+    for (i = 0; i < KYBER_N; i++)
+    {
         r->coeffs[i] = montgomery_reduce((int32_t)r->coeffs[i] * f);
     }
 }
@@ -403,9 +431,11 @@ void poly_tomont(poly *r) {
 *
 * Arguments:   - poly *r: pointer to input/output polynomial
 **************************************************/
-void poly_reduce(poly *r) {
+void poly_reduce(poly *r)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_N; i++) {
+    for (i = 0; i < KYBER_N; i++)
+    {
         r->coeffs[i] = barrett_reduce(r->coeffs[i]);
     }
 }
@@ -419,9 +449,11 @@ void poly_reduce(poly *r) {
 *            - const poly *a: pointer to first input polynomial
 *            - const poly *b: pointer to second input polynomial
 **************************************************/
-void poly_add(poly *r, const poly *a, const poly *b) {
+void poly_add(poly *r, const poly *a, const poly *b)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_N; i++) {
+    for (i = 0; i < KYBER_N; i++)
+    {
         r->coeffs[i] = a->coeffs[i] + b->coeffs[i];
     }
 }
@@ -435,9 +467,11 @@ void poly_add(poly *r, const poly *a, const poly *b) {
 *            - const poly *a: pointer to first input polynomial
 *            - const poly *b: pointer to second input polynomial
 **************************************************/
-void poly_sub(poly *r, const poly *a, const poly *b) {
+void poly_sub(poly *r, const poly *a, const poly *b)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_N; i++) {
+    for (i = 0; i < KYBER_N; i++)
+    {
         r->coeffs[i] = a->coeffs[i] - b->coeffs[i];
     }
 }

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -10,7 +10,8 @@
  * Elements of R_q = Z_q[X]/(X^n + 1). Represents polynomial
  * coeffs[0] + X*coeffs[1] + X^2*coeffs[2] + ... + X^{n-1}*coeffs[n-1]
  */
-typedef struct {
+typedef struct
+{
     int16_t coeffs[KYBER_N];
 } poly;
 

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -13,15 +13,19 @@
 *                            (needs space for KYBER_POLYVECCOMPRESSEDBYTES)
 *              - const polyvec *a: pointer to input vector of polynomials
 **************************************************/
-void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES], const polyvec *a) {
+void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES], const polyvec *a)
+{
     unsigned int i, j, k;
     uint64_t d0;
 
     #if (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 352))
     uint16_t t[8];
-    for (i = 0; i < KYBER_K; i++) {
-        for (j = 0; j < KYBER_N / 8; j++) {
-            for (k = 0; k < 8; k++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
+        for (j = 0; j < KYBER_N / 8; j++)
+        {
+            for (k = 0; k < 8; k++)
+            {
                 t[k]  = a->vec[i].coeffs[8 * j + k];
                 t[k] += ((int16_t)t[k] >> 15) & KYBER_Q;
                 /*      t[k]  = ((((uint32_t)t[k] << 11) + KYBER_Q/2)/KYBER_Q) & 0x7ff; */
@@ -50,9 +54,12 @@ void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES], const polyvec *a)
     }
     #elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 320))
     uint16_t t[4];
-    for (i = 0; i < KYBER_K; i++) {
-        for (j = 0; j < KYBER_N / 4; j++) {
-            for (k = 0; k < 4; k++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
+        for (j = 0; j < KYBER_N / 4; j++)
+        {
+            for (k = 0; k < 4; k++)
+            {
                 t[k]  = a->vec[i].coeffs[4 * j + k];
                 t[k] += ((int16_t)t[k] >> 15) & KYBER_Q;
                 /*      t[k]  = ((((uint32_t)t[k] << 10) + KYBER_Q/2)/ KYBER_Q) & 0x3ff; */
@@ -87,13 +94,16 @@ void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES], const polyvec *a)
 *              - const uint8_t *a: pointer to input byte array
 *                                  (of length KYBER_POLYVECCOMPRESSEDBYTES)
 **************************************************/
-void polyvec_decompress(polyvec *r, const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES]) {
+void polyvec_decompress(polyvec *r, const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES])
+{
     unsigned int i, j, k;
 
     #if (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 352))
     uint16_t t[8];
-    for (i = 0; i < KYBER_K; i++) {
-        for (j = 0; j < KYBER_N / 8; j++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
+        for (j = 0; j < KYBER_N / 8; j++)
+        {
             t[0] = (a[0] >> 0) | ((uint16_t)a[ 1] << 8);
             t[1] = (a[1] >> 3) | ((uint16_t)a[ 2] << 5);
             t[2] = (a[2] >> 6) | ((uint16_t)a[ 3] << 2) | ((uint16_t)a[4] << 10);
@@ -104,22 +114,26 @@ void polyvec_decompress(polyvec *r, const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES
             t[7] = (a[9] >> 5) | ((uint16_t)a[10] << 3);
             a += 11;
 
-            for (k = 0; k < 8; k++) {
+            for (k = 0; k < 8; k++)
+            {
                 r->vec[i].coeffs[8 * j + k] = ((uint32_t)(t[k] & 0x7FF) * KYBER_Q + 1024) >> 11;
             }
         }
     }
     #elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 320))
     uint16_t t[4];
-    for (i = 0; i < KYBER_K; i++) {
-        for (j = 0; j < KYBER_N / 4; j++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
+        for (j = 0; j < KYBER_N / 4; j++)
+        {
             t[0] = (a[0] >> 0) | ((uint16_t)a[1] << 8);
             t[1] = (a[1] >> 2) | ((uint16_t)a[2] << 6);
             t[2] = (a[2] >> 4) | ((uint16_t)a[3] << 4);
             t[3] = (a[3] >> 6) | ((uint16_t)a[4] << 2);
             a += 5;
 
-            for (k = 0; k < 4; k++) {
+            for (k = 0; k < 4; k++)
+            {
                 r->vec[i].coeffs[4 * j + k] = ((uint32_t)(t[k] & 0x3FF) * KYBER_Q + 512) >> 10;
             }
         }
@@ -138,9 +152,11 @@ void polyvec_decompress(polyvec *r, const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES
 *                            (needs space for KYBER_POLYVECBYTES)
 *              - const polyvec *a: pointer to input vector of polynomials
 **************************************************/
-void polyvec_tobytes(uint8_t r[KYBER_POLYVECBYTES], const polyvec *a) {
+void polyvec_tobytes(uint8_t r[KYBER_POLYVECBYTES], const polyvec *a)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_tobytes(r + i * KYBER_POLYBYTES, &a->vec[i]);
     }
 }
@@ -155,9 +171,11 @@ void polyvec_tobytes(uint8_t r[KYBER_POLYVECBYTES], const polyvec *a) {
 *              - const polyvec *a: pointer to input vector of polynomials
 *                                  (of length KYBER_POLYVECBYTES)
 **************************************************/
-void polyvec_frombytes(polyvec *r, const uint8_t a[KYBER_POLYVECBYTES]) {
+void polyvec_frombytes(polyvec *r, const uint8_t a[KYBER_POLYVECBYTES])
+{
     unsigned int i;
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_frombytes(&r->vec[i], a + i * KYBER_POLYBYTES);
     }
 }
@@ -169,9 +187,11 @@ void polyvec_frombytes(polyvec *r, const uint8_t a[KYBER_POLYVECBYTES]) {
 *
 * Arguments:   - polyvec *r: pointer to in/output vector of polynomials
 **************************************************/
-void polyvec_ntt(polyvec *r) {
+void polyvec_ntt(polyvec *r)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_ntt(&r->vec[i]);
     }
 }
@@ -184,9 +204,11 @@ void polyvec_ntt(polyvec *r) {
 *
 * Arguments:   - polyvec *r: pointer to in/output vector of polynomials
 **************************************************/
-void polyvec_invntt_tomont(polyvec *r) {
+void polyvec_invntt_tomont(polyvec *r)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_invntt_tomont(&r->vec[i]);
     }
 }
@@ -201,12 +223,14 @@ void polyvec_invntt_tomont(polyvec *r) {
 *            - const polyvec *a: pointer to first input vector of polynomials
 *            - const polyvec *b: pointer to second input vector of polynomials
 **************************************************/
-void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b) {
+void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
+{
     unsigned int i;
     poly t;
 
     poly_basemul_montgomery(r, &a->vec[0], &b->vec[0]);
-    for (i = 1; i < KYBER_K; i++) {
+    for (i = 1; i < KYBER_K; i++)
+    {
         poly_basemul_montgomery(&t, &a->vec[i], &b->vec[i]);
         poly_add(r, r, &t);
     }
@@ -223,9 +247,11 @@ void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
 *
 * Arguments:   - polyvec *r: pointer to input/output polynomial
 **************************************************/
-void polyvec_reduce(polyvec *r) {
+void polyvec_reduce(polyvec *r)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_reduce(&r->vec[i]);
     }
 }
@@ -239,9 +265,11 @@ void polyvec_reduce(polyvec *r) {
 *            - const polyvec *a: pointer to first input vector of polynomials
 *            - const polyvec *b: pointer to second input vector of polynomials
 **************************************************/
-void polyvec_add(polyvec *r, const polyvec *a, const polyvec *b) {
+void polyvec_add(polyvec *r, const polyvec *a, const polyvec *b)
+{
     unsigned int i;
-    for (i = 0; i < KYBER_K; i++) {
+    for (i = 0; i < KYBER_K; i++)
+    {
         poly_add(&r->vec[i], &a->vec[i], &b->vec[i]);
     }
 }

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -6,7 +6,8 @@
 #include "params.h"
 #include "poly.h"
 
-typedef struct {
+typedef struct
+{
     poly vec[KYBER_K];
 } polyvec;
 

--- a/mlkem/reduce.c
+++ b/mlkem/reduce.c
@@ -14,7 +14,8 @@
 *
 * Returns:     integer in {-q+1,...,q-1} congruent to a * R^-1 modulo q.
 **************************************************/
-int16_t montgomery_reduce(int32_t a) {
+int16_t montgomery_reduce(int32_t a)
+{
     int16_t t;
 
     t = (int16_t)a * QINV;
@@ -32,7 +33,8 @@ int16_t montgomery_reduce(int32_t a) {
 *
 * Returns:     integer in {-(q-1)/2,...,(q-1)/2} congruent to a modulo q.
 **************************************************/
-int16_t barrett_reduce(int16_t a) {
+int16_t barrett_reduce(int16_t a)
+{
     int16_t t;
     const int16_t v = ((1 << 26) + KYBER_Q / 2) / KYBER_Q;
 

--- a/mlkem/symmetric-shake.c
+++ b/mlkem/symmetric-shake.c
@@ -19,7 +19,8 @@
 void kyber_shake128_absorb(xof_state *state,
                            const uint8_t seed[KYBER_SYMBYTES],
                            uint8_t x,
-                           uint8_t y) {
+                           uint8_t y)
+{
     uint8_t extseed[KYBER_SYMBYTES + 2];
 
     memcpy(extseed, seed, KYBER_SYMBYTES);
@@ -40,7 +41,8 @@ void kyber_shake128_absorb(xof_state *state,
 *              - const uint8_t *key: pointer to the key (of length KYBER_SYMBYTES)
 *              - uint8_t nonce: single-byte nonce (public PRF input)
 **************************************************/
-void kyber_shake256_prf(uint8_t *out, size_t outlen, const uint8_t key[KYBER_SYMBYTES], uint8_t nonce) {
+void kyber_shake256_prf(uint8_t *out, size_t outlen, const uint8_t key[KYBER_SYMBYTES], uint8_t nonce)
+{
     uint8_t extkey[KYBER_SYMBYTES + 1];
 
     memcpy(extkey, key, KYBER_SYMBYTES);
@@ -60,7 +62,8 @@ void kyber_shake256_prf(uint8_t *out, size_t outlen, const uint8_t key[KYBER_SYM
 *              - const uint8_t *key: pointer to the key (of length KYBER_SYMBYTES)
 *              - uint8_t nonce: single-byte nonce (public PRF input)
 **************************************************/
-void kyber_shake256_rkprf(uint8_t out[KYBER_SSBYTES], const uint8_t key[KYBER_SYMBYTES], const uint8_t input[KYBER_CIPHERTEXTBYTES]) {
+void kyber_shake256_rkprf(uint8_t out[KYBER_SSBYTES], const uint8_t key[KYBER_SYMBYTES], const uint8_t input[KYBER_CIPHERTEXTBYTES])
+{
     shake256incctx s;
 
     shake256_inc_init(&s);

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -14,11 +14,13 @@
 *
 * Returns 0 if the byte arrays are equal, 1 otherwise
 **************************************************/
-int verify(const uint8_t *a, const uint8_t *b, size_t len) {
+int verify(const uint8_t *a, const uint8_t *b, size_t len)
+{
     size_t i;
     uint8_t r = 0;
 
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < len; i++)
+    {
         r |= a[i] ^ b[i];
     }
 
@@ -38,11 +40,13 @@ int verify(const uint8_t *a, const uint8_t *b, size_t len) {
 *              size_t len:       Amount of bytes to be copied
 *              uint8_t b:        Condition bit; has to be in {0,1}
 **************************************************/
-void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b) {
+void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b)
+{
     size_t i;
 
     b = -b;
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < len; i++)
+    {
         r[i] ^= b & (r[i] ^ x[i]);
     }
 }
@@ -58,7 +62,8 @@ void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b) {
 *              int16_t v:        input int16_t
 *              uint8_t b:        Condition bit; has to be in {0,1}
 **************************************************/
-void cmov_int16(int16_t *r, int16_t v, uint16_t b) {
+void cmov_int16(int16_t *r, int16_t v, uint16_t b)
+{
     b = -b;
     *r ^= b & ((*r) ^ v);
 }

--- a/randombytes/randombytes.c
+++ b/randombytes/randombytes.c
@@ -20,17 +20,21 @@
 #endif
 
 #ifdef _WIN32
-void randombytes(uint8_t *out, size_t outlen) {
+void randombytes(uint8_t *out, size_t outlen)
+{
     HCRYPTPROV ctx;
     size_t len;
 
-    if (!CryptAcquireContext(&ctx, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
+    if (!CryptAcquireContext(&ctx, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+    {
         abort();
     }
 
-    while (outlen > 0) {
+    while (outlen > 0)
+    {
         len = (outlen > 1048576) ? 1048576 : outlen;
-        if (!CryptGenRandom(ctx, len, (BYTE *)out)) {
+        if (!CryptGenRandom(ctx, len, (BYTE *)out))
+        {
             abort();
         }
 
@@ -38,19 +42,25 @@ void randombytes(uint8_t *out, size_t outlen) {
         outlen -= len;
     }
 
-    if (!CryptReleaseContext(ctx, 0)) {
+    if (!CryptReleaseContext(ctx, 0))
+    {
         abort();
     }
 }
 #elif defined(__linux__) && defined(SYS_getrandom)
-void randombytes(uint8_t *out, size_t outlen) {
+void randombytes(uint8_t *out, size_t outlen)
+{
     ssize_t ret;
 
-    while (outlen > 0) {
+    while (outlen > 0)
+    {
         ret = syscall(SYS_getrandom, out, outlen, 0);
-        if (ret == -1 && errno == EINTR) {
+        if (ret == -1 && errno == EINTR)
+        {
             continue;
-        } else if (ret == -1) {
+        }
+        else if (ret == -1)
+        {
             abort();
         }
 
@@ -59,24 +69,33 @@ void randombytes(uint8_t *out, size_t outlen) {
     }
 }
 #else
-void randombytes(uint8_t *out, size_t outlen) {
+void randombytes(uint8_t *out, size_t outlen)
+{
     static int fd = -1;
     ssize_t ret;
 
-    while (fd == -1) {
+    while (fd == -1)
+    {
         fd = open("/dev/urandom", O_RDONLY);
-        if (fd == -1 && errno == EINTR) {
+        if (fd == -1 && errno == EINTR)
+        {
             continue;
-        } else if (fd == -1) {
+        }
+        else if (fd == -1)
+        {
             abort();
         }
     }
 
-    while (outlen > 0) {
+    while (outlen > 0)
+    {
         ret = read(fd, out, outlen);
-        if (ret == -1 && errno == EINTR) {
+        if (ret == -1 && errno == EINTR)
+        {
             continue;
-        } else if (ret == -1) {
+        }
+        else if (ret == -1)
+        {
             abort();
         }
 

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -8,21 +8,25 @@
 
 #define NTESTS 10000
 
-static void print_hex(const char *label, const uint8_t *data, size_t size) {
+static void print_hex(const char *label, const uint8_t *data, size_t size)
+{
     printf("%s = ", label);
-    for (size_t i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++)
+    {
         printf("%02x", data[i]);
     }
     printf("\n");
 }
 
-static void shake256_absorb(shake256incctx *state, const uint8_t *input, size_t inlen) {
+static void shake256_absorb(shake256incctx *state, const uint8_t *input, size_t inlen)
+{
     shake256_inc_init(state);
     shake256_inc_absorb(state, input, inlen);
     shake256_inc_finalize(state);
 }
 
-int main(void) {
+int main(void)
+{
     uint8_t coins[3 * KYBER_SYMBYTES];
     uint8_t pk[CRYPTO_PUBLICKEYBYTES];
     uint8_t sk[CRYPTO_SECRETKEYBYTES];
@@ -39,7 +43,8 @@ int main(void) {
     shake256incctx state;
     shake256_absorb(&state, seed, sizeof(seed));
 
-    for (unsigned int i = 0; i < NTESTS; i++) {
+    for (unsigned int i = 0; i < NTESTS; i++)
+    {
 
         shake256_inc_squeeze(coins, sizeof(coins), &state);
 
@@ -52,7 +57,8 @@ int main(void) {
 
         crypto_kem_dec(ss2, ct, sk);
 
-        if (memcmp(ss1, ss2, sizeof(ss1))) {
+        if (memcmp(ss1, ss2, sizeof(ss1)))
+        {
             fprintf(stderr, "ERROR\n");
             return -1;
         }

--- a/test/gen_NISTKAT.c
+++ b/test/gen_NISTKAT.c
@@ -6,19 +6,23 @@
 #include "kem.h"
 #include "randombytes.h"
 
-static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L) {
+static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L)
+{
     size_t i;
     fprintf(fp, "%s", S);
-    for (i = 0; i < L; i++) {
+    for (i = 0; i < L; i++)
+    {
         fprintf(fp, "%02X", A[i]);
     }
-    if (L == 0) {
+    if (L == 0)
+    {
         fprintf(fp, "00");
     }
     fprintf(fp, "\n");
 }
 
-static void randombytes_nth(uint8_t *seed, size_t nth, size_t len) {
+static void randombytes_nth(uint8_t *seed, size_t nth, size_t len)
+{
     uint8_t entropy_input[48] = {0, 1, 2, 3, 4, 5, 6, 7,
                                  8, 9, 10, 11, 12, 13, 14, 15,
                                  16, 17, 18, 19, 20, 21, 22, 23,
@@ -28,12 +32,14 @@ static void randombytes_nth(uint8_t *seed, size_t nth, size_t len) {
                                 };
     nist_kat_init(entropy_input, NULL, 256);
 
-    for (size_t i = 0; i < nth + 1; i++) {
+    for (size_t i = 0; i < nth + 1; i++)
+    {
         randombytes(seed, len);
     }
 }
 
-int main(void) {
+int main(void)
+{
     uint8_t seed[48];
     FILE *fh = stdout;
     uint8_t public_key[CRYPTO_PUBLICKEYBYTES];
@@ -47,7 +53,8 @@ int main(void) {
 
     fprintf(fh, "# %s\n\n", CRYPTO_ALGNAME);
 
-    do {
+    do
+    {
         fprintf(fh, "count = %d\n", count);
         randombytes_nth(seed, count, 48);
         fprintBstr(fh, "seed = ", seed, 48);
@@ -55,7 +62,8 @@ int main(void) {
         nist_kat_init(seed, NULL, 256);
 
         rc = crypto_kem_keypair(public_key, secret_key);
-        if (rc != 0) {
+        if (rc != 0)
+        {
             fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_keypair failed!\n", CRYPTO_ALGNAME);
             return -1;
         }
@@ -63,7 +71,8 @@ int main(void) {
         fprintBstr(fh, "sk = ", secret_key, CRYPTO_SECRETKEYBYTES);
 
         rc = crypto_kem_enc(ciphertext, shared_secret_e, public_key);
-        if (rc != 0) {
+        if (rc != 0)
+        {
             fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_enc failed!\n", CRYPTO_ALGNAME);
             return -2;
         }
@@ -72,18 +81,21 @@ int main(void) {
         fprintf(fh, "\n");
 
         rc = crypto_kem_dec(shared_secret_d, ciphertext, secret_key);
-        if (rc != 0) {
+        if (rc != 0)
+        {
             fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_dec failed!\n", CRYPTO_ALGNAME);
             return -3;
         }
 
         rc = memcmp(shared_secret_e, shared_secret_d, CRYPTO_BYTES);
-        if (rc != 0) {
+        if (rc != 0)
+        {
             fprintf(stderr, "[kat_kem] %s ERROR: shared secrets are not equal\n", CRYPTO_ALGNAME);
             return -4;
         }
         count++;
-    } while (count < 100);
+    }
+    while (count < 100);
 
     return 0;
 }

--- a/test/nistrng/aes.c
+++ b/test/nistrng/aes.c
@@ -33,37 +33,45 @@
 
 #include "aes.h"
 
-static inline uint32_t br_dec32le(const unsigned char *src) {
+static inline uint32_t br_dec32le(const unsigned char *src)
+{
     return (uint32_t)src[0] | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) | ((uint32_t)src[3] << 24);
 }
 
-static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src) {
-    while (num-- > 0) {
+static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src)
+{
+    while (num-- > 0)
+    {
         *v++ = br_dec32le(src);
         src += 4;
     }
 }
 
-static inline uint32_t br_swap32(uint32_t x) {
+static inline uint32_t br_swap32(uint32_t x)
+{
     x = ((x & (uint32_t)0x00FF00FF) << 8) | ((x >> 8) & (uint32_t)0x00FF00FF);
     return (x << 16) | (x >> 16);
 }
 
-static inline void br_enc32le(unsigned char *dst, uint32_t x) {
+static inline void br_enc32le(unsigned char *dst, uint32_t x)
+{
     dst[0] = (unsigned char)x;
     dst[1] = (unsigned char)(x >> 8);
     dst[2] = (unsigned char)(x >> 16);
     dst[3] = (unsigned char)(x >> 24);
 }
 
-static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num) {
-    while (num-- > 0) {
+static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num)
+{
+    while (num-- > 0)
+    {
         br_enc32le(dst, *v++);
         dst += 4;
     }
 }
 
-static void br_aes_ct64_bitslice_Sbox(uint64_t *q) {
+static void br_aes_ct64_bitslice_Sbox(uint64_t *q)
+{
     /*
      * This S-box implementation is a straightforward translation of
      * the circuit described by Boyar and Peralta in "A new
@@ -237,7 +245,8 @@ static void br_aes_ct64_bitslice_Sbox(uint64_t *q) {
     q[0] = s7;
 }
 
-static void br_aes_ct64_ortho(uint64_t *q) {
+static void br_aes_ct64_ortho(uint64_t *q)
+{
 #define SWAPN(cl, ch, s, x, y)                                      \
     do                                                              \
     {                                                               \
@@ -268,7 +277,8 @@ static void br_aes_ct64_ortho(uint64_t *q) {
     SWAP8(q[3], q[7]);
 }
 
-static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t *w) {
+static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t *w)
+{
     uint64_t x0, x1, x2, x3;
 
     x0 = w[0];
@@ -295,7 +305,8 @@ static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t
     *q1 = x1 | (x3 << 8);
 }
 
-static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1) {
+static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1)
+{
     uint64_t x0, x1, x2, x3;
 
     x0 = q0 & (uint64_t)0x00FF00FF00FF00FF;
@@ -316,11 +327,13 @@ static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1) {
     w[3] = (uint32_t)x3 | (uint32_t)(x3 >> 16);
 }
 
-static const unsigned char Rcon[] = {
+static const unsigned char Rcon[] =
+{
     0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36
 };
 
-static uint32_t sub_word(uint32_t x) {
+static uint32_t sub_word(uint32_t x)
+{
     uint64_t q[8];
 
     memset(q, 0, sizeof q);
@@ -331,7 +344,8 @@ static uint32_t sub_word(uint32_t x) {
     return (uint32_t)q[0];
 }
 
-static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, unsigned int key_len) {
+static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, unsigned int key_len)
+{
     unsigned int i, j, k, nk, nkf;
     uint32_t tmp;
     uint32_t skey[60];
@@ -341,22 +355,28 @@ static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, 
     nkf = ((nrounds + 1) << 2);
     br_range_dec32le(skey, (key_len >> 2), key);
     tmp = skey[(key_len >> 2) - 1];
-    for (i = nk, j = 0, k = 0; i < nkf; i++) {
-        if (j == 0) {
+    for (i = nk, j = 0, k = 0; i < nkf; i++)
+    {
+        if (j == 0)
+        {
             tmp = (tmp << 24) | (tmp >> 8);
             tmp = sub_word(tmp) ^ Rcon[k];
-        } else if (nk > 6 && j == 4) {
+        }
+        else if (nk > 6 && j == 4)
+        {
             tmp = sub_word(tmp);
         }
         tmp ^= skey[i - nk];
         skey[i] = tmp;
-        if (++j == nk) {
+        if (++j == nk)
+        {
             j = 0;
             k++;
         }
     }
 
-    for (i = 0, j = 0; i < nkf; i += 4, j += 2) {
+    for (i = 0, j = 0; i < nkf; i += 4, j += 2)
+    {
         uint64_t q[8];
 
         br_aes_ct64_interleave_in(&q[0], &q[4], skey + i);
@@ -374,11 +394,13 @@ static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, 
     }
 }
 
-static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, unsigned int nrounds) {
+static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, unsigned int nrounds)
+{
     unsigned u, v, n;
 
     n = (nrounds + 1) << 1;
-    for (u = 0, v = 0; u < n; u++, v += 4) {
+    for (u = 0, v = 0; u < n; u++, v += 4)
+    {
         uint64_t x0, x1, x2, x3;
 
         x0 = x1 = x2 = x3 = comp_skey[u];
@@ -396,7 +418,8 @@ static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, u
     }
 }
 
-static inline void add_round_key(uint64_t *q, const uint64_t *sk) {
+static inline void add_round_key(uint64_t *q, const uint64_t *sk)
+{
     q[0] ^= sk[0];
     q[1] ^= sk[1];
     q[2] ^= sk[2];
@@ -407,10 +430,12 @@ static inline void add_round_key(uint64_t *q, const uint64_t *sk) {
     q[7] ^= sk[7];
 }
 
-static inline void shift_rows(uint64_t *q) {
+static inline void shift_rows(uint64_t *q)
+{
     int i;
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < 8; i++)
+    {
         uint64_t x;
 
         x = q[i];
@@ -418,11 +443,13 @@ static inline void shift_rows(uint64_t *q) {
     }
 }
 
-static inline uint64_t rotr32(uint64_t x) {
+static inline uint64_t rotr32(uint64_t x)
+{
     return (x << 32) | (x >> 32);
 }
 
-static inline void mix_columns(uint64_t *q) {
+static inline void mix_columns(uint64_t *q)
+{
     uint64_t q0, q1, q2, q3, q4, q5, q6, q7;
     uint64_t r0, r1, r2, r3, r4, r5, r6, r7;
 
@@ -453,24 +480,28 @@ static inline void mix_columns(uint64_t *q) {
     q[7] = q6 ^ r6 ^ r7 ^ rotr32(q7 ^ r7);
 }
 
-static void inc4_be(uint32_t *x) {
+static void inc4_be(uint32_t *x)
+{
     uint32_t t = br_swap32(*x) + 4;
     *x = br_swap32(t);
 }
 
-static void aes_ecb4x(unsigned char out[64], const uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds) {
+static void aes_ecb4x(unsigned char out[64], const uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds)
+{
     uint32_t w[16];
     uint64_t q[8];
     unsigned int i;
 
     memcpy(w, ivw, sizeof(w));
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 4; i++)
+    {
         br_aes_ct64_interleave_in(&q[i], &q[i + 4], w + (i << 2));
     }
     br_aes_ct64_ortho(q);
 
     add_round_key(q, sk_exp);
-    for (i = 1; i < nrounds; i++) {
+    for (i = 1; i < nrounds; i++)
+    {
         br_aes_ct64_bitslice_Sbox(q);
         shift_rows(q);
         mix_columns(q);
@@ -481,13 +512,15 @@ static void aes_ecb4x(unsigned char out[64], const uint32_t ivw[16], const uint6
     add_round_key(q, sk_exp + 8 * nrounds);
 
     br_aes_ct64_ortho(q);
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 4; i++)
+    {
         br_aes_ct64_interleave_out(w + (i << 2), q[i], q[i + 4]);
     }
     br_range_enc32le(out, w, 16);
 }
 
-static void aes_ctr4x(unsigned char out[64], uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds) {
+static void aes_ctr4x(unsigned char out[64], uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds)
+{
     aes_ecb4x(out, ivw, sk_exp, nrounds);
 
     /* Increase counter for next 4 blocks */
@@ -497,11 +530,13 @@ static void aes_ctr4x(unsigned char out[64], uint32_t ivw[16], const uint64_t *s
     inc4_be(ivw + 15);
 }
 
-static void aes_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const uint64_t *rkeys, unsigned int nrounds) {
+static void aes_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const uint64_t *rkeys, unsigned int nrounds)
+{
     uint32_t blocks[16];
     unsigned char t[64];
 
-    while (nblocks >= 4) {
+    while (nblocks >= 4)
+    {
         br_range_dec32le(blocks, 16, in);
         aes_ecb4x(out, blocks, rkeys, nrounds);
         nblocks -= 4;
@@ -509,14 +544,16 @@ static void aes_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
         out += 64;
     }
 
-    if (nblocks) {
+    if (nblocks)
+    {
         br_range_dec32le(blocks, nblocks * 4, in);
         aes_ecb4x(t, blocks, rkeys, nrounds);
         memcpy(out, t, nblocks * 16);
     }
 }
 
-static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const uint64_t *rkeys, unsigned int nrounds) {
+static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const uint64_t *rkeys, unsigned int nrounds)
+{
     uint32_t ivw[16];
     size_t i;
     uint32_t cc = 0;
@@ -530,25 +567,30 @@ static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, 
     ivw[11] = br_swap32(cc + 2);
     ivw[15] = br_swap32(cc + 3);
 
-    while (outlen > 64) {
+    while (outlen > 64)
+    {
         aes_ctr4x(out, ivw, rkeys, nrounds);
         out += 64;
         outlen -= 64;
     }
-    if (outlen > 0) {
+    if (outlen > 0)
+    {
         unsigned char tmp[64];
         aes_ctr4x(tmp, ivw, rkeys, nrounds);
-        for (i = 0; i < outlen; i++) {
+        for (i = 0; i < outlen; i++)
+        {
             out[i] = tmp[i];
         }
     }
 }
 
-void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key) {
+void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key)
+{
     uint64_t skey[22];
 
     r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES128_STATESIZE);
-    if (r->sk_exp == NULL) {
+    if (r->sk_exp == NULL)
+    {
         exit(111);
     }
 
@@ -556,14 +598,17 @@ void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key) {
     br_aes_ct64_skey_expand(r->sk_exp, skey, 10);
 }
 
-void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key) {
+void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key)
+{
     aes128_ecb_keyexp(r, key);
 }
 
-void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key) {
+void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key)
+{
     uint64_t skey[26];
     r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES192_STATESIZE);
-    if (r->sk_exp == NULL) {
+    if (r->sk_exp == NULL)
+    {
         exit(111);
     }
 
@@ -571,14 +616,17 @@ void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key) {
     br_aes_ct64_skey_expand(r->sk_exp, skey, 12);
 }
 
-void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key) {
+void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key)
+{
     aes192_ecb_keyexp(r, key);
 }
 
-void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key) {
+void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key)
+{
     uint64_t skey[30];
     r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES256_STATESIZE);
-    if (r->sk_exp == NULL) {
+    if (r->sk_exp == NULL)
+    {
         exit(111);
     }
 
@@ -586,42 +634,52 @@ void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key) {
     br_aes_ct64_skey_expand(r->sk_exp, skey, 14);
 }
 
-void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key) {
+void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key)
+{
     aes256_ecb_keyexp(r, key);
 }
 
-void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx) {
+void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx)
+{
     aes_ecb(out, in, nblocks, ctx->sk_exp, 10);
 }
 
-void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes128ctx *ctx) {
+void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes128ctx *ctx)
+{
     aes_ctr(out, outlen, iv, ctx->sk_exp, 10);
 }
 
-void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx) {
+void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx)
+{
     aes_ecb(out, in, nblocks, ctx->sk_exp, 12);
 }
 
-void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes192ctx *ctx) {
+void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes192ctx *ctx)
+{
     aes_ctr(out, outlen, iv, ctx->sk_exp, 12);
 }
 
-void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx) {
+void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx)
+{
     aes_ecb(out, in, nblocks, ctx->sk_exp, 14);
 }
 
-void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes256ctx *ctx) {
+void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes256ctx *ctx)
+{
     aes_ctr(out, outlen, iv, ctx->sk_exp, 14);
 }
 
-void aes128_ctx_release(aes128ctx *r) {
+void aes128_ctx_release(aes128ctx *r)
+{
     free(r->sk_exp);
 }
 
-void aes192_ctx_release(aes192ctx *r) {
+void aes192_ctx_release(aes192ctx *r)
+{
     free(r->sk_exp);
 }
 
-void aes256_ctx_release(aes256ctx *r) {
+void aes256_ctx_release(aes256ctx *r)
+{
     free(r->sk_exp);
 }

--- a/test/nistrng/aes.h
+++ b/test/nistrng/aes.h
@@ -14,17 +14,20 @@
 
 // We've put these states on the heap to make sure ctx_release is used.
 #define PQC_AES128_STATESIZE 88
-typedef struct {
+typedef struct
+{
     uint64_t *sk_exp;
 } aes128ctx;
 
 #define PQC_AES192_STATESIZE 104
-typedef struct {
+typedef struct
+{
     uint64_t  *sk_exp;
 } aes192ctx;
 
 #define PQC_AES256_STATESIZE 120
-typedef struct {
+typedef struct
+{
     uint64_t *sk_exp;
 } aes256ctx;
 

--- a/test/nistrng/rng.c
+++ b/test/nistrng/rng.c
@@ -7,25 +7,30 @@
 #include "aes.h"
 #include "randombytes.h"
 
-typedef struct {
+typedef struct
+{
     unsigned char key[AES256_KEYBYTES];
     unsigned char ctr[AES_BLOCKBYTES];
 } nistkatctx;
 
 static nistkatctx ctx;
 
-static void _aes256_ecb(unsigned char key[AES256_KEYBYTES], unsigned char ctr[AES_BLOCKBYTES], unsigned char buffer[AES_BLOCKBYTES]) {
+static void _aes256_ecb(unsigned char key[AES256_KEYBYTES], unsigned char ctr[AES_BLOCKBYTES], unsigned char buffer[AES_BLOCKBYTES])
+{
     aes256ctx aesctx;
     aes256_ecb_keyexp(&aesctx, key);
     aes256_ecb(buffer, ctr, 1, &aesctx);
     aes256_ctx_release(&aesctx);
 }
 
-static void aes256_block_update(uint8_t block[AES_BLOCKBYTES]) {
-    for (int j = AES_BLOCKBYTES - 1; j >= 0; j--) {
+static void aes256_block_update(uint8_t block[AES_BLOCKBYTES])
+{
+    for (int j = AES_BLOCKBYTES - 1; j >= 0; j--)
+    {
         ctx.ctr[j]++;
 
-        if (ctx.ctr[j] != 0x00) {
+        if (ctx.ctr[j] != 0x00)
+        {
             break;
         }
     }
@@ -33,16 +38,20 @@ static void aes256_block_update(uint8_t block[AES_BLOCKBYTES]) {
     _aes256_ecb(ctx.key, ctx.ctr, block);
 }
 
-static void nistkat_update(const unsigned char *provided_data, unsigned char *key, unsigned char *ctr) {
+static void nistkat_update(const unsigned char *provided_data, unsigned char *key, unsigned char *ctr)
+{
     int len = AES256_KEYBYTES + AES_BLOCKBYTES;
     uint8_t tmp[len];
 
-    for (int i = 0; i < len / AES_BLOCKBYTES; i++) {
+    for (int i = 0; i < len / AES_BLOCKBYTES; i++)
+    {
         aes256_block_update(tmp + AES_BLOCKBYTES * i);
     }
 
-    if (provided_data) {
-        for (int i = 0; i < len; i++) {
+    if (provided_data)
+    {
+        for (int i = 0; i < len; i++)
+        {
             tmp[i] ^= provided_data[i];
         }
     }
@@ -51,14 +60,17 @@ static void nistkat_update(const unsigned char *provided_data, unsigned char *ke
     memcpy(ctr, tmp + AES256_KEYBYTES, AES_BLOCKBYTES);
 }
 
-void nist_kat_init(unsigned char entropy_input[AES256_KEYBYTES + AES_BLOCKBYTES], const unsigned char personalization_string[AES256_KEYBYTES + AES_BLOCKBYTES], int security_strength) {
+void nist_kat_init(unsigned char entropy_input[AES256_KEYBYTES + AES_BLOCKBYTES], const unsigned char personalization_string[AES256_KEYBYTES + AES_BLOCKBYTES], int security_strength)
+{
     int len = AES256_KEYBYTES + AES_BLOCKBYTES;
     uint8_t seed_material[len];
     (void) security_strength;
 
     memcpy(seed_material, entropy_input, len);
-    if (personalization_string) {
-        for (int i = 0; i < len; i++) {
+    if (personalization_string)
+    {
+        for (int i = 0; i < len; i++)
+        {
             seed_material[i] ^= personalization_string[i];
         }
     }
@@ -67,18 +79,21 @@ void nist_kat_init(unsigned char entropy_input[AES256_KEYBYTES + AES_BLOCKBYTES]
     nistkat_update(seed_material, ctx.key, ctx.ctr);
 }
 
-void randombytes(uint8_t *buf, size_t n) {
+void randombytes(uint8_t *buf, size_t n)
+{
     uint8_t block[AES_BLOCKBYTES];
 
     size_t nb = n / AES_BLOCKBYTES;
     size_t tail = n % AES_BLOCKBYTES;
 
-    for (size_t i = 0; i < nb; i++) {
+    for (size_t i = 0; i < nb; i++)
+    {
         aes256_block_update(block);
         memcpy(buf + i * AES_BLOCKBYTES, block, AES_BLOCKBYTES);
     }
 
-    if (tail > 0) {
+    if (tail > 0)
+    {
         aes256_block_update(block);
         memcpy(buf + nb * AES_BLOCKBYTES, block, tail);
     }

--- a/test/test_kyber.c
+++ b/test/test_kyber.c
@@ -7,7 +7,8 @@
 
 #define NTESTS 1000
 
-static int test_keys(void) {
+static int test_keys(void)
+{
     uint8_t pk[CRYPTO_PUBLICKEYBYTES];
     uint8_t sk[CRYPTO_SECRETKEYBYTES];
     uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
@@ -23,7 +24,8 @@ static int test_keys(void) {
     //Alice uses Bobs response to get her shared key
     crypto_kem_dec(key_a, ct, sk);
 
-    if (memcmp(key_a, key_b, CRYPTO_BYTES)) {
+    if (memcmp(key_a, key_b, CRYPTO_BYTES))
+    {
         printf("ERROR keys\n");
         return 1;
     }
@@ -31,7 +33,8 @@ static int test_keys(void) {
     return 0;
 }
 
-static int test_invalid_sk_a(void) {
+static int test_invalid_sk_a(void)
+{
     uint8_t pk[CRYPTO_PUBLICKEYBYTES];
     uint8_t sk[CRYPTO_SECRETKEYBYTES];
     uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
@@ -50,7 +53,8 @@ static int test_invalid_sk_a(void) {
     //Alice uses Bobs response to get her shared key
     crypto_kem_dec(key_a, ct, sk);
 
-    if (!memcmp(key_a, key_b, CRYPTO_BYTES)) {
+    if (!memcmp(key_a, key_b, CRYPTO_BYTES))
+    {
         printf("ERROR invalid sk\n");
         return 1;
     }
@@ -58,7 +62,8 @@ static int test_invalid_sk_a(void) {
     return 0;
 }
 
-static int test_invalid_ciphertext(void) {
+static int test_invalid_ciphertext(void)
+{
     uint8_t pk[CRYPTO_PUBLICKEYBYTES];
     uint8_t sk[CRYPTO_SECRETKEYBYTES];
     uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
@@ -67,9 +72,11 @@ static int test_invalid_ciphertext(void) {
     uint8_t b;
     size_t pos;
 
-    do {
+    do
+    {
         randombytes(&b, sizeof(uint8_t));
-    } while (!b);
+    }
+    while (!b);
     randombytes((uint8_t *)&pos, sizeof(size_t));
 
     //Alice generates a public key
@@ -84,7 +91,8 @@ static int test_invalid_ciphertext(void) {
     //Alice uses Bobs response to get her shared key
     crypto_kem_dec(key_a, ct, sk);
 
-    if (!memcmp(key_a, key_b, CRYPTO_BYTES)) {
+    if (!memcmp(key_a, key_b, CRYPTO_BYTES))
+    {
         printf("ERROR invalid ciphertext\n");
         return 1;
     }
@@ -92,15 +100,18 @@ static int test_invalid_ciphertext(void) {
     return 0;
 }
 
-int main(void) {
+int main(void)
+{
     unsigned int i;
     int r;
 
-    for (i = 0; i < NTESTS; i++) {
+    for (i = 0; i < NTESTS; i++)
+    {
         r  = test_keys();
         r |= test_invalid_sk_a();
         r |= test_invalid_ciphertext();
-        if (r) {
+        if (r)
+        {
             return 1;
         }
     }


### PR DESCRIPTION
This PR closes Issue #59

.astylerc changed to use "bsd" style for braces to ease editing of CBMC contracts, and removes the "--pad-oper" option which breaks CBMC's special "==>" operator.

All .c and .h files reformatted as above and committed as one.
