### PR TITLE
Disable unknown pragma warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INCLUDE_MLKEM = -I mlkem
 INCLUDE_RANDOM = -I randombytes
 INCLUDE_NISTRANDOM = -I test/nistrng
 CFLAGS += -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls \
-  -Wshadow -Wpointer-arith -O3 -fomit-frame-pointer -pedantic -Wno-unknown-pragmas \
+  -Wshadow -Wpointer-arith -Wno-unknown-pragmas -O3 -fomit-frame-pointer -pedantic \
    ${INCLUDE_MLKEM} ${INCLUDE_FIPS202}
 
 HOST_PLATFORM := $(shell uname -s)-$(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INCLUDE_MLKEM = -I mlkem
 INCLUDE_RANDOM = -I randombytes
 INCLUDE_NISTRANDOM = -I test/nistrng
 CFLAGS += -Wall -Wextra -Wpedantic -Wmissing-prototypes -Wredundant-decls \
-  -Wshadow -Wpointer-arith -O3 -fomit-frame-pointer -pedantic \
+  -Wshadow -Wpointer-arith -O3 -fomit-frame-pointer -pedantic -Wno-unknown-pragmas \
    ${INCLUDE_MLKEM} ${INCLUDE_FIPS202}
 
 HOST_PLATFORM := $(shell uname -s)-$(shell uname -m)


### PR DESCRIPTION
Signed-off-by: Duc Tri Nguyen <dnguye69@gmu.edu>

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

The pragma warnings are for CBMC, so for normal usage, it is not neccsary to show. 

Before: 

```
(nix:nix-shell-env) cothans-air:mlkem-c-aarch64 cothan$ scripts/tests kat
INFO  > Kat test
INFO  > make test/bin/gen_KAT512
mlkem/poly.c:28:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check push
        ^
mlkem/poly.c:29:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check disable "unsigned-overflow"
        ^
mlkem/poly.c:31:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check pop
        ^
mlkem/poly.c:67:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check push
        ^
mlkem/poly.c:68:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check disable "unsigned-overflow"
        ^
mlkem/poly.c:70:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check pop
        ^
6 warnings generated.
INFO  > MLKEM512 passed
INFO  > make test/bin/gen_KAT768
mlkem/poly.c:28:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check push
        ^
mlkem/poly.c:29:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check disable "unsigned-overflow"
        ^
mlkem/poly.c:31:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check pop
        ^
mlkem/poly.c:67:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check push
        ^
mlkem/poly.c:68:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check disable "unsigned-overflow"
        ^
mlkem/poly.c:70:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check pop
        ^
6 warnings generated.
INFO  > MLKEM768 passed
INFO  > make test/bin/gen_KAT1024
mlkem/poly.c:28:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check push
        ^
mlkem/poly.c:29:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check disable "unsigned-overflow"
        ^
mlkem/poly.c:31:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check pop
        ^
mlkem/poly.c:67:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check push
        ^
mlkem/poly.c:68:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check disable "unsigned-overflow"
        ^
mlkem/poly.c:70:9: warning: unknown pragma ignored [-Wunknown-pragmas]
#pragma CPROVER check pop
        ^
```

After 

```
(nix:nix-shell-env) cothans-air:mlkem-c-aarch64 cothan$ scripts/tests kat
INFO  > Kat test
INFO  > make test/bin/gen_KAT512
INFO  > MLKEM512 passed
INFO  > make test/bin/gen_KAT768
INFO  > MLKEM768 passed
INFO  > make test/bin/gen_KAT1024
INFO  > MLKEM1024 passed
(nix:nix-shell-env) cothans-air:mlkem-c-aarch64 cothan$ scripts/tests nistkat
INFO  > Nistkat test
INFO  > make test/bin/gen_NISTKAT512
INFO  > MLKEM512 passed
INFO  > make test/bin/gen_NISTKAT768
INFO  > MLKEM768 passed
INFO  > make test/bin/gen_NISTKAT1024
INFO  > MLKEM1024 passed
```


<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
