### PR TITLE
Fix the trigger of bench workflow for PR

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+    types: [ "labeled" ]
 jobs:
   bench:
     runs-on: self-hosted-rpi4


### PR DESCRIPTION
[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->
This should fix the issue of triggering the `bench` workflow for a PR when the `benchmark` label is set, which is what @hanno-becker discovered at https://github.com/pq-code-package/mlkem-c-aarch64/pull/71#issuecomment-2180377139
<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
