### PR TITLE
Add M1 benchmarking code

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -57,6 +57,10 @@ ifeq ($(CYCLES),PERF)
 	CFLAGS += -DPERF_CYCLES
 endif
 
+ifeq ($(CYCLES),M1)
+	CFLAGS += -DM1_CYCLES
+endif
+
 ##############################
 # Include retained variables #
 ##############################

--- a/scripts/tests
+++ b/scripts/tests
@@ -395,7 +395,7 @@ def kat(force_qemu, verbose, cflags, arch_flags):
     type=click.Choice(["utility", "background", "maintenance"]),
     show_default=True,
     default=None,
-    help="Run the program using the specified QoS clamp. Applies to MacOS only. Setting it to 'background' guarentees to run on E-cores.",
+    help="Run the program using the specified QoS clamp. Applies to MacOS only. Setting this flag to 'background' guarantees running on E-cores.",
 )
 def bench(
     force_qemu, verbose, cycles, cflags, arch_flags, output, run_as_root, mac_taskpolicy

--- a/scripts/tests
+++ b/scripts/tests
@@ -25,7 +25,9 @@ def sha256sum(result):
     return m.hexdigest()
 
 
-def base_run(bin, force_qemu, verbose, extra_make_envs={}, extra_make_args=[]):
+def base_run(
+    bin, force_qemu, verbose, run_as_root=False, extra_make_envs={}, extra_make_args=[]
+):
     def dict2str(dict):
         s = ""
         for k, v in dict.items():
@@ -81,7 +83,7 @@ def base_run(bin, force_qemu, verbose, extra_make_envs={}, extra_make_args=[]):
             sys.exit(1)
 
         result = subprocess.run(
-            [f"./{bin}"],
+            (["sudo"] if run_as_root else []) + [f"./{bin}"],
             capture_output=True,
             universal_newlines=False,
         )
@@ -130,6 +132,7 @@ def test_schemes(
     process_result,
     force_qemu,
     verbose,
+    run_as_root=False,
     extra_make_envs={},
     extra_make_args=[],
 ):
@@ -145,7 +148,9 @@ def test_schemes(
     results = {}
     for scheme in SCHEME:
         bin = scheme2file(scheme)
-        result = base_run(bin, force_qemu, verbose, extra_make_envs, extra_make_args)
+        result = base_run(
+            bin, force_qemu, verbose, run_as_root, extra_make_envs, extra_make_args
+        )
         results[scheme] = result
 
         actual = actual_proc(result)
@@ -340,10 +345,10 @@ def kat(force_qemu, verbose, cflags, arch_flags):
     "-c",
     "--cycles",
     nargs=1,
-    type=click.Choice(["NO", "PMU", "PERF"]),
+    type=click.Choice(["NO", "PMU", "PERF", "M1"]),
     show_default=True,
     default="NO",
-    help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support.",
+    help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. M1 only works on Apple silcon.",
 )
 @click.option(
     "-o",
@@ -351,8 +356,20 @@ def kat(force_qemu, verbose, cflags, arch_flags):
     nargs=1,
     help="Path to output file in json format",
 )
-def bench(force_qemu, verbose, cycles, cflags, arch_flags, output):
+@click.option(
+    "-r",
+    "--run-as-root",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    type=bool,
+    help="Benchmarking binary is run with sudo.",
+)
+def bench(force_qemu, verbose, cycles, cflags, arch_flags, output, run_as_root):
     config_logger(verbose)
+
+    if cycles == "M1":
+        run_as_root = True
 
     results = test_schemes(
         "benchmark",
@@ -362,6 +379,7 @@ def bench(force_qemu, verbose, cycles, cflags, arch_flags, output):
         process_bench,
         force_qemu,
         verbose,
+        run_as_root,
         process_make_envs(cflags, arch_flags),
         [f"CYCLES={cycles}"],
     )

--- a/scripts/tests
+++ b/scripts/tests
@@ -348,7 +348,7 @@ def kat(force_qemu, verbose, cflags, arch_flags):
     type=click.Choice(["NO", "PMU", "PERF", "M1"]),
     show_default=True,
     default="NO",
-    help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. M1 only works on Apple silcon.",
+    help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. M1 only works on Apple silicon.",
 )
 @click.option(
     "-o",

--- a/scripts/tests
+++ b/scripts/tests
@@ -26,7 +26,13 @@ def sha256sum(result):
 
 
 def base_run(
-    bin, force_qemu, verbose, run_as_root=False, extra_make_envs={}, extra_make_args=[]
+    bin,
+    force_qemu,
+    verbose,
+    run_as_root=False,
+    mac_taskpolicy=None,
+    extra_make_envs={},
+    extra_make_args=[],
 ):
     def dict2str(dict):
         s = ""
@@ -89,6 +95,9 @@ def base_run(
             )
             cmd = ["sudo"] + cmd
 
+        if mac_taskpolicy is not None:
+            cmd = ["taskpolicy", "-c", mac_taskpolicy] + cmd
+
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -140,6 +149,7 @@ def test_schemes(
     force_qemu,
     verbose,
     run_as_root=False,
+    mac_taskpolicy=None,
     extra_make_envs={},
     extra_make_args=[],
 ):
@@ -156,7 +166,13 @@ def test_schemes(
     for scheme in SCHEME:
         bin = scheme2file(scheme)
         result = base_run(
-            bin, force_qemu, verbose, run_as_root, extra_make_envs, extra_make_args
+            bin,
+            force_qemu,
+            verbose,
+            run_as_root,
+            mac_taskpolicy,
+            extra_make_envs,
+            extra_make_args,
         )
         results[scheme] = result
 
@@ -372,7 +388,18 @@ def kat(force_qemu, verbose, cflags, arch_flags):
     type=bool,
     help="Benchmarking binary is run with sudo.",
 )
-def bench(force_qemu, verbose, cycles, cflags, arch_flags, output, run_as_root):
+@click.option(
+    "-t",
+    "--mac-taskpolicy",
+    nargs=1,
+    type=click.Choice(["utility", "background", "maintenance"]),
+    show_default=True,
+    default=None,
+    help="Run the program using the specified QoS clamp. Applies to MacOS only. Setting it to 'background' guarentees to run on E-cores.",
+)
+def bench(
+    force_qemu, verbose, cycles, cflags, arch_flags, output, run_as_root, mac_taskpolicy
+):
     config_logger(verbose)
 
     results = test_schemes(
@@ -384,6 +411,7 @@ def bench(force_qemu, verbose, cycles, cflags, arch_flags, output, run_as_root):
         force_qemu,
         verbose,
         run_as_root,
+        mac_taskpolicy,
         process_make_envs(cflags, arch_flags),
         [f"CYCLES={cycles}"],
     )

--- a/scripts/tests
+++ b/scripts/tests
@@ -82,8 +82,15 @@ def base_run(
             logging.error(f"make failed: {p.returncode}")
             sys.exit(1)
 
+        cmd = [f"./{bin}"]
+        if run_as_root:
+            logging.info(
+                "Running benchmarks as root -- you may need to enter your root password."
+            )
+            cmd = ["sudo"] + cmd
+
         result = subprocess.run(
-            (["sudo"] if run_as_root else []) + [f"./{bin}"],
+            cmd,
             capture_output=True,
             universal_newlines=False,
         )
@@ -367,9 +374,6 @@ def kat(force_qemu, verbose, cflags, arch_flags):
 )
 def bench(force_qemu, verbose, cycles, cflags, arch_flags, output, run_as_root):
     config_logger(verbose)
-
-    if cycles == "M1":
-        run_as_root = True
 
     results = test_schemes(
         "benchmark",

--- a/test/hal.c
+++ b/test/hal.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022 Arm Limited
+ * Copyright (c) 2020 Dougall Johnson
  * SPDX-License-Identifier: MIT
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -111,6 +112,149 @@ uint64_t get_cyclecounter(void)
     }
     ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
     return cpu_cycles;
+}
+#elif defined(M1_CYCLES)
+// based on https://gist.github.com/dougallj/5bafb113492047c865c0c8cfbc930155#file-m1_robsize-c-L390
+
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define KPERF_LIST                               \
+    /*  ret, name, params */                     \
+    F(int, kpc_get_counting, void)               \
+    F(int, kpc_force_all_ctrs_set, int)          \
+    F(int, kpc_set_counting, uint32_t)           \
+    F(int, kpc_set_thread_counting, uint32_t)    \
+    F(int, kpc_set_config, uint32_t, void *)     \
+    F(int, kpc_get_config, uint32_t, void *)     \
+    F(int, kpc_set_period, uint32_t, void *)     \
+    F(int, kpc_get_period, uint32_t, void *)     \
+    F(uint32_t, kpc_get_counter_count, uint32_t) \
+    F(uint32_t, kpc_get_config_count, uint32_t)  \
+    F(int, kperf_sample_get, int *)              \
+    F(int, kpc_get_thread_counters, int, unsigned int, void *)
+
+#define F(ret, name, ...)                \
+    typedef ret name##proc(__VA_ARGS__); \
+    static name##proc *name;
+KPERF_LIST
+#undef F
+
+#define CFGWORD_EL0A32EN_MASK (0x10000)
+#define CFGWORD_EL0A64EN_MASK (0x20000)
+#define CFGWORD_EL1EN_MASK (0x40000)
+#define CFGWORD_EL3EN_MASK (0x80000)
+#define CFGWORD_ALLMODES_MASK (0xf0000)
+
+#define CPMU_NONE 0
+#define CPMU_CORE_CYCLE 0x02
+#define CPMU_INST_A64 0x8c
+#define CPMU_INST_BRANCH 0x8d
+#define CPMU_SYNC_DC_LOAD_MISS 0xbf
+#define CPMU_SYNC_DC_STORE_MISS 0xc0
+#define CPMU_SYNC_DTLB_MISS 0xc1
+#define CPMU_SYNC_ST_HIT_YNGR_LD 0xc4
+#define CPMU_SYNC_BR_ANY_MISP 0xcb
+#define CPMU_FED_IC_MISS_DEM 0xd3
+#define CPMU_FED_ITLB_MISS 0xd4
+
+#define KPC_CLASS_FIXED (0)
+#define KPC_CLASS_CONFIGURABLE (1)
+#define KPC_CLASS_POWER (2)
+#define KPC_CLASS_RAWPMU (3)
+#define KPC_CLASS_FIXED_MASK (1u << KPC_CLASS_FIXED)
+#define KPC_CLASS_CONFIGURABLE_MASK (1u << KPC_CLASS_CONFIGURABLE)
+#define KPC_CLASS_POWER_MASK (1u << KPC_CLASS_POWER)
+#define KPC_CLASS_RAWPMU_MASK (1u << KPC_CLASS_RAWPMU)
+
+#define COUNTERS_COUNT 10
+#define CONFIG_COUNT 8
+#define KPC_MASK (KPC_CLASS_CONFIGURABLE_MASK | KPC_CLASS_FIXED_MASK)
+uint64_t g_counters[COUNTERS_COUNT];
+uint64_t g_config[COUNTERS_COUNT];
+
+
+static void configure_rdtsc(void)
+{
+    if (kpc_force_all_ctrs_set(1))
+    {
+        printf("kpc_force_all_ctrs_set failed\n");
+        return;
+    }
+
+    if (kpc_set_counting(KPC_MASK))
+    {
+        printf("kpc_set_counting failed\n");
+        return;
+    }
+
+    if (kpc_set_thread_counting(KPC_MASK))
+    {
+        printf("kpc_set_thread_counting failed\n");
+        return;
+    }
+
+    if (kpc_set_config(KPC_MASK, g_config))
+    {
+        printf("kpc_set_config failed\n");
+        return;
+    }
+}
+
+static void init_rdtsc(void)
+{
+    void *kperf = dlopen(
+                      "/System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf",
+                      RTLD_LAZY);
+    if (!kperf)
+    {
+        printf("kperf = %p\n", kperf);
+        return;
+    }
+#define F(ret, name, ...)                         \
+    name = (name##proc *)(dlsym(kperf, #name));   \
+    if (!name)                                    \
+    {                                             \
+        printf("%s = %p\n", #name, (void *)name); \
+        return;                                   \
+    }
+    KPERF_LIST
+#undef F
+
+    g_config[0] = CPMU_CORE_CYCLE | CFGWORD_EL0A64EN_MASK;
+}
+
+void enable_cyclecounter(void)
+{
+    int test_high_perf_cores = 1;
+
+    if (test_high_perf_cores)
+    {
+        pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+    }
+    else
+    {
+        pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
+    }
+    init_rdtsc();
+    configure_rdtsc();
+}
+
+void disable_cyclecounter(void)
+{
+    return;
+}
+
+uint64_t get_cyclecounter(void)
+{
+    if (kpc_get_thread_counters(0, COUNTERS_COUNT, g_counters))
+    {
+        printf("kpc_get_thread_counters failed\n");
+        return 1;
+    }
+    return g_counters[2];
 }
 
 #else


### PR DESCRIPTION
This adds M1 benchmarking code based on based on https://gist.github.com/dougallj/5bafb113492047c865c0c8cfbc930155. 

~@potsrevennil @hanno-becker, please test this on your M1 devices. Can you also each run it maybe 3 times and post the results here , so we can make sure we are getting stable results?~ 
Results seem stable accross 4 different M1 devices (MacMini and various MacBook). 

To run on the P-cores (Firestorm), run 
```
tests bench -c M1 --run-as-root   
```

To run on the E-cores (Icestorm), run 
```
tests bench -c M1 --run-as-root --mac-taskpolicy background
```

Internally this runs:
```
taskpolicy -c background sudo ./test/bin/bench_kyberXXX
```

Currently this requires to be run as the `root` user, so I added a flag `--run-as-root` to the benchmarking script, but this may require the user to enter a password. If anyone knows a way to use performance counters on Apple Silicon without using `sudo`, please do let me know. 

I'd like to point out that this code has caused me significant pain. 
The original code contains two calls to `configure_rdtsc()` right after each other. I thought this must be a mistake and naively removed one of the calls. This resulted in the code working fine on a M1 MacMini, but reporting wrong numbers (like 0/1/2/3/4 cycles rather than serveral 10ks) on mulitple different MacBooks we have tried.
After some trial-and-error, we found out that the calls within  `configure_rdtsc()` seem to be in the wrong order resulting in some of them being ineffective on the first invocation (on some devices). 
This is fixed by reordering
`kpc_set_config`, `kpc_force_all_ctrs_set`, `kpc_set_counting`, `kpc_set_thread_counting`
to 
`kpc_force_all_ctrs_set`, `kpc_set_counting`, `kpc_set_thread_counting`, `kpc_set_config`.
Thanks @hanno-becker for helping me with that!

Then it should work with a single call to `configure_rdtsc`.