### PR TITLE
Add support for static linking of glibc on aarch64 and x86_64 linux 

### DIFF
--- a/arm-gnu-gcc.nix
+++ b/arm-gnu-gcc.nix
@@ -8,19 +8,13 @@ stdenvNoCC.mkDerivation rec {
   pname = "gcc-arm";
   version = "13.2.rel1";
 
-  platform = {
-    x86_64-linux = "x86_64";
-  }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+  platform = "x86_64";
 
-  platform_suffix = {
-    x86_64-linux = "linux-gnu";
-  }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+  platform_suffix = "linux-gnu";
 
   src = fetchurl {
     url = "https://developer.arm.com/-/media/Files/downloads/gnu/${version}/binrel/arm-gnu-toolchain-${version}-${platform}-aarch64-none-${platform_suffix}.tar.xz";
-    sha256 = {
-      x86_64-linux = "sha256-EvzfE6dDBlUimyBDiknoVm4mVRugh1mSLNr0aVsNTiM=";
-    }.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+    sha256 = "sha256-EvzfE6dDBlUimyBDiknoVm4mVRugh1mSLNr0aVsNTiM=";
   };
 
   dontConfigure = true;
@@ -32,4 +26,10 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out
     cp -r * $out
   '';
+
+  meta = {
+    description = "Pre-built cross-compiled aarch64 gcc for x86_64 linux";
+    homepage = "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads";
+    platforms = [ "x86_64-linux" ];
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
               aarch64-gcc =
                 if pkgs.stdenv.isx86_64
                 then [ cross-gcc ]
-                else [ pkgs.glibc pkgs.glibc.static ]; # I assume this is used in `mkShell`, therefore for aarch64 platforms gcc is already available in PATH
+                else [ (pkgs.gcc13.override { propagateDoc = true; isGNU = true; }) pkgs.glibc pkgs.glibc.static ];
             in
             pkgs.lib.optionals pkgs.stdenv.isLinux aarch64-gcc ++
             builtins.attrValues {
@@ -86,7 +86,7 @@
             });
         in
         {
-          devShells.default = wrapShell pkgs.mkShell {
+          devShells.default = wrapShell pkgs.mkShellNoCC {
             packages = core ++ linters ++ cbmcpkg ++
               builtins.attrValues {
                 inherit (pkgs)
@@ -95,8 +95,8 @@
               };
           };
 
-          devShells.ci = wrapShell pkgs.mkShell { packages = core; };
-          devShells.ci-cbmc = wrapShell pkgs.mkShell { packages = (core ++ cbmcpkg); };
+          devShells.ci = wrapShell pkgs.mkShellNoCC { packages = core; };
+          devShells.ci-cbmc = wrapShell pkgs.mkShellNoCC { packages = (core ++ cbmcpkg); };
           devShells.ci-linter = wrapShell pkgs.mkShellNoCC { packages = linters; };
         };
       flake = {

--- a/flake.nix
+++ b/flake.nix
@@ -16,36 +16,32 @@
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [ ];
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
-      perSystem = { pkgs, system, ... }:
+      perSystem = { pkgs, ... }:
         let
-          litani = pkgs.callPackage ./litani.nix { };
-          cbmc-viewer = pkgs.callPackage ./cbmc-viewer.nix { };
-          astyle = pkgs.astyle.overrideAttrs (old: rec {
-            version = "3.4.13";
-            src = pkgs.fetchurl {
-              url = "mirror://sourceforge/${old.pname}/${old.pname}-${version}.tar.bz2";
-              hash = "sha256-eKYQq9OelOD5E+nuXNoehbtizWM1U97LngDT2SAQGc4=";
-            };
-          });
-          cbmc = pkgs.cbmc.overrideAttrs (old: rec {
-            version = "a8b8f0fd2ad2166d71ccce97dd6925198a018144";
-            src = pkgs.fetchFromGitHub {
-              owner = "diffblue";
-              repo = old.pname;
-              rev = "${version}";
-              hash = "sha256-mPRkkKN7Hz9Qi6a3fEwVFh7a9OaBFcksNw9qwNOarao=";
-            };
-          });
-
           cbmcpkg = builtins.attrValues
             {
-              cbmc = cbmc;
-              litani = litani; # 1.29.0
-              cbmc-viewer = cbmc-viewer; # 3.8
+              cbmc = pkgs.cbmc.overrideAttrs (old: rec {
+                version = "a8b8f0fd2ad2166d71ccce97dd6925198a018144";
+                src = pkgs.fetchFromGitHub {
+                  owner = "diffblue";
+                  repo = old.pname;
+                  rev = "${version}";
+                  hash = "sha256-mPRkkKN7Hz9Qi6a3fEwVFh7a9OaBFcksNw9qwNOarao=";
+                };
+              }); # 6.0.0
+              litani = pkgs.callPackage ./litani.nix { }; # 1.29.0
+              cbmc-viewer = pkgs.callPackage ./cbmc-viewer.nix { }; # 3.8
             };
 
           linters = builtins.attrValues {
-            astyle = astyle;
+            astyle = pkgs.astyle.overrideAttrs (old: rec {
+              version = "3.4.13";
+              src = pkgs.fetchurl {
+                url = "mirror://sourceforge/${old.pname}/${old.pname}-${version}.tar.bz2";
+                hash = "sha256-eKYQq9OelOD5E+nuXNoehbtizWM1U97LngDT2SAQGc4=";
+              };
+            });
+
 
             inherit (pkgs)
               nixpkgs-fmt

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,6 @@
               };
             });
 
-
             inherit (pkgs)
               nixpkgs-fmt
               shfmt;
@@ -99,8 +98,6 @@
           devShells.ci = wrapShell pkgs.mkShell { packages = core; };
           devShells.ci-cbmc = wrapShell pkgs.mkShell { packages = (core ++ cbmcpkg); };
           devShells.ci-linter = wrapShell pkgs.mkShellNoCC { packages = linters; };
-
-
         };
       flake = {
         # The usual flake attributes can be defined here, including system-

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
               aarch64-gcc =
                 if pkgs.stdenv.isx86_64
                 then [ cross-gcc ]
-                else [ pkgs.glibc.static ]; # I assume this is used in `mkShell`, therefore for aarch64 platforms gcc is already available in PATH
+                else [ pkgs.glibc pkgs.glibc.static ]; # I assume this is used in `mkShell`, therefore for aarch64 platforms gcc is already available in PATH
             in
             pkgs.lib.optionals pkgs.stdenv.isLinux aarch64-gcc ++
             builtins.attrValues {


### PR DESCRIPTION
[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->
In the `nix` shell, we specify that `gcc` is downloaded from arm gnu official website for `x86_64` linux, and use the nixpkgs `gcc` for `aarch64` linux. 

However glibc only comes as a dynamic library in both cases, making compiling with `-static` result in error: 
```
ld: cannot find -lc: No such file or directory
```

Now I added glibc static library as a dependency, and configured it into one of the gcc default search path. Additional context, some package manager like `pacman` in `archlinux` packed the gcc with glibc, so that compilation with `-static` works automatically in this case.

@hanno-becker @mkannwischer Please have a look and see if the static compilation works, and the original usage won't break. The static compilation can be tested such as:
```
CFLAGS="-mcpu=cortex-a55 -march=armv8.2-a -static" make bench CYCLES=PERF # aarch64
CFLAGS="-mcpu=cortex-a55 -march=armv8.2-a -static" CROSS_PREFIX=aarch64-none-linux-gnu- make bench CYCLES=PERF # x86_64
```

I've also cleanup the nix file a bit, hope that it can be more readable and easier to maintain.
<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
