### PR TITLE
Add z3_4_12 to standard NIX config for all platforms.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
                 yq
                 ninja# 1.11.1
                 qemu# 8.2.4
+                z3_4_12
                 cadical;
 
               inherit (pkgs.python3Packages)


### PR DESCRIPTION
Adds Z3_4_12 to standard NIX config, ensuring that "cbmc --smt2" will work on all platforms and CI runners.