### PR TITLE
Benchmarking on Cortex-A76 (Raspberry Pi 5)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,6 +17,9 @@ jobs:
         - system: rpi4
           name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
           cmd: tests bench -c PMU --cflags -mcpu=cortex-a72 -v --output output.json
+        - system: rpi5
+          name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
+          cmd: tests bench -c PERF --cflags -mcpu=cortex-a76 --arch-flags -march=armv8.2-a -v --output output.json
         - system: a55
           name: Arm Cortex-A55 (Snapdragon 888) benchmarks
           cmd: tests bench -c PERF --cflags "-static -mcpu=cortex-a55" --arch-flags -march=armv8.2-a -w exec-on-a55 -v --output output.json


### PR DESCRIPTION
Depends on #84

We recently bought a Raspberry Pi 5 which comes with a Arm Cortex-A76 (BCM2712).
I've setup up a self-hosted Github runner on it today. 
This PR adds it to the benchmarking. I'm using perf on this platform as I could not yet get a kernel module to compile on this version of Raspberry Pi OS.
This should also automatically create a new section on https://pq-code-package.github.io/mlkem-c-aarch64/dev/bench/ once it is merged.