### PR TITLE
Update to cbmc-viewer version 3.9

### DIFF
--- a/cbmc/cbmc-viewer.nix
+++ b/cbmc/cbmc-viewer.nix
@@ -5,10 +5,10 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "cbmc-viewer";
-  version = "3.8";
+  version = "3.9";
   src = fetchurl {
     url = "https://github.com/model-checking/${pname}/releases/download/viewer-${version}/cbmc_viewer-${version}-py3-none-any.whl";
-    hash = "sha256-a73odd7mt8uB7qq7yPt/IZNZe/WFvRQDOX8JuHobihQ=";
+    hash = "sha256-lf5wXmoqV9Qm6Iq7+vS4L9ECSq6p6OnVGJGnfFA429Q=";
   };
   format = "wheel";
   dontUseSetuptoolsCheck = true;

--- a/cbmc/default.nix
+++ b/cbmc/default.nix
@@ -18,7 +18,7 @@ builtins.attrValues {
     ];
   });
   litani = callPackage ./litani.nix { }; # 1.29.0
-  cbmc-viewer = callPackage ./cbmc-viewer.nix { }; # 3.8
+  cbmc-viewer = callPackage ./cbmc-viewer.nix { }; # 3.9
 
   inherit
     z3_4_12; # 4.12.5


### PR DESCRIPTION
For compatibility with CBMC 6.1.1 and above, we should upgrade to cbmc-viewer 3.9

This PR updates the version number and hash for this in the NIX flake.
