### PR TITLE
Clear nix-installer cache prior to EC2 benchmarks

### DIFF
--- a/.github/actions/clear-cache/action.yml
+++ b/.github/actions/clear-cache/action.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Clear GitHub cache entries
+description: Removes entries from GitHub cache by key
+
+inputs:
+  key_prefix:
+    description: Fixed prefix of ID of Github cache entries that should be removed.
+    required: true
+  repository:
+    description: Name of the repository
+    required: true
+  gh_token:
+    description: Github access token to use
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: List and remove cache entries
+      shell: bash
+      run: |
+        cache_keys=$(gh cache list -R ${{ env.REPO }} -k ${{ inputs.key_prefix }} | cut -f 1)
+        echo "Deleting nix-installer caches..."
+        for key in $cache_keys
+        do
+          gh cache -R ${{ env.REPO }} delete $key || echo "Failed to remove key $key from Github action cache. Could be a race condition with another instance of this action."
+        done
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+        REPO: ${{ inputs.repository }}

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -20,6 +20,9 @@ on:
       store_results:
         description: Indicates if results should be pushed to github pages
         default: false
+      always_terminate:
+        description: Indicates if EC2 instance should always be terminated
+        default: true
 jobs:
   bench-ec2-any:
     name: Ad-hoc benchmark on $${{ github.event.inputs.ec2_instance_type }}
@@ -31,4 +34,5 @@ jobs:
       archflags: ${{ github.event.inputs.archflags }}
       name: ${{ github.event.inputs.name }}
       store_results: ${{ github.event.inputs.store_results }}
+      always_terminate: ${{ github.event.inputs.always_terminate }}
     secrets: inherit

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -26,6 +26,10 @@ on:
         type: string
         description: Indicates if results should be pushed to github pages
         default: 'false'
+      always_terminate:
+        type: string
+        description: Indicates if instance should always be terminated, even on failure
+        default: 'true'
 env:
   AWS_ROLE: arn:aws:iam::559050233797:role/mlkem-c-aarch64-gh-action
   AWS_REGION: us-east-1
@@ -106,7 +110,7 @@ jobs:
       - start-ec2-runner
       - bench # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
+    if: ${{ (inputs.always_terminate == 'true' && always()) || success() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -44,6 +44,17 @@ jobs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
+      - name: Clear nix-installer action cache
+        run: |
+          cache_keys=$(gh cache list -R ${{ env.REPO }} -k determinatesystem-nix-installer-aarch64-linux | cut -f 1)
+          echo "Deleting nix-installer caches..."
+          for key in $cache_keys
+          do
+            gh cache -R ${{ env.REPO }} delete $key
+          done
+        env:
+          GH_TOKEN: ${{ secrets.AWS_GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -44,17 +44,13 @@ jobs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
+      - uses: actions/checkout@v4
       - name: Clear nix-installer action cache
-        run: |
-          cache_keys=$(gh cache list -R ${{ env.REPO }} -k determinatesystem-nix-installer-aarch64-linux | cut -f 1)
-          echo "Deleting nix-installer caches..."
-          for key in $cache_keys
-          do
-            gh cache -R ${{ env.REPO }} delete $key
-          done
-        env:
-          GH_TOKEN: ${{ secrets.AWS_GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
+        uses: ./.github/actions/clear-cache
+        with:
+           key_prefix: determinatesystem-nix-installer-
+           repository: ${{ github.repository }}
+           gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -98,10 +94,6 @@ jobs:
         shell: nix develop .#ci -c bash -e {0}
         run: |
           tests bench -c PERF --cflags "${{ inputs.cflags }}" --arch-flags "${{ inputs.archflags }}" -v --output output.json
-      - name: Dump benchmark
-        if: ${{ inputs.store_results != 'true' }}
-        run: |
-          cat output.json
       - name: Store benchmark result
         if: ${{ inputs.store_results == 'true' }}
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
There are spurious failures with the EC2 benchmarking workflows related to the nix-installer cache. This commit modifies the EC2 benchmarking workflow to clear the respective caches first, forcing the download of the installer and thereby avoiding the caching issue.

It also adds an option to keep benchmarking instances are the workflow terminates, which can be useful for debugging issues on workflow failure.