### PR TITLE
Update CBMC to version 6.2.0

### DIFF
--- a/cbmc/default.nix
+++ b/cbmc/default.nix
@@ -6,7 +6,7 @@
 }:
 builtins.attrValues {
   cbmc = cbmc.overrideAttrs (old: rec {
-    version = "6.2.0";
+    version = "6.2.0"; # remember to adjust this in ../flake.nix too
     src = fetchFromGitHub {
       owner = "diffblue";
       repo = old.pname;

--- a/cbmc/default.nix
+++ b/cbmc/default.nix
@@ -6,12 +6,12 @@
 }:
 builtins.attrValues {
   cbmc = cbmc.overrideAttrs (old: rec {
-    version = "6.1.1";
+    version = "6.2.0";
     src = fetchFromGitHub {
       owner = "diffblue";
       repo = old.pname;
       rev = "${old.pname}-${version}";
-      hash = "sha256-zxlEel/HlCrz4Shy+4WZX7up4qm5h2FoP77kngi8XAo=";
+      hash = "sha256-WktGmkQpd7OXYEPgv0v7/+vwhTm1rERrjXIe6dzelFA=";
     };
     patches = [
       ./0001-Do-not-download-sources-in-cmake.patch

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { pkgs, ... }:
         let
-          cbmcpkg = pkgs.callPackage ./cbmc { }; # 6.1.1
+          cbmcpkg = pkgs.callPackage ./cbmc { }; # 6.2.0
 
           linters = builtins.attrValues {
             astyle = pkgs.astyle.overrideAttrs (old: rec {


### PR DESCRIPTION
This PR upgrades the CBMC tool in NIX to version 6.2.0.

All existing proofs should pass OK with this new version.
