### PR TITLE
Add cpucap.h header and detect AArch64 systems

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,19 +18,19 @@ jobs:
           name: Arm Cortex-A72 (Raspberry Pi 4) benchmarks
           bench_pmu: PMU
           archflags: -mcpu=cortex-a72
-          cflags:
+          cflags: -DFORCE_AARCH64
           bench_extra_args:
         - system: rpi5
           name: Arm Cortex-A76 (Raspberry Pi 5) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a76 -march=armv8.2-a"
-          cflags:
+          cflags: -DFORCE_AARCH64
           bench_extra_args:
         - system: a55
           name: Arm Cortex-A55 (Snapdragon 888) benchmarks
           bench_pmu: PERF
           archflags: "-mcpu=cortex-a55 -march=armv8.2-a"
-          cflags: -static
+          cflags: "-static -DFORCE_AARCH64"
           bench_extra_args: -w exec-on-a55
     runs-on: self-hosted-${{ matrix.target.system }}
     defaults:

--- a/.github/workflows/bench_ec2_all.yml
+++ b/.github/workflows/bench_ec2_all.yml
@@ -18,6 +18,7 @@ jobs:
       ec2_instance_type: t4g.small
       ec2_ami_id: ami-096ea6a12ea24a797
       archflags: -mcpu=cortex-a76 -march=armv8.2-a
+      cflags: -DFORCE_AARCH64
       store_results: 'true'
       name: Graviton2
     secrets: inherit
@@ -32,6 +33,7 @@ jobs:
       ec2_instance_type: c7g.medium
       ec2_ami_id: ami-096ea6a12ea24a797
       archflags: -mcpu=neoverse-v1 -march=armv8.4-a
+      cflags: -DFORCE_AARCH64
       store_results: 'true'
       name: Graviton3
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [ macos-latest, pqcp-arm64, ubuntu-latest ]
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: macos-latest
+           name: 'MacOS'
+           arch: 'arm64'
+           cross-prefix: ' '
+           cflags: '-DFORCE_AARCH64'
+         - runner: pqcp-arm64
+           name: 'ubuntu-latest (aarch64)'
+           arch: 'aarch64'
+           cross-prefix: ' '
+           cflags: '-DFORCE_AARCH64'
+         - runner: ubuntu-latest
+           name: 'ubuntu-latest (x86_64)'
+           arch: 'x86_64'
+           cross-prefix: 'aarch64-unknown-linux-gnu-'
+           cflags: '-DFORCE_AARCH64'
         exclude:
-          - system: ${{ github.repository_owner != 'pq-code-package' && 'pqcp-arm64' }}
-    name: build_kat (${{ matrix.system }})
-    runs-on: ${{ matrix.system }}
+         - external: true
+           target:
+             - runner: 'pqcp-arm64'
+               name: 'ubuntu-latest (aarch64)'
+    name: build_kat (${{ matrix.target.name }})
+    runs-on: ${{ matrix.target.runner }}
     defaults:
       run:
         shell: nix develop .#ci -c bash -e {0}
-    env:
-      CROSS_PREFIX: "${{ (matrix.system == 'ubuntu-latest' && 'aarch64-unknown-linux-gnu-') || ' ' }}"
-      EXPECT_ARCH: "${{ (matrix.system == 'macos-latest' && 'arm64') || (matrix.system == 'pqcp-arm64' && 'aarch64') || (matrix.system == 'ubuntu-latest' && 'x86_64') }}"
     steps:
       - uses: actions/checkout@v4
       - name: Setup nix
@@ -36,25 +53,25 @@ jobs:
               - $(uname -a)
               - $(nix --version)
               - $(astyle --version)
-              - $(${CROSS_PREFIX}gcc --version | grep -m1 "")
+              - $(${{ matrix.target.cross-prefix }}gcc --version | grep -m1 "")
               - $(bash --version | grep -m1 "")
             EOF
 
-            if [[ "$ARCH" != $EXPECT_ARCH ]]; then
-              echo ":x: Expecting to run on $EXPECT_ARCH, but instead running on $ARCH" >> $GITHUB_STEP_SUMMARY
+            if [[ "$ARCH" != ${{ matrix.target.arch }} ]]; then
+              echo ":x: Expecting to run on ${{ matrix.target.arch }}, but instead running on $ARCH" >> $GITHUB_STEP_SUMMARY
               exit 1
             fi
       - name: Run functional tests
         id: func_test
         run: |
-          tests func --cross-prefix=$CROSS_PREFIX -v
+          tests func --cross-prefix=${{ matrix.target.cross-prefix }} --cflags ${{ matrix.target.cflags }} -v
       - name: Run KAT tests
         id: kat_test
         if: |
           success()
           || steps.func_test.conclusion == 'failure'
         run: |
-          tests kat --cross-prefix=$CROSS_PREFIX -v
+          tests kat --cross-prefix=${{ matrix.target.cross-prefix }} --cflags ${{ matrix.target.cflags }} -v
       - name: Run Nistkat tests
         id: nistkat_test
         if: |
@@ -62,7 +79,7 @@ jobs:
           || steps.func_test.conclusion == 'failure'
           || steps.kat_test.conclusion == 'failure'
         run: |
-          tests nistkat --cross-prefix=$CROSS_PREFIX -v
+          tests nistkat --cross-prefix=${{ matrix.target.cross-prefix }} --cflags ${{ matrix.target.cflags }} -v
   lint:
     strategy:
       matrix:
@@ -86,7 +103,7 @@ jobs:
               - $(uname -a)
               - $(nix --version)
               - $(astyle --version)
-              - $(${CROSS_PREFIX}gcc --version | grep -m1 "")
+              - $(${{ matrix.target.cross-prefix }}gcc --version | grep -m1 "")
               - $(bash --version | grep -m1 "")
             EOF
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   cbmc:
     strategy:
       matrix:
-        system: [macos-latest, ubuntu-latest]
+        system: [macos-latest]
     runs-on: ${{ matrix.system }}
     defaults:
       run:

--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -311,7 +311,7 @@ ADD_LIBRARY_FLAG := --add-library
 # Preprocessor include paths -I...
 INCLUDES ?=
 INCLUDES += -I$(PROOFDIR)
-INCLUDES += -I$(SRCDIR)/mlkem
+INCLUDES += -I$(SRCDIR)/mlkem -I$(SRCDIR)/mlkem/sys
 INCLUDES += -I$(SRCDIR)/fips202
 
 # Preprocessor definitions -D...

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 SOURCES = $(wildcard mlkem/*.c)
 
-CPPFLAGS += -Imlkem
+CPPFLAGS += -Imlkem -Imlkem/sys
 TESTS = test_kyber bench_kyber gen_NISTKAT gen_KAT
 
 MLKEM512_DIR = $(BUILD_DIR)/mlkem512

--- a/mlkem/params.h
+++ b/mlkem/params.h
@@ -2,6 +2,8 @@
 #ifndef PARAMS_H
 #define PARAMS_H
 
+#include "cpucap.h"
+
 #ifndef KYBER_K
 #define KYBER_K 3   /* Change this for different security strengths */
 #endif

--- a/mlkem/sys/cpucap.h
+++ b/mlkem/sys/cpucap.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef CPUCAP_H
+#define CPUCAP_H
+
+/* Check if we're running on an AArch64 system. _M_ARM64 is set by MSVC. */
+#if defined(__AARCH64EL__) || defined(_M_ARM64)
+#define SYS_AARCH64
+#endif
+
+/* If FORCE_AARCH64 is set, assert that we're indeed on an AArch64 system. */
+#if defined(FORCE_AARCH64) && !defined(SYS_AARCH64)
+#error "FORCE_AARCH64 is set, but we don't seem to be on an AArch64 system."
+#endif
+
+#endif


### PR DESCRIPTION
Also, allow `FORCE_AARCH64` to double-check that a system is recognized as AArch64. Use this in all AArch64-based CI builds.