### PR TITLE
X86 64 gcc

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -29,11 +29,11 @@ inputs:
   gh_token:
     description: GitHub access token
     required: true
-  use-nix:
-    description: Whether to run in the default Nix environment
-    default: "true"
+  nix-shell:
+    description: Run in the specified Nix environment if exists
+    default: "ci"
   custom_shell:
-    description: The shell to use. Only relevant if use-nix is "false"
+    description: The shell to use. Only relevant if no nix-shell specified
     default: "bash"
   cross_prefix:
     description: "Binary prefix for cross-compilation builds"
@@ -42,10 +42,10 @@ runs:
   using: composite
   steps:
     - name: Setup nix
-      if: ${{ inputs.use-nix }}
+      if: ${{ inputs.nix-shell != '' }}
       uses: ./.github/actions/setup-nix
       with:
-        devShell: ci
+        devShell: ${{ inputs.nix-shell }}
         script: |
           ARCH=$(uname -m)
           cat >> $GITHUB_STEP_SUMMARY <<-EOF
@@ -61,7 +61,7 @@ runs:
           EOF
     - name: Set shell
       shell: bash
-      run: echo SHELL="${{ inputs.use-nix && 'nix develop .#ci -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+      run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
     - name: Run benchmark
       shell: ${{ env.SHELL }}
       run: |

--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -61,7 +61,12 @@ runs:
           EOF
     - name: Set shell
       shell: bash
-      run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+      run: |
+        if [[ ${{ inputs.nix-shell }} != '' ]]; then
+          echo SHELL="nix develop .#${{ inputs.nix-shell }} -c bash -e {0}" >> $GITHUB_ENV
+        else
+          echo SHELL="${{ inputs.custom_shell }}" >> $GITHUB_ENV
+        fi
     - name: Run benchmark
       shell: ${{ env.SHELL }}
       run: |

--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -35,7 +35,12 @@ runs:
             EOF
       - name: Set shell
         shell: bash
-        run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+        run: |
+          if [[ ${{ inputs.nix-shell }} != '' ]]; then
+            echo SHELL="nix develop .#${{ inputs.nix-shell }} -c bash -e {0}" >> $GITHUB_ENV
+          else
+            echo SHELL="${{ inputs.custom_shell }}" >> $GITHUB_ENV
+          fi
       - name: Run CBMC proofs
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -4,9 +4,9 @@ name: CBMC
 description: Run CBMC proofs for MLKEM-C_AArch64
 
 inputs:
-  use-nix:
-    description: Whether to run in the default Nix environment
-    default: "true"
+  nix-shell:
+    description: Run in the specified Nix environment if exists
+    default: "ci-cbmc"
   custom_shell:
     description: The shell to use. Only relevant if use-nix is 'false'
     default: "bash"
@@ -18,10 +18,10 @@ runs:
   steps:
       - uses: actions/checkout@v4
       - name: Setup nix
-        if: ${{ inputs.use-nix }}
+        if: ${{ inputs.nix-shell != '' }}
         uses: ./.github/actions/setup-nix
         with:
-          devShell: ci-cbmc
+          devShell: ${{ inputs.nix-shell }}
           script: |
             cat >> $GITHUB_STEP_SUMMARY << EOF
               ## Setup
@@ -35,7 +35,7 @@ runs:
             EOF
       - name: Set shell
         shell: bash
-        run: echo SHELL="${{ inputs.use-nix && 'nix develop .#ci-cbmc -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+        run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
       - name: Run CBMC proofs
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -4,9 +4,12 @@ name: Functional tests
 description: Run functional tests for MLKEM-C_AArch64
 
 inputs:
-  use-nix:
-    description: Whether to run in the default Nix environment
-    default: "true"
+  nix-shell:
+    description: Run in the specified Nix environment if exists
+    default: "ci"
+  custom_shell:
+    description: The shell to use. Only relevant if no nix-shell specified
+    default: "bash"
   cflags:
     description: CFLAGS to pass to compilation
     default: ""
@@ -21,9 +24,9 @@ runs:
   steps:
       - name: Setup nix
         uses: ./.github/actions/setup-nix
-        if: ${{ inputs.use-nix }}
+        if: ${{ inputs.nix-shell != '' }}
         with:
-          devShell: ci
+          devShell: ${{ inputs.nix-shell }}
           script: |
             ARCH=$(uname -m)
             cat >> $GITHUB_STEP_SUMMARY <<-EOF
@@ -36,7 +39,7 @@ runs:
             EOF
       - name: Set shell
         shell: bash
-        run: echo SHELL="${{ inputs.use-nix && 'nix develop .#ci -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+        run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
       - name: Run functional tests
         id: func_test
         shell: ${{ env.SHELL }}

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -39,7 +39,12 @@ runs:
             EOF
       - name: Set shell
         shell: bash
-        run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+        run: |
+          if [[ ${{ inputs.nix-shell }} != '' ]]; then
+            echo SHELL="nix develop .#${{ inputs.nix-shell }} -c bash -e {0}" >> $GITHUB_ENV
+          else
+            echo SHELL="${{ inputs.custom_shell }}" >> $GITHUB_ENV
+          fi
       - name: Run functional tests
         id: func_test
         shell: ${{ env.SHELL }}

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -33,7 +33,12 @@ runs:
             EOF
       - name: Set shell
         shell: bash
-        run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+        run: |
+          if [[ ${{ inputs.nix-shell }} != '' ]]; then
+            echo SHELL="nix develop .#${{ inputs.nix-shell }} -c bash -e {0}" >> $GITHUB_ENV
+          else
+            echo SHELL="${{ inputs.custom_shell }}" >> $GITHUB_ENV
+          fi
       - name: Run linter
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -4,11 +4,11 @@ name: Lint
 description: Lint MLKEM-C_AArch64
 
 inputs:
-  use-nix:
-    description: Whether to run in the default Nix environment
-    default: "true"
+  nix-shell:
+    description: Run in the specified Nix environment if exists
+    default: "ci-linter"
   custom_shell:
-    description: The shell to use. Only relevant if use-nix is 'false'
+    description: The shell to use. Only relevant if no nix-shell specified
     default: "bash"
   cross-prefix:
     description: Binary prefix for cross compilation
@@ -17,10 +17,10 @@ runs:
   using: composite
   steps:
       - name: Setup nix
-        if: ${{ inputs.use-nix }}
+        if: ${{ inputs.nix-shell != '' }}
         uses: ./.github/actions/setup-nix
         with:
-          devShell: ci-linter
+          devShell: ${{ inputs.nix-shell }}
           script: |
             cat >> $GITHUB_STEP_SUMMARY << EOF
               ## Setup
@@ -33,7 +33,7 @@ runs:
             EOF
       - name: Set shell
         shell: bash
-        run: echo SHELL="${{ inputs.use-nix && 'nix develop .#ci-linter -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
+        run: echo SHELL="${{ inputs.nix-shell != '' && 'nix develop .#${{ inputs.nix-shell }} -c bash -e {0}' || inputs.custom_shell }}" >> $GITHUB_ENV
       - name: Run linter
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bench
         with:
-          use-nix: true
+          nix-shell: ci
           name: ${{ inputs.name }}
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,24 @@ jobs:
            arch: 'arm64'
            cross-prefix: ' '
            cflags: '-DFORCE_AARCH64'
+           nix-shell: ci
          - runner: pqcp-arm64
            name: 'ubuntu-latest (aarch64)'
            arch: 'aarch64'
            cross-prefix: ' '
            cflags: '-DFORCE_AARCH64'
+           nix-shell: 'ci'
          - runner: ubuntu-latest
            name: 'ubuntu-latest (x86_64, cross)'
            arch: 'x86_64'
            cross-prefix: 'aarch64-unknown-linux-gnu-'
            cflags: '-DFORCE_AARCH64'
+           nix-shell: 'x86_64-linux-cross-ci'
          - runner: ubuntu-latest
            name: 'ubuntu-latest (x86_64, native)'
            arch: 'x86_64'
            cross-prefix: ''
+           nix-shell: 'ci'
         exclude:
          - {external: true,
             target: {
@@ -40,7 +44,8 @@ jobs:
               name: 'ubuntu-latest (aarch64)',
               arch: 'aarch64',
               cross-prefix: ' ',
-              cflags: '-DFORCE_AARCH64'
+              cflags: '-DFORCE_AARCH64',
+              nix-shell: 'ci'
             }}
     name: Functional tests (${{ matrix.target.name }})
     runs-on: ${{ matrix.target.runner }}
@@ -49,14 +54,14 @@ jobs:
       - name: functest opt
         uses: ./.github/actions/functest
         with:
-          nix-shell: ci
+          nix-shell: ${{ matrix.target.nix-shell }}
           cflags: ${{ matrix.target.cflags }}
           cross-prefix: ${{ matrix.target.cross-prefix }}
           opt: true
       - name: functest non-opt
         uses: ./.github/actions/functest
         with:
-          nix-shell: ci
+          nix-shell: ${{ matrix.target.nix-shell }}
           cflags: ${{ matrix.target.cflags }}
           cross-prefix: ${{ matrix.target.cross-prefix }}
           opt: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,14 @@ jobs:
       - name: functest opt
         uses: ./.github/actions/functest
         with:
-          use-nix: true
+          nix-shell: ci
           cflags: ${{ matrix.target.cflags }}
           cross-prefix: ${{ matrix.target.cross-prefix }}
           opt: true
       - name: functest non-opt
         uses: ./.github/actions/functest
         with:
-          use-nix: true
+          nix-shell: ci
           cflags: ${{ matrix.target.cflags }}
           cross-prefix: ${{ matrix.target.cross-prefix }}
           opt: false
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/lint
         with:
-          use-nix: true
+          nix-shell: ci-linter
           cross-prefix: "aarch64-unknown-linux-gnu-"
   cbmc:
     strategy:
@@ -82,4 +82,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cbmc
         with:
-          use-nix: true
+          nix-shell: ci-cbmc

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/functest
         with:
-          use-nix: true
+          nix-shell: ci
           cflags: ${{ inputs.cflags }}
           cross-prefix: ${{ inputs.cross-prefix }}
           opt: ${{ inputs.opt }}
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/lint
         with:
-          use-nix: true
+          nix-shell: ci-linter
           cross-prefix: ${{ inputs.cross-prefix }}
   cbmc:
     name: CBMC ${{ inputs.name }}
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/cbmc
         with:
-          use-nix: true
+          nix-shell: ci-cbmc
           cross-prefix: ${{ inputs.cross-prefix }}
   stop-ec2-runner:
     name: Stop ${{ inputs.name }} (${{ inputs.ec2_instance_type }})

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
               gcc =
                 if pkgs.stdenv.isDarwin
                 then
-                  if pkgs.stdenv.x864_64
+                  if pkgs.stdenv.isx86_64
                   then [ ]
                   else aarch64-gcc
                 else

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,19 @@
                     pkgs.pkgsCross.aarch64-multiplatform.glibc
                     pkgs.pkgsCross.aarch64-multiplatform.glibc.static
                   ];
+              x86_64-gcc =
+                pkgs.lib.optionals
+                  (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64)
+                  [
+                    (pkgs.gcc13.override {
+                      propagateDoc = true;
+                      isGNU = true;
+                    })
+                    pkgs.glibc
+                    pkgs.glibc.static
+                  ];
             in
+            x86_64-gcc ++
             aarch64-gcc ++
             builtins.attrValues {
               inherit (pkgs)

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -45,7 +45,7 @@ QEMU = qemu-aarch64
 
 HOST_PLATFORM := $(shell uname -s)-$(shell uname -m)
 ifeq ($(HOST_PLATFORM),Linux-x86_64)
-	CFLAGS += -static
+	CFLAGS += -z noexecstack
 endif
 
 CYCLES ?= NO


### PR DESCRIPTION
In order to support native and cross compiled gcc on x86_64 linux, I added some extra nix shell, since mixing different version of gcc in a same shell, and correctly linking against standard library like glibc is a nightmare...

Therefore there are some changes for ci workflows accordingly, including ec2 related workflows. We should test those workflows as well.