### PR TITLE
Add cache for scaled polys/polyvecs in NTT domain

### DIFF
--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -56,21 +56,6 @@ const int16_t zetas[128] =
 };
 
 /*************************************************
- * Name:        fqmul
- *
- * Description: Multiplication followed by Montgomery reduction
- *
- * Arguments:   - int16_t a: first factor
- *              - int16_t b: second factor
- *
- * Returns 16-bit integer congruent to a*b*R^{-1} mod q
- **************************************************/
-static int16_t fqmul(int16_t a, int16_t b)
-{
-    return montgomery_reduce((int32_t)a * b);
-}
-
-/*************************************************
  * Name:        ntt
  *
  * Description: Inplace number-theoretic transform (NTT) in Rq.

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -166,3 +166,22 @@ void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2],
     r[1] = fqmul(a[0], b[1]);
     r[1] += fqmul(a[1], b[0]);
 }
+
+/*************************************************
+ * Name:        basemul_cached
+ *
+ * Description: Multiplication of polynomials in Zq[X]/(X^2-zeta)
+ *              used for multiplication of elements in Rq in NTT domain
+ *
+ * Arguments:   - int16_t r[2]: pointer to the output polynomial
+ *              - const int16_t a[2]: pointer to the first factor
+ *              - const int16_t b[2]: pointer to the second factor
+ *              - int16_t b_cached: Cached precomputation of b[1] * zeta
+ **************************************************/
+void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t b_cached)
+{
+    r[0] = fqmul(a[1], b_cached);
+    r[0] += fqmul(a[0], b[0]);
+    r[1] = fqmul(a[0], b[1]);
+    r[1] += fqmul(a[1], b[0]);
+}

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -160,10 +160,10 @@ void invntt(int16_t r[256])
 void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2],
              int16_t zeta)
 {
-    r[0] = fqmul(a[1], b[1]);
-    r[0] = fqmul(r[0], zeta);
+    r[0]  = fqmul(a[1], b[1]);
+    r[0]  = fqmul(r[0], zeta);
     r[0] += fqmul(a[0], b[0]);
-    r[1] = fqmul(a[0], b[1]);
+    r[1]  = fqmul(a[0], b[1]);
     r[1] += fqmul(a[1], b[0]);
 }
 
@@ -180,8 +180,11 @@ void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2],
  **************************************************/
 void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t b_cached)
 {
-    r[0] = fqmul(a[1], b_cached);
-    r[0] += fqmul(a[0], b[0]);
-    r[1] = fqmul(a[0], b[1]);
-    r[1] += fqmul(a[1], b[0]);
+    int32_t t0, t1;
+    t0  = (int32_t) a[1] * b_cached;
+    t0 += (int32_t) a[0] * b[0];
+    t1  = (int32_t) a[0] * b[1];
+    t1 += (int32_t) a[1] * b[0];
+    r[0] = montgomery_reduce(t0);
+    r[1] = montgomery_reduce(t1);
 }

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -17,4 +17,7 @@ void invntt(int16_t poly[256]);
 #define basemul KYBER_NAMESPACE(basemul)
 void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta);
 
+#define basemul_cached KYBER_NAMESPACE(basemul_cached)
+void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t b_cached);
+
 #endif

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -707,7 +707,7 @@ static int16_t fqmul(int16_t a, int16_t b)
 *              base multiplications of polynomials
 *              in NTT domain.
 *
-* Arguments: - poly_mulcache *x: point to output cache.
+* Arguments: - poly_mulcache *x: pointer to output cache.
 *            - const poly *a: pointer to input polynomial
 **************************************************/
 void poly_mulcache_compute(poly_mulcache *x, const poly *a)

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -682,24 +682,6 @@ void poly_sub(poly *r, const poly *a, const poly *b)
     }
 }
 
-// REF-CHANGE: Duplicates fqmul() from ntt.c.
-// TODO: Consolidate this
-
-/*************************************************
- * Name:        fqmul
- *
- * Description: Multiplication followed by Montgomery reduction
- *
- * Arguments:   - int16_t a: first factor
- *              - int16_t b: second factor
- *
- * Returns 16-bit integer congruent to a*b*R^{-1} mod q
- **************************************************/
-static int16_t fqmul(int16_t a, int16_t b)
-{
-    return montgomery_reduce((int32_t)a * b);
-}
-
 /*************************************************
 * Name:        poly_mulcache_compute
 *

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -16,6 +16,17 @@ typedef struct
     int16_t coeffs[KYBER_N];
 } poly;
 
+/*
+ * INTERNAL presentation of precomputed data speeding up
+ * the base multiplication of two polynomials in NTT domain.
+ */
+// REF-CHANGE: This structure does not exist in the reference
+// implementation.
+typedef struct
+{
+    int16_t coeffs[KYBER_N >> 1];
+} poly_mulcache;
+
 #define scalar_compress_q_16           KYBER_NAMESPACE(scalar_compress_q_16)
 #define scalar_decompress_q_16         KYBER_NAMESPACE(scalar_decompress_q_16)
 #define scalar_compress_q_32           KYBER_NAMESPACE(scalar_compress_q_32)
@@ -127,8 +138,14 @@ void poly_ntt(poly *r);
 void poly_invntt_tomont(poly *r);
 #define poly_basemul_montgomery KYBER_NAMESPACE(poly_basemul_montgomery)
 void poly_basemul_montgomery(poly *r, const poly *a, const poly *b);
+#define poly_basemul_montgomery_cached KYBER_NAMESPACE(poly_basemul_montgomery_cached)
+void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b, const poly_mulcache *b_cache);
 #define poly_tomont KYBER_NAMESPACE(poly_tomont)
 void poly_tomont(poly *r);
+
+// REF-CHANGE: This function does not exist in the reference implementation
+#define poly_mulcache_compute KYBER_NAMESPACE(poly_mulcache_compute)
+void poly_mulcache_compute(poly_mulcache *x, const poly *a);
 
 #define poly_reduce KYBER_NAMESPACE(poly_reduce)
 void poly_reduce(poly *r);

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -253,7 +253,7 @@ void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
 {
     polyvec_mulcache b_cache;
     polyvec_mulcache_compute(&b_cache, b);
-    polyvec_basemul_acc_montgomery_cached( r, a, b, &b_cache);
+    polyvec_basemul_acc_montgomery_cached(r, a, b, &b_cache);
 }
 
 /*************************************************

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -263,7 +263,7 @@ void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
 *              base multiplications of polynomials
 *              in NTT domain.
 *
-* Arguments: - polyvec_mulcache *x: point to output cache.
+* Arguments: - polyvec_mulcache *x: pointer to output cache.
 *            - const poly *a: pointer to input polynomial
 **************************************************/
 void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a)

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -11,6 +11,12 @@ typedef struct
     poly vec[KYBER_K];
 } polyvec;
 
+// REF-CHANGE: This struct does not exist in the reference implementation
+typedef struct
+{
+    poly_mulcache vec[KYBER_K];
+} polyvec_mulcache;
+
 #define polyvec_compress KYBER_NAMESPACE(polyvec_compress)
 void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES], const polyvec *a);
 #define polyvec_decompress KYBER_NAMESPACE(polyvec_decompress)
@@ -28,6 +34,14 @@ void polyvec_invntt_tomont(polyvec *r);
 
 #define polyvec_basemul_acc_montgomery KYBER_NAMESPACE(polyvec_basemul_acc_montgomery)
 void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b);
+
+// REF-CHANGE: This function does not exist in the reference implementation
+#define polyvec_basemul_acc_montgomery_cached KYBER_NAMESPACE(polyvec_basemul_acc_montgomery_cached)
+void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a, const polyvec *b, const polyvec_mulcache *b_cache);
+
+// REF-CHANGE: This function does not exist in the reference implementation
+#define polyvec_mulcache_compute KYBER_NAMESPACE(polyvec_mulcache_compute)
+void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a);
 
 #define polyvec_reduce KYBER_NAMESPACE(polyvec_reduce)
 void polyvec_reduce(polyvec *r);

--- a/mlkem/reduce.h
+++ b/mlkem/reduce.h
@@ -14,4 +14,19 @@ int16_t montgomery_reduce(int32_t a);
 #define barrett_reduce KYBER_NAMESPACE(barrett_reduce)
 int16_t barrett_reduce(int16_t a);
 
+/*************************************************
+ * Name:        fqmul
+ *
+ * Description: Multiplication followed by Montgomery reduction
+ *
+ * Arguments:   - int16_t a: first factor
+ *              - int16_t b: second factor
+ *
+ * Returns 16-bit integer congruent to a*b*R^{-1} mod q
+ **************************************************/
+static inline int16_t fqmul(int16_t a, int16_t b)
+{
+    return montgomery_reduce((int32_t)a * b);
+}
+
 #endif


### PR DESCRIPTION
Asymmetric multiplication [1] speeds up matrix-vector multiplication in NTT-domain via additional caching on the polyvec argument.

This commit provides a C implementation of this strategy and paves the way for clean integration of ASM.

It introduces types poly_mulcache and polyvec_mulcache for precomputed data used by poly/polyvec base multiplication. Those types are meant to be opaque to the caller, an exposed only to allow their construction on the stack.

The mulcache for a poly/polyvec can be computed via `poly[vec]_mulcache_compute()`. It is then passed to base multiplication routines as an additional argument.

Apart from caching repeated computations, another benefit of asymmetric multiplication is that it allows lazy Montgomery reduction during base multiplication, and even matrix-vector multiplication. This will be fully leveraged on the ASM level later on. On the C-level, we merely use lazy reduction for a small speedup of the cached basemul.

[1]: https://eprint.iacr.org/2021/986
     Neon NTT: Faster Dilithium, Kyber, and Saber on Cortex-A72 and Apple M1

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
