### PR TITLE
Prove poly decompress

### DIFF
--- a/cbmc/proofs/poly_decompress/Makefile
+++ b/cbmc/proofs/poly_decompress/Makefile
@@ -10,41 +10,40 @@ HARNESS_FILE = poly_decompress_harness
 PROOF_UID = poly_decompress
 
 DEFINES +=
+INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
 UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/poly.c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/verify.c
 
-# For KYBER_K=2,3 a loop with 128 iterations is used.
-# For KYBER_K=4, a nested loop with 32 and 8 iterations is used.
-ifneq ($(KYBER_K),4)
-	UNWINDSET += $(KYBER_NAMESPACE)poly_decompress.0:129
+CHECK_FUNCTION_CONTRACTS=$(KYBER_NAMESPACE)poly_decompress
+
+# For K = 2 or 3, the code calls scalar_decompress_q_16, so
+ifeq ($(KYBER_POLYCOMPRESSBYTES),128)
+USE_FUNCTION_CONTRACTS = $(KYBER_NAMESPACE)scalar_decompress_q_16
 else
-	UNWINDSET += $(KYBER_NAMESPACE)poly_decompress.1:33
-	UNWINDSET += $(KYBER_NAMESPACE)poly_decompress.0:9
 endif
 
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--bitwuzla
+
 FUNCTION_NAME = $(KYBER_NAMESPACE)poly_decompress
-
-USE_FUNCTION_CONTRACTS = $(KYBER_NAMESPACE)scalar_decompress_q_16
-
-# TODO: I would like to comment this out to have CBMC validate the
-# function contract as annotated in the source, rather than being forced
-# to replicate it in the harness. But somehow this doesn't work...?
-
-# USE_FUNCTION_CONTRACTS = $(FUNCTION_NAME)
-
-# USE_DYNAMIC_FRAMES = 1
-# EXTERNAL_SAT_SOLVER = cadical
-# CBMCFLAGS += --smt2
 
 # If this proof is found to consume huge amounts of RAM, you can set the
 # EXPENSIVE variable. With new enough versions of the proof tools, this will
 # restrict the number of EXPENSIVE CBMC jobs running at once. See the
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 12
 
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file

--- a/cbmc/proofs/poly_decompress/poly_decompress_harness.c
+++ b/cbmc/proofs/poly_decompress/poly_decompress_harness.c
@@ -27,12 +27,4 @@ void harness(void)
     uint8_t a[KYBER_POLYCOMPRESSEDBYTES];
 
     poly_decompress(&r, a);
-
-    // TODO: We're replicating the post-condition of the function contract of
-    // poly_decompress here. Ideally, we'd use CBMC's function contract mechanism
-    // here, but there are still issues. cf. a similar comment in the Makefile.
-    __CPROVER_assert(__CPROVER_forall
-    {
-        unsigned i; (i < KYBER_N) ==> ( 0 <= r.coeffs[i] && r.coeffs[i] < KYBER_Q )
-    }, "failed to prove post-condition for poly_decompress");
 }

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -220,10 +220,8 @@ void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)
 **************************************************/
 void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
 {
-    unsigned int i;
-
     #if (KYBER_POLYCOMPRESSEDBYTES == 128)
-    for (i = 0; i < KYBER_N / 2; i++)
+    for (int i = 0; i < KYBER_N / 2; i++)
         __CPROVER_assigns(i, __CPROVER_object_whole(r))
         __CPROVER_loop_invariant(i >= 0)
         __CPROVER_loop_invariant(i <= KYBER_N / 2)
@@ -240,52 +238,46 @@ void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
 
 
     #elif (KYBER_POLYCOMPRESSEDBYTES == 160)
-    for (i = 0; i < KYBER_N / 8; i++)
+    const int num_blocks = KYBER_N / 8;
+    for (int i = 0; i < num_blocks; i++)
         __CPROVER_assigns(i, __CPROVER_object_whole(r))
         __CPROVER_loop_invariant(i >= 0)
-        __CPROVER_loop_invariant(i <= KYBER_N / 8)
-        __CPROVER_loop_invariant(__CPROVER_forall { unsigned int k; (k < i) ==>
-                                 ( r->coeffs[8 * k]     >= 0 && r->coeffs[8 * k]     < KYBER_Q &&
-                                   r->coeffs[8 * k + 1] >= 0 && r->coeffs[8 * k + 1] < KYBER_Q &&
-                                   r->coeffs[8 * k + 2] >= 0 && r->coeffs[8 * k + 2] < KYBER_Q &&
-                                   r->coeffs[8 * k + 3] >= 0 && r->coeffs[8 * k + 3] < KYBER_Q &&
-                                   r->coeffs[8 * k + 4] >= 0 && r->coeffs[8 * k + 4] < KYBER_Q &&
-                                   r->coeffs[8 * k + 5] >= 0 && r->coeffs[8 * k + 5] < KYBER_Q &&
-                                   r->coeffs[8 * k + 6] >= 0 && r->coeffs[8 * k + 6] < KYBER_Q &&
-                                   r->coeffs[8 * k + 7] >= 0 && r->coeffs[8 * k + 7] < KYBER_Q ) })
-        __CPROVER_decreases(KYBER_N / 8 - i)
+        __CPROVER_loop_invariant(i <= num_blocks)
+        __CPROVER_loop_invariant(num_blocks == 32)
+        __CPROVER_loop_invariant(__CPROVER_forall { int k; k >= 0 && k <= (8 * i - 1) ==>
+                                 ( r->coeffs[k] >= 0 && r->coeffs[k] < KYBER_Q )})
+        __CPROVER_decreases(num_blocks - i)
     {
-        uint8_t t;
-        const unsigned int offset = i * 5;
+        uint8_t t[8];
+        const int offset = i * 5;
         // REF-CHANGE: Explicitly truncate to avoid warning about
         // implicit truncation in CBMC and unwind loop for ease
         // of proof.
 
         // Decompress 5 8-bit bytes (so 40 bits) into
         // 8 5-bit values stored in t[]
-        t = 0x1F &  (a[offset + 0] >> 0);
-        r->coeffs[8 * i]     = ((uint32_t) t * KYBER_Q + 16) >> 5;
+        t[0] = 0x1F &  (a[offset + 0] >> 0);
+        t[1] = 0x1F & ((a[offset + 0] >> 5) | (a[offset + 1] << 3));
+        t[2] = 0x1F &  (a[offset + 1] >> 2);
+        t[3] = 0x1F & ((a[offset + 1] >> 7) | (a[offset + 2] << 1));
+        t[4] = 0x1F & ((a[offset + 2] >> 4) | (a[offset + 3] << 4));
+        t[5] = 0x1F &  (a[offset + 3] >> 1);
+        t[6] = 0x1F & ((a[offset + 3] >> 6) | (a[offset + 4] << 2));
+        t[7] = 0x1F &  (a[offset + 4] >> 3);
 
-        t = 0x1F & ((a[offset + 0] >> 5) | (a[offset + 1] << 3));
-        r->coeffs[8 * i + 1] = ((uint32_t) t * KYBER_Q + 16) >> 5;
-
-        t = 0x1F &  (a[offset + 1] >> 2);
-        r->coeffs[8 * i + 2] = ((uint32_t) t * KYBER_Q + 16) >> 5;
-
-        t = 0x1F & ((a[offset + 1] >> 7) | (a[offset + 2] << 1));
-        r->coeffs[8 * i + 3] = ((uint32_t) t * KYBER_Q + 16) >> 5;
-
-        t = 0x1F & ((a[offset + 2] >> 4) | (a[offset + 3] << 4));
-        r->coeffs[8 * i + 4] = ((uint32_t) t * KYBER_Q + 16) >> 5;
-
-        t = 0x1F &  (a[offset + 3] >> 1);
-        r->coeffs[8 * i + 5] = ((uint32_t) t * KYBER_Q + 16) >> 5;
-
-        t = 0x1F & ((a[offset + 3] >> 6) | (a[offset + 4] << 2));
-        r->coeffs[8 * i + 6] = ((uint32_t) t * KYBER_Q + 16) >> 5;
-
-        t = 0x1F &  (a[offset + 4] >> 3);
-        r->coeffs[8 * i + 7] = ((uint32_t) t * KYBER_Q + 16) >> 5;
+        // and copy to the correct slice in r[]
+        for (int j = 0; j < 8; j++)
+            __CPROVER_assigns(j, __CPROVER_object_whole(r))
+            __CPROVER_loop_invariant(j >= 0)
+            __CPROVER_loop_invariant(j <= 8)
+            __CPROVER_loop_invariant(i >= 0)
+            __CPROVER_loop_invariant(i <= num_blocks)
+            __CPROVER_loop_invariant(__CPROVER_forall { int k; k >= 0 && k <= (8 * i + j - 1) ==>
+                                     ( r->coeffs[k] >= 0 && r->coeffs[k] < KYBER_Q )})
+            __CPROVER_decreases(8 - j)
+        {
+            r->coeffs[8 * i + j] = ((uint32_t) t[j] * KYBER_Q + 16) >> 5;
+        }
     }
     #else
 #error "KYBER_POLYCOMPRESSEDBYTES needs to be in {128, 160}"

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -224,13 +224,13 @@ void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
 
     #if (KYBER_POLYCOMPRESSEDBYTES == 128)
     for (i = 0; i < KYBER_N / 2; i++)
-    __CPROVER_assigns(i, __CPROVER_object_whole(r))
-    __CPROVER_loop_invariant(i >= 0)
-    __CPROVER_loop_invariant(i <= KYBER_N / 2)
-    __CPROVER_loop_invariant(__CPROVER_forall { unsigned int k; (k < i) ==>
-        ( r->coeffs[2 * k]     >= 0 && r->coeffs[2 * k]     < KYBER_Q &&
-          r->coeffs[2 * k + 1] >= 0 && r->coeffs[2 * k + 1] < KYBER_Q ) })
-    __CPROVER_decreases(KYBER_N / 2 - i)
+        __CPROVER_assigns(i, __CPROVER_object_whole(r))
+        __CPROVER_loop_invariant(i >= 0)
+        __CPROVER_loop_invariant(i <= KYBER_N / 2)
+        __CPROVER_loop_invariant(__CPROVER_forall { unsigned int k; (k < i) ==>
+                                 ( r->coeffs[2 * k]     >= 0 && r->coeffs[2 * k]     < KYBER_Q &&
+                                   r->coeffs[2 * k + 1] >= 0 && r->coeffs[2 * k + 1] < KYBER_Q ) })
+        __CPROVER_decreases(KYBER_N / 2 - i)
     {
         // REF-CHANGE: Hoist scalar decompression into separate function
         r->coeffs[2 * i + 0] = scalar_decompress_q_16((a[i] >> 0) & 0xF);
@@ -241,19 +241,19 @@ void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
 
     #elif (KYBER_POLYCOMPRESSEDBYTES == 160)
     for (i = 0; i < KYBER_N / 8; i++)
-    __CPROVER_assigns(i, __CPROVER_object_whole(r))
-    __CPROVER_loop_invariant(i >= 0)
-    __CPROVER_loop_invariant(i <= KYBER_N / 8)
-    __CPROVER_loop_invariant(__CPROVER_forall { unsigned int k; (k < i) ==>
-        ( r->coeffs[8 * k]     >= 0 && r->coeffs[8 * k]     < KYBER_Q &&
-          r->coeffs[8 * k + 1] >= 0 && r->coeffs[8 * k + 1] < KYBER_Q &&
-          r->coeffs[8 * k + 2] >= 0 && r->coeffs[8 * k + 2] < KYBER_Q &&
-          r->coeffs[8 * k + 3] >= 0 && r->coeffs[8 * k + 3] < KYBER_Q &&
-          r->coeffs[8 * k + 4] >= 0 && r->coeffs[8 * k + 4] < KYBER_Q &&
-          r->coeffs[8 * k + 5] >= 0 && r->coeffs[8 * k + 5] < KYBER_Q &&
-          r->coeffs[8 * k + 6] >= 0 && r->coeffs[8 * k + 6] < KYBER_Q &&
-          r->coeffs[8 * k + 7] >= 0 && r->coeffs[8 * k + 7] < KYBER_Q ) })
-    __CPROVER_decreases(KYBER_N / 8 - i)
+        __CPROVER_assigns(i, __CPROVER_object_whole(r))
+        __CPROVER_loop_invariant(i >= 0)
+        __CPROVER_loop_invariant(i <= KYBER_N / 8)
+        __CPROVER_loop_invariant(__CPROVER_forall { unsigned int k; (k < i) ==>
+                                 ( r->coeffs[8 * k]     >= 0 && r->coeffs[8 * k]     < KYBER_Q &&
+                                   r->coeffs[8 * k + 1] >= 0 && r->coeffs[8 * k + 1] < KYBER_Q &&
+                                   r->coeffs[8 * k + 2] >= 0 && r->coeffs[8 * k + 2] < KYBER_Q &&
+                                   r->coeffs[8 * k + 3] >= 0 && r->coeffs[8 * k + 3] < KYBER_Q &&
+                                   r->coeffs[8 * k + 4] >= 0 && r->coeffs[8 * k + 4] < KYBER_Q &&
+                                   r->coeffs[8 * k + 5] >= 0 && r->coeffs[8 * k + 5] < KYBER_Q &&
+                                   r->coeffs[8 * k + 6] >= 0 && r->coeffs[8 * k + 6] < KYBER_Q &&
+                                   r->coeffs[8 * k + 7] >= 0 && r->coeffs[8 * k + 7] < KYBER_Q ) })
+        __CPROVER_decreases(KYBER_N / 8 - i)
     {
         uint8_t t;
         const unsigned int offset = i * 5;

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -258,7 +258,8 @@ void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
         uint8_t t;
         const unsigned int offset = i * 5;
         // REF-CHANGE: Explicitly truncate to avoid warning about
-        // implicit truncation in CBMC.
+        // implicit truncation in CBMC and unwind loop for ease
+        // of proof.
 
         // Decompress 5 8-bit bytes (so 40 bits) into
         // 8 5-bit values stored in t[]

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -81,7 +81,15 @@ __CPROVER_assigns(__CPROVER_object_whole(r));
 
 
 #define poly_decompress KYBER_NAMESPACE(poly_decompress)
-void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES]);
+void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
+/* *INDENT-OFF* */
+__CPROVER_requires(a != NULL)
+__CPROVER_requires(__CPROVER_is_fresh(a, KYBER_POLYCOMPRESSEDBYTES))
+__CPROVER_requires(r != NULL)
+__CPROVER_requires(__CPROVER_is_fresh(r, sizeof(poly)))
+__CPROVER_assigns(__CPROVER_object_whole(r))
+__CPROVER_ensures(__CPROVER_forall { unsigned k; (k < KYBER_N) ==> ( r->coeffs[k] >= 0 && r->coeffs[k] < KYBER_Q ) });
+/* *INDENT-ON* */
 
 #define poly_tobytes KYBER_NAMESPACE(poly_tobytes)
 void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a);


### PR DESCRIPTION
This PR updates the CBMC proofs of poly_decompress() to use unbounded and contract-based verification.

All tests pass.

"format" run with no changes.

