### PR TITLE
Remove `poly_[inv]ntt -> [inv]ntt()` indirection and unnecessary reduction

### DIFF
--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -94,8 +94,6 @@ void poly_ntt(poly *p)
 void poly_ntt(poly *p)
 {
     ntt_asm(p->coeffs);
-
-    poly_reduce(p);
 }
 #endif /* MLKEM_USE_AARCH64_ASM */
 

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -56,19 +56,22 @@ const int16_t zetas[128] =
 };
 
 /*************************************************
- * Name:        ntt
- *
- * Description: Inplace number-theoretic transform (NTT) in Rq.
- *              input is in standard order, output is in bitreversed order
- *
- * Arguments:   - int16_t r[256]: pointer to input/output vector of elements of
- *Zq
- **************************************************/
+* Name:        poly_ntt
+*
+* Description: Computes negacyclic number-theoretic transform (NTT) of
+*              a polynomial in place;
+*              inputs assumed to be in normal order, output in bitreversed order
+*
+* Arguments:   - poly *p: pointer to in/output polynomial
+**************************************************/
 #if !defined(MLKEM_USE_AARCH64_ASM)
-void ntt(int16_t r[256])
+// REF-CHANGE: Removed indirection poly_ntt -> ntt()
+// and integrated polynomial reduction into the NTT.
+void poly_ntt(poly *p)
 {
     unsigned int len, start, j, k;
     int16_t t, zeta;
+    int16_t *r = p->coeffs;
 
     k = 1;
     for (len = 128; len >= 2; len >>= 1)
@@ -84,30 +87,35 @@ void ntt(int16_t r[256])
             }
         }
     }
+
+    poly_reduce(p);
 }
 #else /* MLKEM_USE_AARCH64_ASM */
-void ntt(int16_t r[256])
+void poly_ntt(poly *p)
 {
-    ntt_asm(r);
+    ntt_asm(p->coeffs);
+
+    poly_reduce(p);
 }
 #endif /* MLKEM_USE_AARCH64_ASM */
 
 /*************************************************
- * Name:        invntt_tomont
- *
- * Description: Inplace inverse number-theoretic transform in Rq and
- *              multiplication by Montgomery factor 2^16.
- *              Input is in bitreversed order, output is in standard order
- *
- * Arguments:   - int16_t r[256]: pointer to input/output vector of elements of
- *Zq
- **************************************************/
+* Name:        poly_invntt_tomont
+*
+* Description: Computes inverse of negacyclic number-theoretic transform (NTT)
+*              of a polynomial in place;
+*              inputs assumed to be in bitreversed order, output in normal order
+*
+* Arguments:   - uint16_t *a: pointer to in/output polynomial
+**************************************************/
 #if !defined(MLKEM_USE_AARCH64_ASM)
-void invntt(int16_t r[256])
+// REF-CHANGE: Removed indirection poly_invntt_tomont -> invntt()
+void poly_invntt_tomont(poly *p)
 {
     unsigned int start, len, j, k;
     int16_t t, zeta;
     const int16_t f = 1441; // mont^2/128
+    int16_t *r = p->coeffs;
 
     k = 127;
     for (len = 2; len <= 128; len <<= 1)
@@ -131,9 +139,9 @@ void invntt(int16_t r[256])
     }
 }
 #else /* MLKEM_USE_AARCH64_ASM */
-void invntt(int16_t r[256])
+void poly_invntt_tomont(poly *p)
 {
-    intt_asm(r);
+    intt_asm(p->coeffs);
 }
 #endif /* MLKEM_USE_AARCH64_ASM */
 

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -4,15 +4,16 @@
 
 #include <stdint.h>
 #include "params.h"
+#include "poly.h"
 
 #define zetas KYBER_NAMESPACE(zetas)
 extern const int16_t zetas[128];
 
 #define ntt KYBER_NAMESPACE(ntt)
-void ntt(int16_t poly[256]);
+void poly_ntt(poly *r);
 
 #define invntt KYBER_NAMESPACE(invntt)
-void invntt(int16_t poly[256]);
+void poly_invntt_tomont(poly *r);
 
 #define basemul KYBER_NAMESPACE(basemul)
 void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta);

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -528,35 +528,6 @@ void poly_getnoise_eta1122_4x(poly *r0,
 }
 
 /*************************************************
-* Name:        poly_ntt
-*
-* Description: Computes negacyclic number-theoretic transform (NTT) of
-*              a polynomial in place;
-*              inputs assumed to be in normal order, output in bitreversed order
-*
-* Arguments:   - uint16_t *r: pointer to in/output polynomial
-**************************************************/
-void poly_ntt(poly *r)
-{
-    ntt(r->coeffs);
-    poly_reduce(r);
-}
-
-/*************************************************
-* Name:        poly_invntt_tomont
-*
-* Description: Computes inverse of negacyclic number-theoretic transform (NTT)
-*              of a polynomial in place;
-*              inputs assumed to be in bitreversed order, output in normal order
-*
-* Arguments:   - uint16_t *a: pointer to in/output polynomial
-**************************************************/
-void poly_invntt_tomont(poly *r)
-{
-    invntt(r->coeffs);
-}
-
-/*************************************************
 * Name:        poly_basemul_montgomery
 *
 * Description: Multiplication of two polynomials in NTT domain

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -129,10 +129,6 @@ void poly_getnoise_eta1122_4x(poly *r0,
                               uint8_t nonce2,
                               uint8_t nonce3);
 
-#define poly_ntt KYBER_NAMESPACE(poly_ntt)
-void poly_ntt(poly *r);
-#define poly_invntt_tomont KYBER_NAMESPACE(poly_invntt_tomont)
-void poly_invntt_tomont(poly *r);
 #define poly_basemul_montgomery KYBER_NAMESPACE(poly_basemul_montgomery)
 void poly_basemul_montgomery(poly *r, const poly *a, const poly *b);
 #define poly_basemul_montgomery_cached KYBER_NAMESPACE(poly_basemul_montgomery_cached)

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include "params.h"
 #include "poly.h"
+#include "ntt.h"
 #include "polyvec.h"
 #include "config.h"
 #include "asm/asm.h"


### PR DESCRIPTION
This PR removes the indirection `poly_[inv]ntt() -> [inv]ntt()` and instead defines [inv]NTT as operating on `poly` directly.

It also removes an unnecessary double Barrett reduction at the end of the AArch64 NTT.