### PR TITLE
cbmc: Move contracts to separate header

### DIFF
--- a/cbmc/proofs/Makefile.common
+++ b/cbmc/proofs/Makefile.common
@@ -319,6 +319,7 @@ ADD_LIBRARY_FLAG := --add-library
 # Preprocessor include paths -I...
 INCLUDES ?=
 INCLUDES += -I$(PROOFDIR)
+INCLUDES += -I$(PROOFDIR)/../specs
 INCLUDES += -I$(SRCDIR)/mlkem -I$(SRCDIR)/mlkem/sys
 INCLUDES += -I$(SRCDIR)/fips202
 

--- a/cbmc/proofs/poly_compress/poly_compress_harness.c
+++ b/cbmc/proofs/poly_compress/poly_compress_harness.c
@@ -9,7 +9,7 @@
  * @file poly_compress_harness.c
  * @brief Implements the proof harness for poly_compress function.
  */
-#include "poly.h"
+#include <poly_specs.h>
 
 /*
  * Insert project header files that

--- a/cbmc/proofs/poly_decompress/poly_decompress_harness.c
+++ b/cbmc/proofs/poly_decompress/poly_decompress_harness.c
@@ -15,7 +15,7 @@
  *   - include the declaration of the function
  *   - include the types needed to declare function arguments
  */
-#include "poly.h"
+#include <poly_specs.h>
 
 /**
  * @brief Starting point for formal analysis

--- a/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
+++ b/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
@@ -15,7 +15,7 @@
  *   - include the declaration of the function
  *   - include the types needed to declare function arguments
  */
-#include <poly.h>
+#include <poly_specs.h>
 
 /**
  * @brief Starting point for formal analysis

--- a/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
+++ b/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
@@ -15,7 +15,7 @@
  *   - include the declaration of the function
  *   - include the types needed to declare function arguments
  */
-#include <poly.h>
+#include <poly_specs.h>
 
 /**
  * @brief Starting point for formal analysis

--- a/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
@@ -15,7 +15,7 @@
  *   - include the declaration of the function
  *   - include the types needed to declare function arguments
  */
-#include <poly.h>
+#include <poly_specs.h>
 
 /**
  * @brief Starting point for formal analysis

--- a/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
@@ -15,7 +15,7 @@
  *   - include the declaration of the function
  *   - include the types needed to declare function arguments
  */
-#include <poly.h>
+#include <poly_specs.h>
 
 /**
  * @brief Starting point for formal analysis

--- a/cbmc/proofs/scalar_signed_to_unsigned_q_16/scalar_signed_to_unsigned_q_16_harness.c
+++ b/cbmc/proofs/scalar_signed_to_unsigned_q_16/scalar_signed_to_unsigned_q_16_harness.c
@@ -15,7 +15,7 @@
  *   - include the declaration of the function
  *   - include the types needed to declare function arguments
  */
-#include <poly.h>
+#include <poly_specs.h>
 
 /**
  * @brief Starting point for formal analysis

--- a/cbmc/proofs/specs/poly_specs.h
+++ b/cbmc/proofs/specs/poly_specs.h
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef POLY_SPECS_H
+#define POLY_SPECS_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "params.h"
+#include "cbmc.h"
+
+/*
+ * Elements of R_q = Z_q[X]/(X^n + 1). Represents polynomial
+ * coeffs[0] + X*coeffs[1] + X^2*coeffs[2] + ... + X^{n-1}*coeffs[n-1]
+ */
+typedef struct
+{
+    int16_t coeffs[KYBER_N];
+} ALIGN(16) poly;
+
+/*
+ * INTERNAL presentation of precomputed data speeding up
+ * the base multiplication of two polynomials in NTT domain.
+ */
+// REF-CHANGE: This structure does not exist in the reference
+// implementation.
+typedef struct
+{
+    int16_t coeffs[KYBER_N >> 1];
+} poly_mulcache;
+
+#define scalar_compress_q_16 KYBER_NAMESPACE(scalar_compress_q_16)
+#define scalar_decompress_q_16 KYBER_NAMESPACE(scalar_decompress_q_16)
+#define scalar_compress_q_32 KYBER_NAMESPACE(scalar_compress_q_32)
+#define scalar_decompress_q_32 KYBER_NAMESPACE(scalar_decompress_q_32)
+#define scalar_signed_to_unsigned_q_16 KYBER_NAMESPACE(scalar_signed_to_unsigned_q_16)
+#define poly_compress KYBER_NAMESPACE(poly_compress)
+#define poly_decompress KYBER_NAMESPACE(poly_decompress)
+
+uint32_t scalar_compress_q_16   (int32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < KYBER_Q)
+__CPROVER_ensures(__CPROVER_return_value < 16)
+__CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 16 + KYBER_Q / 2) / KYBER_Q) % 16);
+/* INDENT-ON */
+
+uint32_t scalar_decompress_q_16 (uint32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < 16)
+__CPROVER_ensures(__CPROVER_return_value < KYBER_Q);
+/* INDENT-ON */
+
+uint32_t scalar_compress_q_32   (int32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < KYBER_Q)
+__CPROVER_ensures(__CPROVER_return_value < 32)
+__CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 32 + KYBER_Q / 2) / KYBER_Q) % 32);
+/* INDENT-ON */
+
+uint32_t scalar_decompress_q_32 (uint32_t u)
+/* INDENT-OFF */
+__CPROVER_requires(0 <= u && u < 32)
+__CPROVER_ensures(__CPROVER_return_value < KYBER_Q);
+/* INDENT-ON */
+
+uint16_t scalar_signed_to_unsigned_q_16 (int16_t c)
+/* *INDENT-OFF* */
+__CPROVER_requires(c > -KYBER_Q) // c >= -3328
+__CPROVER_requires(c < KYBER_Q)  // c <= 3328
+__CPROVER_ensures(__CPROVER_return_value >= 0)
+__CPROVER_ensures(__CPROVER_return_value < KYBER_Q)
+__CPROVER_ensures(__CPROVER_return_value == (int32_t) c + (((int32_t) c < 0) * KYBER_Q));
+/* *INDENT-ON* */
+
+void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)
+/* *INDENT-OFF* */
+__CPROVER_requires(r != NULL)
+__CPROVER_requires(__CPROVER_is_fresh(r, KYBER_POLYCOMPRESSEDBYTES))
+__CPROVER_requires(a != NULL)
+__CPROVER_requires(__CPROVER_is_fresh(a, sizeof(poly)))
+__CPROVER_requires(__CPROVER_forall { unsigned k; (k < KYBER_N) ==> ( -KYBER_Q < a->coeffs[k] && a->coeffs[k] < KYBER_Q ) })
+__CPROVER_assigns(__CPROVER_object_whole(r));
+/* *INDENT-ON* */
+
+#undef scalar_compress_q_16
+#undef scalar_decompress_q_16
+#undef scalar_compress_q_32
+#undef scalar_decompress_q_32
+#undef scalar_signed_to_unsigned_q_16
+#undef poly_compress
+#undef poly_decompress
+
+
+// Include to ensure that signature changes in poly.h are reflected here.
+#include <poly.h>
+
+#endif

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -27,58 +27,24 @@ typedef struct
     int16_t coeffs[KYBER_N >> 1];
 } poly_mulcache;
 
-#define scalar_compress_q_16           KYBER_NAMESPACE(scalar_compress_q_16)
-#define scalar_decompress_q_16         KYBER_NAMESPACE(scalar_decompress_q_16)
-#define scalar_compress_q_32           KYBER_NAMESPACE(scalar_compress_q_32)
-#define scalar_decompress_q_32         KYBER_NAMESPACE(scalar_decompress_q_32)
+
+#define scalar_compress_q_16 KYBER_NAMESPACE(scalar_compress_q_16)
+uint32_t scalar_compress_q_16 (int32_t u);
+
+#define scalar_decompress_q_16 KYBER_NAMESPACE(scalar_decompress_q_16)
+uint32_t scalar_decompress_q_16 (uint32_t u);
+
+#define scalar_compress_q_32 KYBER_NAMESPACE(scalar_compress_q_32)
+uint32_t scalar_compress_q_32 (int32_t u);
+
+#define scalar_decompress_q_32 KYBER_NAMESPACE(scalar_decompress_q_32)
+uint32_t scalar_decompress_q_32 (uint32_t u);
+
 #define scalar_signed_to_unsigned_q_16 KYBER_NAMESPACE(scalar_signed_to_unsigned_q_16)
-
-uint32_t scalar_compress_q_16   (int32_t u)
-/* INDENT-OFF */
-__CPROVER_requires(0 <= u && u < KYBER_Q)
-__CPROVER_ensures(__CPROVER_return_value < 16)
-__CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 16 + KYBER_Q / 2) / KYBER_Q) % 16);
-/* INDENT-ON */
-
-uint32_t scalar_decompress_q_16 (uint32_t u)
-/* INDENT-OFF */
-__CPROVER_requires(0 <= u && u < 16)
-__CPROVER_ensures(__CPROVER_return_value < KYBER_Q);
-/* INDENT-ON */
-
-uint32_t scalar_compress_q_32   (int32_t u)
-/* INDENT-OFF */
-__CPROVER_requires(0 <= u && u < KYBER_Q)
-__CPROVER_ensures(__CPROVER_return_value < 32)
-__CPROVER_ensures(__CPROVER_return_value == (((uint32_t) u * 32 + KYBER_Q / 2) / KYBER_Q) % 32);
-/* INDENT-ON */
-
-uint32_t scalar_decompress_q_32 (uint32_t u)
-/* INDENT-OFF */
-__CPROVER_requires(0 <= u && u < 32)
-__CPROVER_ensures(__CPROVER_return_value < KYBER_Q);
-/* INDENT-ON */
-
-uint16_t scalar_signed_to_unsigned_q_16 (int16_t c)
-/* *INDENT-OFF* */
-__CPROVER_requires(c > -KYBER_Q) // c >= -3328
-__CPROVER_requires(c < KYBER_Q)  // c <= 3328
-__CPROVER_ensures(__CPROVER_return_value >= 0)
-__CPROVER_ensures(__CPROVER_return_value < KYBER_Q)
-__CPROVER_ensures(__CPROVER_return_value == (int32_t) c + (((int32_t) c < 0) * KYBER_Q));
-/* *INDENT-ON* */
+uint16_t scalar_signed_to_unsigned_q_16 (int16_t c);
 
 #define poly_compress KYBER_NAMESPACE(poly_compress)
-void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)
-/* *INDENT-OFF* */
-__CPROVER_requires(r != NULL)
-__CPROVER_requires(__CPROVER_is_fresh(r, KYBER_POLYCOMPRESSEDBYTES))
-__CPROVER_requires(a != NULL)
-__CPROVER_requires(__CPROVER_is_fresh(a, sizeof(poly)))
-__CPROVER_requires(__CPROVER_forall { unsigned k; (k < KYBER_N) ==> ( -KYBER_Q < a->coeffs[k] && a->coeffs[k] < KYBER_Q ) })
-__CPROVER_assigns(__CPROVER_object_whole(r));
-/* *INDENT-ON* */
-
+void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a);
 
 #define poly_decompress KYBER_NAMESPACE(poly_decompress)
 void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES]);


### PR DESCRIPTION
CBMC annotations should be organized so that they clutter the main code base as little as possible.

This commit moves the CBMC specs written so far from `poly.h` into a new header `poly_specs.h` that's in the `cbmc/` subdirectory, keeping the original `poly.h` from the reference implementation.

An alternative could be to make the annotations less cryptic by introducing abbreviations like

```
    #define CONTRACT_ASSERT(...)      __CPROVER_assert(__VA_ARGS__)
    #define CONTRACT_ASSIGNS(...)     __CPROVER_assigns(__VA_ARGS__)
    #define CONTRACT_ASSIGNS_ERR(...) CONTRACT_ASSIGNS(__VA_ARGS__, _s2n_debug_info, s2n_errno)
    #define CONTRACT_ASSUME(...)      __CPROVER_assume(__VA_ARGS__)
    #define CONTRACT_REQUIRES(...)    __CPROVER_requires(__VA_ARGS__)
    #define CONTRACT_ENSURES(...)     __CPROVER_ensures(__VA_ARGS__)
    #define CONTRACT_INVARIANT(...)   __CPROVER_loop_invariant(__VA_ARGS__)
    #define CONTRACT_RETURN_VALUE     (__CPROVER_return_value)
    #define CONTRACT_ASSERT(...)
    #define CONTRACT_ASSIGNS(...)
    #define CONTRACT_ASSIGNS_ERR(...)
    #define CONTRACT_ASSUME(...)
    #define CONTRACT_REQUIRES(...)
    #define CONTRACT_ENSURES(...)
    #define CONTRACT_INVARIANT(...)
    #define CONTRACT_RETURN_VALUE
```

which is the approach taken by
s2n-tls (https://github.com/aws/s2n-tls/blob/ff610637368c31ef7bea5e3e5814c30af64263de/utils/s2n_ensure.h#L130).

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
