### PR TITLE
Add binary for benchmarking MLKEM components

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -62,6 +62,7 @@ runs:
       shell: ${{ env.SHELL }}
       run: |
         tests bench -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --arch-flags="${{ inputs.archflags }}" --opt="${{ inputs.opt }}" -v --output=output.json ${{ inputs.bench_extra_args }}
+        tests bench --components -c ${{ inputs.perf }} --cross-prefix="${{ inputs.cross_prefix }}" --cflags="${{ inputs.cflags }}" --arch-flags="${{ inputs.archflags }}" --opt="${{ inputs.opt }}" -v --output=output.json ${{ inputs.bench_extra_args }}
     - name: Store benchmark result
       if: ${{ inputs.store_results == 'true' }}
       uses: benchmark-action/github-action-benchmark@v1

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ bench: \
 	$(MLKEM768_DIR)/bin/bench_kyber768 \
 	$(MLKEM1024_DIR)/bin/bench_kyber1024
 
+bench_components: \
+	$(MLKEM512_DIR)/bin/bench_components_kyber512 \
+	$(MLKEM768_DIR)/bin/bench_components_kyber768 \
+	$(MLKEM1024_DIR)/bin/bench_components_kyber1024
+
 nistkat: \
 	$(MLKEM512_DIR)/bin/gen_NISTKAT512 \
 	$(MLKEM768_DIR)/bin/gen_NISTKAT768 \

--- a/mk/bench_components.mk
+++ b/mk/bench_components.mk
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+LIBDEPS += $(LIB_DIR)/libhal.a
+LDLIBS += -lhal
+CPPFLAGS += -Itest/hal
+$(LIB_DIR)/libhal.a: $(call OBJS,$(wildcard test/hal/*.c))

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -6,7 +6,7 @@ ifeq ($(OPT),1)
 endif
 
 CPPFLAGS += -Imlkem -Imlkem/sys
-TESTS = test_kyber bench_kyber gen_NISTKAT gen_KAT
+TESTS = test_kyber bench_kyber bench_components_kyber gen_NISTKAT gen_KAT
 
 MLKEM512_DIR = $(BUILD_DIR)/mlkem512
 MLKEM768_DIR = $(BUILD_DIR)/mlkem768

--- a/scripts/tests
+++ b/scripts/tests
@@ -30,6 +30,7 @@ class TEST_TYPES(Enum):
     BENCH = 2
     NISTKAT = 3
     KAT = 4
+    BENCH_COMPONENTS = 5
 
     def __str__(self):
         return self.name.lower()
@@ -40,6 +41,8 @@ class TEST_TYPES(Enum):
                 return "Functional Test"
             case TEST_TYPES.BENCH:
                 return "Benchmark"
+            case TEST_TYPES.BENCH_COMPONENTS:
+                return "Benchmark Components"
             case TEST_TYPES.NISTKAT:
                 return "Nistkat Test"
             case TEST_TYPES.KAT:
@@ -51,6 +54,8 @@ class TEST_TYPES(Enum):
                 return "test_kyber"
             case TEST_TYPES.BENCH:
                 return "bench_kyber"
+            case TEST_TYPES.BENCH_COMPONENTS:
+                return "bench_components_kyber"
             case TEST_TYPES.NISTKAT:
                 return "gen_NISTKAT"
             case TEST_TYPES.KAT:
@@ -307,6 +312,56 @@ _shared_options = [
     ),
 ]
 
+_bench_options = [
+    click.option(
+        "-c",
+        "--cycles",
+        nargs=1,
+        type=click.Choice(["NO", "PMU", "PERF", "M1"]),
+        show_default=True,
+        default="NO",
+        help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. M1 only works on Apple silicon.",
+    ),
+    click.option(
+        "-o",
+        "--output",
+        nargs=1,
+        help="Path to output file in json format",
+    ),
+    click.option(
+        "-r",
+        "--run-as-root",
+        is_flag=True,
+        show_default=True,
+        default=False,
+        type=bool,
+        help="Benchmarking binary is run with sudo.",
+    ),
+    click.option(
+        "-w",
+        "--exec-wrapper",
+        help="Run the benchmark binary with the user-customized wrapper.",
+    ),
+    click.option(
+        "-t",
+        "--mac-taskpolicy",
+        nargs=1,
+        type=click.Choice(["utility", "background", "maintenance"]),
+        hidden=platform.system() != "Darwin",
+        show_default=True,
+        default=None,
+        help="Run the program using the specified QoS clamp. Applies to MacOS only. Setting this flag to 'background' guarantees running on E-cores. This is an abbreviation of --exec-wrapper 'taskpolicy -c {mac_taskpolicy}'.",
+    ),
+    click.option(
+        "--components",
+        is_flag=True,
+        type=bool,
+        show_default=True,
+        default=False,
+        help="Benchmark low-level components",
+    ),
+]
+
 
 def add_options(options):
     return lambda func: reduce(lambda f, o: o(f), reversed(options), func)
@@ -391,45 +446,7 @@ def kat(force_qemu, verbose, cross_prefix, cflags, arch_flags, opt):
     context_settings={"show_default": True},
 )
 @add_options(_shared_options)
-@click.option(
-    "-c",
-    "--cycles",
-    nargs=1,
-    type=click.Choice(["NO", "PMU", "PERF", "M1"]),
-    show_default=True,
-    default="NO",
-    help="Method for counting clock cycles. PMU requires (user-space) access to the Arm Performance Monitor Unit (PMU). PERF requires a kernel with perf support. M1 only works on Apple silicon.",
-)
-@click.option(
-    "-o",
-    "--output",
-    nargs=1,
-    help="Path to output file in json format",
-)
-@click.option(
-    "-r",
-    "--run-as-root",
-    is_flag=True,
-    show_default=True,
-    default=False,
-    type=bool,
-    help="Benchmarking binary is run with sudo.",
-)
-@click.option(
-    "-w",
-    "--exec-wrapper",
-    help="Run the benchmark binary with the user-customized wrapper.",
-)
-@click.option(
-    "-t",
-    "--mac-taskpolicy",
-    nargs=1,
-    type=click.Choice(["utility", "background", "maintenance"]),
-    hidden=platform.system() != "Darwin",
-    show_default=True,
-    default=None,
-    help="Run the program using the specified QoS clamp. Applies to MacOS only. Setting this flag to 'background' guarantees running on E-cores. This is an abbreviation of --exec-wrapper 'taskpolicy -c {mac_taskpolicy}'.",
-)
+@add_options(_bench_options)
 def bench(
     force_qemu,
     verbose,
@@ -442,6 +459,7 @@ def bench(
     run_as_root,
     exec_wrapper,
     mac_taskpolicy,
+    components,
 ):
     config_logger(verbose)
 
@@ -452,8 +470,14 @@ def bench(
         else:
             exec_wrapper = f"taskpolicy -c {mac_taskpolicy}"
 
+    if components is False:
+        bench_type = TEST_TYPES.BENCH
+    else:
+        bench_type = TEST_TYPES.BENCH_COMPONENTS
+        output = False
+
     results = test_schemes(
-        TEST_TYPES.BENCH,
+        bench_type,
         lambda _: True,
         lambda _: True,
         process_bench,
@@ -469,7 +493,7 @@ def bench(
         ],
     )
 
-    if output:
+    if output is True and components is False:
         import json
 
         with open(output, "w") as f:

--- a/test/bench_components_kyber.c
+++ b/test/bench_components_kyber.c
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include "kem.h"
+#include "hal.h"
+#include "randombytes.h"
+
+#include "keccakf1600.h"
+#include "../mlkem/asm/asm.h"
+
+#define NWARMUP 50
+#define NITERERATIONS 300
+#define NTESTS 200
+
+static int cmp_uint64_t(const void *a, const void *b)
+{
+    return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));
+}
+
+#define BENCH(txt,code)                                   \
+    for (i = 0; i < NTESTS; i++)                          \
+    {                                                     \
+        randombytes((uint8_t*)data0, sizeof(data0));      \
+        randombytes((uint8_t*)data1, sizeof(data1));      \
+        randombytes((uint8_t*)data2, sizeof(data2));      \
+        randombytes((uint8_t*)data3, sizeof(data3));      \
+        for (j = 0; j < NWARMUP; j++)                     \
+        {                                                 \
+            code;                                         \
+        }                                                 \
+        \
+        t0 = get_cyclecounter();                          \
+        for (j = 0; j < NITERERATIONS; j++)               \
+        {                                                 \
+            code;                                         \
+        }                                                 \
+        t1 = get_cyclecounter();                          \
+        (cyc)[i] = t1 - t0;                               \
+    }                                                     \
+    qsort((cyc), NTESTS, sizeof(uint64_t), cmp_uint64_t); \
+    printf(txt " cycles=%"PRIu64"\n",                  \
+           (cyc)[NTESTS >> 1]/NITERERATIONS);
+
+static int bench(void)
+{
+    uint64_t data0[1024];
+    uint64_t data1[1024];
+    uint64_t data2[1024];
+    uint64_t data3[1024];
+    uint64_t cyc[NTESTS];
+
+    unsigned int i, j;
+    uint64_t t0, t1;
+
+    BENCH("keccak-f1600-x1", KeccakF1600_StatePermute(data0));
+    BENCH("keccak-f1600-x4", KeccakF1600x4_StatePermute(data0));
+
+    #if defined(MLKEM_USE_AARCH64_ASM)
+    BENCH("ntt-clean", ntt_asm_clean((int16_t *)data0));
+    BENCH("intt-clean", intt_asm_clean((int16_t *)data0));
+    BENCH("poly-reduce-clean", poly_reduce_asm_clean((int16_t *)data0));
+    BENCH("poly-tomont-clean", poly_tomont_asm_clean((int16_t *)data0));
+    BENCH("poly-tobytes-clean", poly_tobytes_asm_clean((uint8_t *) data0, (int16_t *)data1));
+    BENCH("poly-mulcache-compute-clean",                                  \
+          poly_mulcache_compute_asm_clean(                                \
+                  (int16_t *) data0, (int16_t *) data1,                           \
+                  (int16_t *) data2, (int16_t *) data3));
+    BENCH("poly-basemul-acc-montgomery-clean",                            \
+          polyvec_basemul_acc_montgomery_cached_asm_clean_name(KYBER_K) ( \
+                  (int16_t *) data0, (int16_t *) data1,                           \
+                  (int16_t *) data2, (int16_t *) data3));
+
+    BENCH("ntt-opt", ntt_asm_opt((int16_t *)data0));
+    BENCH("intt-opt", intt_asm_opt((int16_t *)data0));
+    BENCH("poly-reduce-opt", poly_reduce_asm_opt((int16_t *)data0));
+    BENCH("poly-tomont-opt", poly_tomont_asm_opt((int16_t *)data0));
+    BENCH("poly-mulcache-compute-opt",                                    \
+          poly_mulcache_compute_asm_opt(                                  \
+                  (int16_t *) data0, (int16_t *) data1,                           \
+                  (int16_t *) data2, (int16_t *) data3));
+    BENCH("poly-basemul-acc-montgomery-opt",                              \
+          polyvec_basemul_acc_montgomery_cached_asm_opt_name(KYBER_K) (   \
+                  (int16_t *) data0, (int16_t *) data1,                           \
+                  (int16_t *) data2, (int16_t *) data3));
+    #endif
+
+    return 0;
+}
+
+int main(void)
+{
+    enable_cyclecounter();
+    bench();
+    disable_cyclecounter();
+
+    return 0;
+}


### PR DESCRIPTION
Until now, `tests bench` would only give performance numbers for the MLKEM toplevel API. While most interesting to the user, the developer needs more insight into where cycles are spent.

This commit introdues `tests bench --components`, backed by a new benchmarking binary `bench_components_kyber{512,768,1024}`, benchmarking various performance critical components of MLKEM.

For now, there is one binary per security level, despite all benchmarks except for the base multiplication being the same for all levels. This is mostly to fit easily into the existing makefile framework, and will likely need refining.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
