### PR TITLE
tests: Fix bug in export of benchmarking results

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -493,7 +493,7 @@ def bench(
         ],
     )
 
-    if output is True and components is False:
+    if output is not None and components is False:
         import json
 
         with open(output, "w") as f:


### PR DESCRIPTION
Symptom: `scripts/tests` does no longer write benchmarking outputs, which leads to subsequent invocations of the `benchmark-action` failing. This only happens _after_ merge to `main`, as the call to `benchmark-action` is skipped otherwise.

Bug: A previous commit replaced an `if output` check by `if output is True` in the wrong assumption that `output` is a boolean. Instead, it's `None` or a string, so the previous version of the check is necessary.

This commit reverts the respective change.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
