### PR TITLE
Fix CI workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 
 name: CI
 on:
+  workflow_dispatch:
   push:
     branches: ["*"]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches: ["*"]
   pull_request:
     branches: ["main"]
-    types: [ "labeled" ]
 jobs:
   build_kat:
     strategy:
@@ -101,7 +100,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     uses: ./.github/workflows/ci_ec2_reusable.yml
-    if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'ci' || github.ref == 'refs/heads/main')
+    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
     with:
       name: ${{ matrix.target.name }}
       ec2_instance_type: ${{ matrix.target.ec2_instance_type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     uses: ./.github/workflows/ci_ec2_reusable.yml
-    if: github.repository_owner == 'pq-code-package' && !github.event.pull_request.head.repo.fork
+    if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'ci' || !github.event.pull_request.head.repo.fork)
     with:
       name: ${{ matrix.target.name }}
       ec2_instance_type: ${{ matrix.target.ec2_instance_type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: ["*"]
   pull_request:
     branches: ["main"]
+    types: [ "labeled", "synchronize" ]
 jobs:
   build_kat:
     strategy:


### PR DESCRIPTION
Run the CI workflow automatically as before, 
enable re-running it by adding a label, 
and ensure the CI ec2 workflow only runs if the PR is created from the main repository.