### PR TITLE
Adoption of clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# clang-format style file for MLKEM-C
+#
+# This is based on the style for for AWS-LC
+#
+BasedOnStyle: Google
+MaxEmptyLinesToKeep: 3
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+DerivePointerAlignment: false
+PointerAlignment: Right
+# TODO(davidben): The default for Google style is now Regroup, but the default
+# IncludeCategories does not recognize <openssl/header.h>. We should
+# reconfigure IncludeCategories to match. For now, keep it at Preserve.
+IncludeBlocks: Preserve
+
+# Designate CBMC contracts/macros that appear in .h files
+# as "attributes" so they don't get increasingly indented line after line
+AttributeMacros: ['REQUIRES', 'ENSURES', 'ASSIGNS']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,16 +86,18 @@ jobs:
         target:
           - name: AMD EPYC 4th gen (t3a)
             ec2_instance_type: t3a.small
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu-latest (custom AMI)
+            ec2_ami_id: ami-0d47e137a1108e078 # x86_64 ubuntu-latest, 32g
             cbmc: 'false'
           - name: Intel Xeon 4th gen (t3)
             ec2_instance_type: t3.small
-            ec2_ami: ubuntu-latest (x86_64)
+            ec2_ami: ubuntu-latest (custom AMI)
+            ec2_ami_id: ami-0d47e137a1108e078 # x86_64 ubuntu-latest, 32g
             cbmc: 'false'
           - name: Graviton3, CBMC (c7g.4xlarge)
             ec2_instance_type: c7g.4xlarge
             ec2_ami: ubuntu-latest (custom AMI)
-            ec2_ami_id: ami-08ddb0acd99dc3d33
+            ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
             cbmc: 'true'
     name: ${{ matrix.target.name }}
     permissions:

--- a/cbmc/proofs/poly_compress/poly_compress_harness.c
+++ b/cbmc/proofs/poly_compress/poly_compress_harness.c
@@ -21,10 +21,9 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void)
-{
-    poly r;
-    uint8_t a[KYBER_POLYCOMPRESSEDBYTES];
+void harness(void) {
+  poly r;
+  uint8_t a[KYBER_POLYCOMPRESSEDBYTES];
 
-    poly_compress(a, &r);
+  poly_compress(a, &r);
 }

--- a/cbmc/proofs/poly_decompress/poly_decompress_harness.c
+++ b/cbmc/proofs/poly_decompress/poly_decompress_harness.c
@@ -21,10 +21,9 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void)
-{
-    poly r;
-    uint8_t a[KYBER_POLYCOMPRESSEDBYTES];
+void harness(void) {
+  poly r;
+  uint8_t a[KYBER_POLYCOMPRESSEDBYTES];
 
-    poly_decompress(&r, a);
+  poly_decompress(&r, a);
 }

--- a/cbmc/proofs/poly_tobytes/poly_tobytes_harness.c
+++ b/cbmc/proofs/poly_tobytes/poly_tobytes_harness.c
@@ -1,14 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT-0
 
 /*
  * Insert copyright notice
  */
 
 /**
- * @file scalar_signed_to_unsigned_q_16.c
- * @brief Implements the proof harness for scalar_signed_to_unsigned_q_16
- * function.
+ * @file poly_tobytes_harness.c
+ * @brief Implements the proof harness for poly_tobytes function.
  */
 
 /*
@@ -23,8 +22,9 @@
  *
  */
 void harness(void) {
-  int16_t u;
+  poly a;
+  uint8_t r[KYBER_POLYBYTES];
 
   /* Contracts for this function are in poly.h */
-  uint16_t d = scalar_signed_to_unsigned_q_16(u);
+  poly_tobytes(r, &a);
 }

--- a/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
+++ b/cbmc/proofs/scalar_compress_q_16/scalar_compress_q_16_harness.c
@@ -21,10 +21,9 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void)
-{
-    int32_t u;
+void harness(void) {
+  int32_t u;
 
-    /* Contracts for this function are in poly.h */
-    uint32_t d = scalar_compress_q_16(u);
+  /* Contracts for this function are in poly.h */
+  uint32_t d = scalar_compress_q_16(u);
 }

--- a/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
+++ b/cbmc/proofs/scalar_compress_q_32/scalar_compress_q_32_harness.c
@@ -21,10 +21,9 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void)
-{
-    int32_t u;
+void harness(void) {
+  int32_t u;
 
-    /* Contracts for this function are in poly.h */
-    uint32_t d = scalar_compress_q_32(u);
+  /* Contracts for this function are in poly.h */
+  uint32_t d = scalar_compress_q_32(u);
 }

--- a/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_16/scalar_decompress_q_16_harness.c
@@ -21,12 +21,12 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void)
-{
-    // Check that decompression followed by compression is the identity
-    uint32_t c0, c1, d;
+void harness(void) {
+  // Check that decompression followed by compression is the identity
+  uint32_t c0, c1, d;
 
-    d = scalar_decompress_q_16(c0);
-    c1 = scalar_compress_q_16(d);
-    __CPROVER_assert(c0 == c1, "scalar_compress_q_16 o scalar_decompress_q_16 != id");
+  d = scalar_decompress_q_16(c0);
+  c1 = scalar_compress_q_16(d);
+  __CPROVER_assert(c0 == c1,
+                   "scalar_compress_q_16 o scalar_decompress_q_16 != id");
 }

--- a/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
+++ b/cbmc/proofs/scalar_decompress_q_32/scalar_decompress_q_32_harness.c
@@ -21,12 +21,12 @@
  * @brief Starting point for formal analysis
  *
  */
-void harness(void)
-{
-    // Check that decompression followed by compression is the identity
-    uint32_t c0, c1, d;
+void harness(void) {
+  // Check that decompression followed by compression is the identity
+  uint32_t c0, c1, d;
 
-    d = scalar_decompress_q_32(c0);
-    c1 = scalar_compress_q_32(d);
-    __CPROVER_assert(c0 == c1, "scalar_compress_q_32 o scalar_decompress_q_32 != id");
+  d = scalar_decompress_q_32(c0);
+  c1 = scalar_compress_q_32(d);
+  __CPROVER_assert(c0 == c1,
+                   "scalar_compress_q_32 o scalar_decompress_q_32 != id");
 }

--- a/fips202/asm/asm.h
+++ b/fips202/asm/asm.h
@@ -3,8 +3,8 @@
 #define FIPS202_ASM_H
 
 #include <stdint.h>
-#include "params.h"
 #include "config.h"
+#include "params.h"
 
 #ifdef MLKEM_USE_AARCH64_ASM
 void keccak_f1600_x1_scalar_asm_opt(uint64_t *state);
@@ -43,7 +43,7 @@ void keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt(uint64_t *state);
 
 // Pick exactly one profile from the following list
 #include "profiles/default.h"
-//#include "profiles/cortex_a55.h"
+// #include "profiles/cortex_a55.h"
 
 #else /* !FIPS202_ASM_PROFILE && FIPS202_ASM_MANUAL */
 

--- a/fips202/fips202.c
+++ b/fips202/fips202.c
@@ -23,66 +23,57 @@
  * Description: Absorb step of Keccak;
  *              non-incremental, starts by zeroeing the state.
  *
- * Arguments:   - uint64_t *s:       pointer to (uninitialized) output Keccak state
+ * Arguments:   - uint64_t *s:       pointer to (uninitialized) output Keccak
+ *state
  *              - uint32_t r:        rate in bytes (e.g., 168 for SHAKE128)
  *              - const uint8_t *m:  pointer to input to be absorbed into s
  *              - size_t mlen:       length of input in bytes
- *              - uint8_t p:         domain-separation byte for different Keccak-derived functions
+ *              - uint8_t p:         domain-separation byte for different
+ *Keccak-derived functions
  **************************************************/
-static void keccak_absorb(uint64_t *s,
-                          uint32_t r,
-                          const uint8_t *m, size_t mlen,
-                          uint8_t p)
-{
-    while (mlen >= r)
-    {
-        KeccakF1600_StateXORBytes(s, m, 0, r);
-        KeccakF1600_StatePermute(s);
-        mlen -= r;
-        m += r;
-    }
+static void keccak_absorb(uint64_t *s, uint32_t r, const uint8_t *m,
+                          size_t mlen, uint8_t p) {
+  while (mlen >= r) {
+    KeccakF1600_StateXORBytes(s, m, 0, r);
+    KeccakF1600_StatePermute(s);
+    mlen -= r;
+    m += r;
+  }
 
-    if (mlen > 0)
-    {
-        KeccakF1600_StateXORBytes(s, m, 0, mlen);
-    }
+  if (mlen > 0) {
+    KeccakF1600_StateXORBytes(s, m, 0, mlen);
+  }
 
-    if (mlen == r - 1)
-    {
-        p |= 128;
-        KeccakF1600_StateXORBytes(s, &p, mlen, 1);
-    }
-    else
-    {
-        KeccakF1600_StateXORBytes(s, &p, mlen, 1);
-        p = 128;
-        KeccakF1600_StateXORBytes(s, &p, r - 1, 1);
-    }
+  if (mlen == r - 1) {
+    p |= 128;
+    KeccakF1600_StateXORBytes(s, &p, mlen, 1);
+  } else {
+    KeccakF1600_StateXORBytes(s, &p, mlen, 1);
+    p = 128;
+    KeccakF1600_StateXORBytes(s, &p, r - 1, 1);
+  }
 }
 
 /*************************************************
  * Name:        keccak_squeezeblocks
  *
  * Description: Squeeze step of Keccak. Squeezes full blocks of r bytes each.
- *              Modifies the state. Can be called multiple times to keep squeezing,
- *              i.e., is incremental.
+ *              Modifies the state. Can be called multiple times to keep
+ *squeezing, i.e., is incremental.
  *
  * Arguments:   - uint8_t *h:     pointer to output blocks
  *              - size_t nblocks: number of blocks to be squeezed (written to h)
  *              - uint64_t *s:    pointer to in/output Keccak state
  *              - uint32_t r:     rate in bytes (e.g., 168 for SHAKE128)
  **************************************************/
-static void keccak_squeezeblocks(uint8_t *h, size_t nblocks,
-                                 uint64_t *s,
-                                 uint32_t r)
-{
-    while (nblocks > 0)
-    {
-        KeccakF1600_StatePermute(s);
-        KeccakF1600_StateExtractBytes(s, h, 0, r);
-        h += r;
-        nblocks--;
-    }
+static void keccak_squeezeblocks(uint8_t *h, size_t nblocks, uint64_t *s,
+                                 uint32_t r) {
+  while (nblocks > 0) {
+    KeccakF1600_StatePermute(s);
+    KeccakF1600_StateExtractBytes(s, h, 0, r);
+    h += r;
+    nblocks--;
+  }
 }
 
 /*************************************************
@@ -95,15 +86,13 @@ static void keccak_squeezeblocks(uint8_t *h, size_t nblocks,
  *                26th value represents either the number of absorbed bytes
  *                that have not been permuted, or not-yet-squeezed bytes.
  **************************************************/
-static void keccak_inc_init(uint64_t *s_inc)
-{
-    size_t i;
+static void keccak_inc_init(uint64_t *s_inc) {
+  size_t i;
 
-    for (i = 0; i < 25; ++i)
-    {
-        s_inc[i] = 0;
-    }
-    s_inc[25] = 0;
+  for (i = 0; i < 25; ++i) {
+    s_inc[i] = 0;
+  }
+  s_inc[25] = 0;
 }
 /*************************************************
  * Name:        keccak_inc_absorb
@@ -120,22 +109,19 @@ static void keccak_inc_init(uint64_t *s_inc)
  *              - size_t mlen: length of input in bytes
  **************************************************/
 static void keccak_inc_absorb(uint64_t *s_inc, uint32_t r, const uint8_t *m,
-                              size_t mlen)
-{
-    /* Recall that s_inc[25] is the non-absorbed bytes xored into the state */
-    while (mlen + s_inc[25] >= r)
-    {
+                              size_t mlen) {
+  /* Recall that s_inc[25] is the non-absorbed bytes xored into the state */
+  while (mlen + s_inc[25] >= r) {
+    KeccakF1600_StateXORBytes(s_inc, m, s_inc[25], r - s_inc[25]);
+    mlen -= (size_t)(r - s_inc[25]);
+    m += r - s_inc[25];
+    s_inc[25] = 0;
 
-        KeccakF1600_StateXORBytes(s_inc, m, s_inc[25], r - s_inc[25]);
-        mlen -= (size_t)(r - s_inc[25]);
-        m += r - s_inc[25];
-        s_inc[25] = 0;
+    KeccakF1600_StatePermute(s_inc);
+  }
 
-        KeccakF1600_StatePermute(s_inc);
-    }
-
-    KeccakF1600_StateXORBytes(s_inc, m, s_inc[25], mlen);
-    s_inc[25] += mlen;
+  KeccakF1600_StateXORBytes(s_inc, m, s_inc[25], mlen);
+  s_inc[25] += mlen;
 }
 
 /*************************************************
@@ -151,22 +137,18 @@ static void keccak_inc_absorb(uint64_t *s_inc, uint32_t r, const uint8_t *m,
  *              - uint8_t p: domain-separation byte for different
  *                                 Keccak-derived functions
  **************************************************/
-static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p)
-{
-    /* After keccak_inc_absorb, we are guaranteed that s_inc[25] < r,
-       so we can always use one more byte for p in the current state. */
-    if (s_inc[25] == r - 1)
-    {
-        p |= 128;
-        KeccakF1600_StateXORBytes(s_inc, &p, s_inc[25], 1);
-    }
-    else
-    {
-        KeccakF1600_StateXORBytes(s_inc, &p, s_inc[25], 1);
-        p = 128;
-        KeccakF1600_StateXORBytes(s_inc, &p, r - 1, 1);
-    }
-    s_inc[25] = 0;
+static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p) {
+  /* After keccak_inc_absorb, we are guaranteed that s_inc[25] < r,
+     so we can always use one more byte for p in the current state. */
+  if (s_inc[25] == r - 1) {
+    p |= 128;
+    KeccakF1600_StateXORBytes(s_inc, &p, s_inc[25], 1);
+  } else {
+    KeccakF1600_StateXORBytes(s_inc, &p, s_inc[25], 1);
+    p = 128;
+    KeccakF1600_StateXORBytes(s_inc, &p, r - 1, 1);
+  }
+  s_inc[25] = 0;
 }
 
 /*************************************************
@@ -182,62 +164,50 @@ static void keccak_inc_finalize(uint64_t *s_inc, uint32_t r, uint8_t p)
  *                that have not been permuted, or not-yet-squeezed bytes.
  *              - uint32_t r: rate in bytes (e.g., 168 for SHAKE128)
  **************************************************/
-static void keccak_inc_squeeze(uint8_t *h, size_t outlen,
-                               uint64_t *s_inc, uint32_t r)
-{
-    size_t len;
-    if (outlen < s_inc[25])
-    {
-        len = outlen;
-    }
-    else
-    {
-        len = s_inc[25];
-    }
+static void keccak_inc_squeeze(uint8_t *h, size_t outlen, uint64_t *s_inc,
+                               uint32_t r) {
+  size_t len;
+  if (outlen < s_inc[25]) {
+    len = outlen;
+  } else {
+    len = s_inc[25];
+  }
 
-    KeccakF1600_StateExtractBytes(s_inc, h, r - s_inc[25], len);
+  KeccakF1600_StateExtractBytes(s_inc, h, r - s_inc[25], len);
+  h += len;
+  outlen -= len;
+  s_inc[25] -= len;
+
+  /* Then squeeze the remaining necessary blocks */
+  while (outlen > 0) {
+    KeccakF1600_StatePermute(s_inc);
+
+    if (outlen < r) {
+      len = outlen;
+    } else {
+      len = r;
+    }
+    KeccakF1600_StateExtractBytes(s_inc, h, 0, len);
     h += len;
     outlen -= len;
-    s_inc[25] -= len;
-
-    /* Then squeeze the remaining necessary blocks */
-    while (outlen > 0)
-    {
-        KeccakF1600_StatePermute(s_inc);
-
-        if (outlen < r)
-        {
-            len = outlen;
-        }
-        else
-        {
-            len = r;
-        }
-        KeccakF1600_StateExtractBytes(s_inc, h, 0, len);
-        h += len;
-        outlen -= len;
-        s_inc[25] = r - len;
-    }
+    s_inc[25] = r - len;
+  }
 }
 
-void shake256_inc_init(shake256incctx *state)
-{
-    keccak_inc_init(state->ctx);
+void shake256_inc_init(shake256incctx *state) { keccak_inc_init(state->ctx); }
+
+void shake256_inc_absorb(shake256incctx *state, const uint8_t *input,
+                         size_t inlen) {
+  keccak_inc_absorb(state->ctx, SHAKE256_RATE, input, inlen);
 }
 
-void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen)
-{
-    keccak_inc_absorb(state->ctx, SHAKE256_RATE, input, inlen);
+void shake256_inc_finalize(shake256incctx *state) {
+  keccak_inc_finalize(state->ctx, SHAKE256_RATE, 0x1F);
 }
 
-void shake256_inc_finalize(shake256incctx *state)
-{
-    keccak_inc_finalize(state->ctx, SHAKE256_RATE, 0x1F);
-}
-
-void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state)
-{
-    keccak_inc_squeeze(output, outlen, state->ctx, SHAKE256_RATE);
+void shake256_inc_squeeze(uint8_t *output, size_t outlen,
+                          shake256incctx *state) {
+  keccak_inc_squeeze(output, outlen, state->ctx, SHAKE256_RATE);
 }
 
 /*************************************************
@@ -246,35 +216,36 @@ void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state)
  * Description: Absorb step of the SHAKE128 XOF.
  *              non-incremental, starts by zeroeing the state.
  *
- * Arguments:   - uint64_t *state:      pointer to (uninitialized) output Keccak state
- *              - const uint8_t *input: pointer to input to be absorbed into state
+ * Arguments:   - uint64_t *state:      pointer to (uninitialized) output Keccak
+ *state
+ *              - const uint8_t *input: pointer to input to be absorbed into
+ *state
  *              - size_t inlen:         length of input in bytes
  **************************************************/
-void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen)
-{
-    int i;
-    for (i = 0; i < 25; i++)
-    {
-        state->ctx[i] = 0;
-    }
+void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen) {
+  int i;
+  for (i = 0; i < 25; i++) {
+    state->ctx[i] = 0;
+  }
 
-    keccak_absorb(state->ctx, SHAKE128_RATE, input, inlen, 0x1F);
+  keccak_absorb(state->ctx, SHAKE128_RATE, input, inlen, 0x1F);
 }
 
 /*************************************************
  * Name:        shake128_squeezeblocks
  *
- * Description: Squeeze step of SHAKE128 XOF. Squeezes full blocks of SHAKE128_RATE bytes each.
- *              Modifies the state. Can be called multiple times to keep squeezing,
- *              i.e., is incremental.
+ * Description: Squeeze step of SHAKE128 XOF. Squeezes full blocks of
+ *SHAKE128_RATE bytes each. Modifies the state. Can be called multiple times to
+ *keep squeezing, i.e., is incremental.
  *
  * Arguments:   - uint8_t *output:     pointer to output blocks
- *              - size_t nblocks:      number of blocks to be squeezed (written to output)
+ *              - size_t nblocks:      number of blocks to be squeezed (written
+ *to output)
  *              - shake128ctx *state:  pointer to in/output Keccak state
  **************************************************/
-void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
-{
-    keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE128_RATE);
+void shake128_squeezeblocks(uint8_t *output, size_t nblocks,
+                            shake128ctx *state) {
+  keccak_squeezeblocks(output, nblocks, state->ctx, SHAKE128_RATE);
 }
 
 /*************************************************
@@ -287,19 +258,18 @@ void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state)
  *              - const uint8_t *input: pointer to input
  *              - size_t inlen:         length of input in bytes
  **************************************************/
-void shake256(uint8_t *output, size_t outlen,
-              const uint8_t *input, size_t inlen)
-{
-    shake256incctx state;
+void shake256(uint8_t *output, size_t outlen, const uint8_t *input,
+              size_t inlen) {
+  shake256incctx state;
 
-    keccak_inc_init(state.ctx);
+  keccak_inc_init(state.ctx);
 
-    /* Absorb input */
-    keccak_inc_absorb(state.ctx, SHAKE256_RATE, input, inlen);
-    keccak_inc_finalize(state.ctx, SHAKE256_RATE, 0x1F);
+  /* Absorb input */
+  keccak_inc_absorb(state.ctx, SHAKE256_RATE, input, inlen);
+  keccak_inc_finalize(state.ctx, SHAKE256_RATE, 0x1F);
 
-    /* Squeeze output */
-    keccak_inc_squeeze(output, outlen, state.ctx, SHAKE256_RATE);
+  /* Squeeze output */
+  keccak_inc_squeeze(output, outlen, state.ctx, SHAKE256_RATE);
 }
 
 /*************************************************
@@ -311,17 +281,16 @@ void shake256(uint8_t *output, size_t outlen,
  *              - const uint8_t *input: pointer to input
  *              - size_t inlen:         length of input in bytes
  **************************************************/
-void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen)
-{
-    uint64_t ctx[26];
-    keccak_inc_init(ctx);
+void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen) {
+  uint64_t ctx[26];
+  keccak_inc_init(ctx);
 
-    /* Absorb input */
-    keccak_inc_absorb(ctx, SHA3_256_RATE, input, inlen);
-    keccak_inc_finalize(ctx, SHA3_256_RATE, 0x06);
+  /* Absorb input */
+  keccak_inc_absorb(ctx, SHA3_256_RATE, input, inlen);
+  keccak_inc_finalize(ctx, SHA3_256_RATE, 0x06);
 
-    /* Squeeze output */
-    keccak_inc_squeeze(output, 32, ctx, SHA3_256_RATE);
+  /* Squeeze output */
+  keccak_inc_squeeze(output, 32, ctx, SHA3_256_RATE);
 }
 
 /*************************************************
@@ -333,15 +302,14 @@ void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen)
  *              - const uint8_t *input: pointer to input
  *              - size_t inlen:         length of input in bytes
  **************************************************/
-void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen)
-{
-    uint64_t ctx[26];
-    keccak_inc_init(ctx);
+void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen) {
+  uint64_t ctx[26];
+  keccak_inc_init(ctx);
 
-    /* Absorb input */
-    keccak_inc_absorb(ctx, SHA3_512_RATE, input, inlen);
-    keccak_inc_finalize(ctx, SHA3_512_RATE, 0x06);
+  /* Absorb input */
+  keccak_inc_absorb(ctx, SHA3_512_RATE, input, inlen);
+  keccak_inc_finalize(ctx, SHA3_512_RATE, 0x06);
 
-    /* Squeeze output */
-    keccak_inc_squeeze(output, 64, ctx, SHA3_512_RATE);
+  /* Squeeze output */
+  keccak_inc_squeeze(output, 64, ctx, SHA3_512_RATE);
 }

--- a/fips202/fips202.h
+++ b/fips202/fips202.h
@@ -12,27 +12,23 @@
 #define SHA3_512_RATE 72
 
 // Context for incremental API
-typedef struct
-{
-    uint64_t ctx[26];
+typedef struct {
+  uint64_t ctx[26];
 } shake128incctx;
 
 // Context for non-incremental API
-typedef struct
-{
-    uint64_t ctx[25];
+typedef struct {
+  uint64_t ctx[25];
 } shake128ctx;
 
 // Context for incremental API
-typedef struct
-{
-    uint64_t ctx[26];
+typedef struct {
+  uint64_t ctx[26];
 } shake256incctx;
 
 // Context for non-incremental API
-typedef struct
-{
-    uint64_t ctx[25];
+typedef struct {
+  uint64_t ctx[25];
 } shake256ctx;
 
 /* Initialize the state and absorb the provided input.
@@ -45,11 +41,13 @@ void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen);
  *
  * Supports being called multiple times
  */
-void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state);
+void shake128_squeezeblocks(uint8_t *output, size_t nblocks,
+                            shake128ctx *state);
 
 /* Initialize incremental hashing API */
 void shake256_inc_init(shake256incctx *state);
-void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen);
+void shake256_inc_absorb(shake256incctx *state, const uint8_t *input,
+                         size_t inlen);
 /* Prepares for squeeze phase */
 void shake256_inc_finalize(shake256incctx *state);
 
@@ -57,11 +55,12 @@ void shake256_inc_finalize(shake256incctx *state);
  *
  * Supports being called multiple times
  */
-void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state);
+void shake256_inc_squeeze(uint8_t *output, size_t outlen,
+                          shake256incctx *state);
 
 /* One-stop SHAKE256 call */
-void shake256(uint8_t *output, size_t outlen,
-              const uint8_t *input, size_t inlen);
+void shake256(uint8_t *output, size_t outlen, const uint8_t *input,
+              size_t inlen);
 
 /* One-stop SHA3-256 shop */
 void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen);

--- a/fips202/fips202x4.c
+++ b/fips202/fips202x4.c
@@ -1,147 +1,108 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <string.h>
 #include "fips202x4.h"
+#include <string.h>
 #include "fips202.h"
 #include "keccakf1600.h"
 
-static void keccak_absorb_x4(keccakx4_state *ctxt,
-                             uint32_t r,
-                             const uint8_t *in0,
-                             const uint8_t *in1,
-                             const uint8_t *in2,
-                             const uint8_t *in3,
-                             size_t inlen,
-                             uint8_t p)
-{
-    uint64_t *s = (uint64_t *) ctxt;
+static void keccak_absorb_x4(keccakx4_state *ctxt, uint32_t r,
+                             const uint8_t *in0, const uint8_t *in1,
+                             const uint8_t *in2, const uint8_t *in3,
+                             size_t inlen, uint8_t p) {
+  uint64_t *s = (uint64_t *)ctxt;
 
-    while (inlen >= r)
-    {
-        KeccakF1600x4_StateXORBytes(s, in0, in1, in2, in3, 0, r);
-        KeccakF1600x4_StatePermute(s);
+  while (inlen >= r) {
+    KeccakF1600x4_StateXORBytes(s, in0, in1, in2, in3, 0, r);
+    KeccakF1600x4_StatePermute(s);
 
-        in0 += r;
-        in1 += r;
-        in2 += r;
-        in3 += r;
-        inlen -= r;
-    }
+    in0 += r;
+    in1 += r;
+    in2 += r;
+    in3 += r;
+    inlen -= r;
+  }
 
-    if (inlen > 0)
-    {
-        KeccakF1600x4_StateXORBytes(s, in0, in1, in2, in3, 0, inlen);
-    }
+  if (inlen > 0) {
+    KeccakF1600x4_StateXORBytes(s, in0, in1, in2, in3, 0, inlen);
+  }
 
-    if (inlen == r - 1)
-    {
-        p |= 128;
-        KeccakF1600x4_StateXORBytes(s, &p, &p, &p, &p, inlen, 1);
-    }
-    else
-    {
-        KeccakF1600x4_StateXORBytes(s, &p, &p, &p, &p, inlen, 1);
-        p = 128;
-        KeccakF1600x4_StateXORBytes(s, &p, &p, &p, &p, r-1, 1);
-    }
+  if (inlen == r - 1) {
+    p |= 128;
+    KeccakF1600x4_StateXORBytes(s, &p, &p, &p, &p, inlen, 1);
+  } else {
+    KeccakF1600x4_StateXORBytes(s, &p, &p, &p, &p, inlen, 1);
+    p = 128;
+    KeccakF1600x4_StateXORBytes(s, &p, &p, &p, &p, r - 1, 1);
+  }
 }
 
-static void keccak_squeezeblocks_x4(uint8_t *out0,
-                                    uint8_t *out1,
-                                    uint8_t *out2,
-                                    uint8_t *out3,
-                                    size_t nblocks,
-                                    keccakx4_state *ctxt,
-                                    uint32_t r)
-{
-    uint64_t *s = (uint64_t *) ctxt;
+static void keccak_squeezeblocks_x4(uint8_t *out0, uint8_t *out1, uint8_t *out2,
+                                    uint8_t *out3, size_t nblocks,
+                                    keccakx4_state *ctxt, uint32_t r) {
+  uint64_t *s = (uint64_t *)ctxt;
 
-    while (nblocks > 0)
-    {
-        KeccakF1600x4_StatePermute(s);
-        KeccakF1600x4_StateExtractBytes(s, out0, out1, out2, out3, 0, r);
+  while (nblocks > 0) {
+    KeccakF1600x4_StatePermute(s);
+    KeccakF1600x4_StateExtractBytes(s, out0, out1, out2, out3, 0, r);
 
-        out0 += r;
-        out1 += r;
-        out2 += r;
-        out3 += r;
-        nblocks--;
-    }
+    out0 += r;
+    out1 += r;
+    out2 += r;
+    out3 += r;
+    nblocks--;
+  }
 }
 
-void shake128x4_absorb(keccakx4_state *state,
-                       const uint8_t *in0,
-                       const uint8_t *in1,
-                       const uint8_t *in2,
-                       const uint8_t *in3,
-                       size_t inlen)
-{
-    memset(state, 0, sizeof(keccakx4_state));
-    keccak_absorb_x4(state, SHAKE128_RATE, in0, in1, in2, in3, inlen, 0x1F);
+void shake128x4_absorb(keccakx4_state *state, const uint8_t *in0,
+                       const uint8_t *in1, const uint8_t *in2,
+                       const uint8_t *in3, size_t inlen) {
+  memset(state, 0, sizeof(keccakx4_state));
+  keccak_absorb_x4(state, SHAKE128_RATE, in0, in1, in2, in3, inlen, 0x1F);
 }
 
-void shake256x4_absorb(keccakx4_state *state,
-                       const uint8_t *in0,
-                       const uint8_t *in1,
-                       const uint8_t *in2,
-                       const uint8_t *in3,
-                       size_t inlen)
-{
-    memset(state, 0, sizeof(keccakx4_state));
-    keccak_absorb_x4(state, SHAKE256_RATE, in0, in1, in2, in3, inlen, 0x1F);
+void shake256x4_absorb(keccakx4_state *state, const uint8_t *in0,
+                       const uint8_t *in1, const uint8_t *in2,
+                       const uint8_t *in3, size_t inlen) {
+  memset(state, 0, sizeof(keccakx4_state));
+  keccak_absorb_x4(state, SHAKE256_RATE, in0, in1, in2, in3, inlen, 0x1F);
 }
 
 
-void shake128x4_squeezeblocks(uint8_t *out0,
-                              uint8_t *out1,
-                              uint8_t *out2,
-                              uint8_t *out3,
-                              size_t nblocks,
-                              keccakx4_state *state)
-{
-    keccak_squeezeblocks_x4(out0, out1, out2, out3, nblocks, state, SHAKE128_RATE);
+void shake128x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
+                              uint8_t *out3, size_t nblocks,
+                              keccakx4_state *state) {
+  keccak_squeezeblocks_x4(out0, out1, out2, out3, nblocks, state,
+                          SHAKE128_RATE);
 }
 
-void shake256x4_squeezeblocks(uint8_t *out0,
-                              uint8_t *out1,
-                              uint8_t *out2,
-                              uint8_t *out3,
-                              size_t nblocks,
-                              keccakx4_state *state)
-{
-    keccak_squeezeblocks_x4(out0, out1, out2, out3, nblocks, state, SHAKE256_RATE);
+void shake256x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
+                              uint8_t *out3, size_t nblocks,
+                              keccakx4_state *state) {
+  keccak_squeezeblocks_x4(out0, out1, out2, out3, nblocks, state,
+                          SHAKE256_RATE);
 }
 
-void shake256x4(uint8_t *out0,
-                uint8_t *out1,
-                uint8_t *out2,
-                uint8_t *out3,
-                size_t outlen,
-                uint8_t *in0,
-                uint8_t *in1,
-                uint8_t *in2,
-                uint8_t *in3,
-                size_t inlen)
-{
-    keccakx4_state statex;
-    size_t nblocks = outlen/SHAKE256_RATE;
-    uint8_t tmp[KECCAK_WAY][SHAKE256_RATE];
+void shake256x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3,
+                size_t outlen, uint8_t *in0, uint8_t *in1, uint8_t *in2,
+                uint8_t *in3, size_t inlen) {
+  keccakx4_state statex;
+  size_t nblocks = outlen / SHAKE256_RATE;
+  uint8_t tmp[KECCAK_WAY][SHAKE256_RATE];
 
-    shake256x4_absorb(&statex, in0, in1, in2, in3, inlen);
-    shake256x4_squeezeblocks(out0, out1, out2, out3, nblocks, &statex);
+  shake256x4_absorb(&statex, in0, in1, in2, in3, inlen);
+  shake256x4_squeezeblocks(out0, out1, out2, out3, nblocks, &statex);
 
-    out0 += nblocks * SHAKE256_RATE;
-    out1 += nblocks * SHAKE256_RATE;
-    out2 += nblocks * SHAKE256_RATE;
-    out3 += nblocks * SHAKE256_RATE;
+  out0 += nblocks * SHAKE256_RATE;
+  out1 += nblocks * SHAKE256_RATE;
+  out2 += nblocks * SHAKE256_RATE;
+  out3 += nblocks * SHAKE256_RATE;
 
-    outlen -= nblocks * SHAKE256_RATE;
+  outlen -= nblocks * SHAKE256_RATE;
 
-    if (outlen)
-    {
-        shake256x4_squeezeblocks(tmp[0], tmp[1], tmp[2], tmp[3], 1, &statex);
-        memcpy(out0, tmp[0], outlen);
-        memcpy(out1, tmp[1], outlen);
-        memcpy(out2, tmp[2], outlen);
-        memcpy(out3, tmp[3], outlen);
-    }
+  if (outlen) {
+    shake256x4_squeezeblocks(tmp[0], tmp[1], tmp[2], tmp[3], 1, &statex);
+    memcpy(out0, tmp[0], outlen);
+    memcpy(out1, tmp[1], outlen);
+    memcpy(out2, tmp[2], outlen);
+    memcpy(out3, tmp[3], outlen);
+  }
 }

--- a/fips202/fips202x4.h
+++ b/fips202/fips202x4.h
@@ -2,48 +2,30 @@
 #ifndef FIPS_202X4_H
 #define FIPS_202X4_H
 
-#include "keccakf1600.h"
+#include <stddef.h>
 #include <stdint.h>
+#include "keccakf1600.h"
 
-void shake128x4_absorb(keccakx4_state *state,
-                       const uint8_t *in0,
-                       const uint8_t *in1,
-                       const uint8_t *in2,
-                       const uint8_t *in3,
-                       size_t inlen);
+void shake128x4_absorb(keccakx4_state *state, const uint8_t *in0,
+                       const uint8_t *in1, const uint8_t *in2,
+                       const uint8_t *in3, size_t inlen);
 
-void shake256x4_absorb(keccakx4_state *state,
-                       const uint8_t *in0,
-                       const uint8_t *in1,
-                       const uint8_t *in2,
-                       const uint8_t *in3,
-                       size_t inlen);
+void shake256x4_absorb(keccakx4_state *state, const uint8_t *in0,
+                       const uint8_t *in1, const uint8_t *in2,
+                       const uint8_t *in3, size_t inlen);
 
 
-void shake128x4_squeezeblocks(uint8_t *out0,
-                              uint8_t *out1,
-                              uint8_t *out2,
-                              uint8_t *out3,
-                              size_t nblocks,
+void shake128x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
+                              uint8_t *out3, size_t nblocks,
                               keccakx4_state *state);
 
-void shake256x4_squeezeblocks(uint8_t *out0,
-                              uint8_t *out1,
-                              uint8_t *out2,
-                              uint8_t *out3,
-                              size_t nblocks,
+void shake256x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
+                              uint8_t *out3, size_t nblocks,
                               keccakx4_state *state);
 
 
-void shake256x4(uint8_t *out0,
-                uint8_t *out1,
-                uint8_t *out2,
-                uint8_t *out3,
-                size_t outlen,
-                uint8_t *in0,
-                uint8_t *in1,
-                uint8_t *in2,
-                uint8_t *in3,
-                size_t inlen);
+void shake256x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3,
+                size_t outlen, uint8_t *in0, uint8_t *in1, uint8_t *in2,
+                uint8_t *in3, size_t inlen);
 
 #endif

--- a/fips202/keccakf1600.c
+++ b/fips202/keccakf1600.c
@@ -7,469 +7,440 @@
  * from https://twitter.com/tweetfips202
  * by Gilles Van Assche, Daniel J. Bernstein, and Peter Schwabe */
 
-#include <stdint.h>
-#include <assert.h>
 #include "keccakf1600.h"
+#include <assert.h>
+#include <stdint.h>
 
 #include "asm/asm.h"
 #include "config.h"
 
 
 #define NROUNDS 24
-#define ROL(a, offset) ((a << offset) ^ (a >> (64-offset)))
+#define ROL(a, offset) ((a << offset) ^ (a >> (64 - offset)))
 
-void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data, unsigned int offset, unsigned int length)
-{
-    #if defined(SYS_LITTLE_ENDIAN)
-    uint8_t *state_ptr = (uint8_t *) state + offset;
-    for (unsigned int i=0; i < length; i++ )
-    {
-        data[i] = state_ptr[i];
-    }
-    #else /* SYS_LITTLE_ENDIAN */
-    // Portable version
-    unsigned int i;
-    for (i = 0; i < length; i++)
-    {
-        data[i] = state[(offset + i) >> 3] >> (8 * ((offset + i) & 0x07));
-    }
-    #endif /* SYS_LITTLE_ENDIAN */
+void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data,
+                                   unsigned int offset, unsigned int length) {
+#if defined(SYS_LITTLE_ENDIAN)
+  uint8_t *state_ptr = (uint8_t *)state + offset;
+  for (unsigned int i = 0; i < length; i++) {
+    data[i] = state_ptr[i];
+  }
+#else  /* SYS_LITTLE_ENDIAN */
+  // Portable version
+  unsigned int i;
+  for (i = 0; i < length; i++) {
+    data[i] = state[(offset + i) >> 3] >> (8 * ((offset + i) & 0x07));
+  }
+#endif /* SYS_LITTLE_ENDIAN */
 }
 
-void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data, unsigned int offset, unsigned int length)
-{
-    #if defined(SYS_LITTLE_ENDIAN)
-    uint8_t *state_ptr = (uint8_t *) state + offset;
-    for (unsigned int i=0; i < length; i++ )
-    {
-        state_ptr[i] ^= data[i];
-    }
-    #else /* SYS_LITTLE_ENDIAN */
-    // Portable version
-    unsigned int i;
-    for (i = 0; i < length; i++)
-    {
-        state[(offset + i) >> 3] ^= (uint64_t)data[i] << (8 * ((offset + i) & 0x07));
-    }
-    #endif /* SYS_LITTLE_ENDIAN */
+void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data,
+                               unsigned int offset, unsigned int length) {
+#if defined(SYS_LITTLE_ENDIAN)
+  uint8_t *state_ptr = (uint8_t *)state + offset;
+  for (unsigned int i = 0; i < length; i++) {
+    state_ptr[i] ^= data[i];
+  }
+#else  /* SYS_LITTLE_ENDIAN */
+  // Portable version
+  unsigned int i;
+  for (i = 0; i < length; i++) {
+    state[(offset + i) >> 3] ^= (uint64_t)data[i]
+                                << (8 * ((offset + i) & 0x07));
+  }
+#endif /* SYS_LITTLE_ENDIAN */
 }
 
-void KeccakF1600x4_StateExtractBytes(uint64_t *state,
-                                     unsigned char *data0,
-                                     unsigned char *data1,
-                                     unsigned char *data2,
-                                     unsigned char *data3,
-                                     unsigned int offset,
-                                     unsigned int length)
-{
-    KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 0, data0, offset, length);
-    KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 1, data1, offset, length);
-    KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 2, data2, offset, length);
-    KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 3, data3, offset, length);
+void KeccakF1600x4_StateExtractBytes(uint64_t *state, unsigned char *data0,
+                                     unsigned char *data1, unsigned char *data2,
+                                     unsigned char *data3, unsigned int offset,
+                                     unsigned int length) {
+  KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 0, data0, offset,
+                                length);
+  KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 1, data1, offset,
+                                length);
+  KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 2, data2, offset,
+                                length);
+  KeccakF1600_StateExtractBytes(state + KECCAK_LANES * 3, data3, offset,
+                                length);
 }
 
-void KeccakF1600x4_StateXORBytes(uint64_t *state,
-                                 const unsigned char *data0,
+void KeccakF1600x4_StateXORBytes(uint64_t *state, const unsigned char *data0,
                                  const unsigned char *data1,
                                  const unsigned char *data2,
                                  const unsigned char *data3,
-                                 unsigned int offset, unsigned int length)
-{
-
-    KeccakF1600_StateXORBytes(state + KECCAK_LANES * 0, data0, offset, length);
-    KeccakF1600_StateXORBytes(state + KECCAK_LANES * 1, data1, offset, length);
-    KeccakF1600_StateXORBytes(state + KECCAK_LANES * 2, data2, offset, length);
-    KeccakF1600_StateXORBytes(state + KECCAK_LANES * 3, data3, offset, length);
+                                 unsigned int offset, unsigned int length) {
+  KeccakF1600_StateXORBytes(state + KECCAK_LANES * 0, data0, offset, length);
+  KeccakF1600_StateXORBytes(state + KECCAK_LANES * 1, data1, offset, length);
+  KeccakF1600_StateXORBytes(state + KECCAK_LANES * 2, data2, offset, length);
+  KeccakF1600_StateXORBytes(state + KECCAK_LANES * 3, data3, offset, length);
 }
 
-#if defined(MLKEM_USE_FIPS202_X2_ASM) && defined(MLKEM_USE_FIPS202_X2_ASM_ZIPPED)
+#if defined(MLKEM_USE_FIPS202_X2_ASM) && \
+    defined(MLKEM_USE_FIPS202_X2_ASM_ZIPPED)
 #include <string.h>
 // TODO: This should either be integrated into the batched Keccak ASM,
 // or we should keep the Keccak state in deinterleaved form throughout,
 // but transpose the inputs/outputs of {Extract,XOR}Bytes functions.
-static void keccakx2_zip(uint64_t *state)
-{
-    uint64_t tmp[2 * KECCAK_LANES];
-    for (unsigned i=0; i < 2; i++)
-        for (unsigned j=0; j < KECCAK_LANES; j++)
-        {
-            tmp[2*j + i] = state[KECCAK_LANES*i + j];
-        }
+static void keccakx2_zip(uint64_t *state) {
+  uint64_t tmp[2 * KECCAK_LANES];
+  for (unsigned i = 0; i < 2; i++)
+    for (unsigned j = 0; j < KECCAK_LANES; j++) {
+      tmp[2 * j + i] = state[KECCAK_LANES * i + j];
+    }
 
-    memcpy(state, tmp, sizeof(tmp));
+  memcpy(state, tmp, sizeof(tmp));
 }
 
-static void keccakx2_unzip(uint64_t *state)
-{
-    uint64_t tmp[2 * KECCAK_LANES];
-    for (unsigned i=0; i < 2; i++)
-        for (unsigned j=0; j < KECCAK_LANES; j++)
-        {
-            tmp[KECCAK_LANES*i + j] = state[2*j + i];
-        }
+static void keccakx2_unzip(uint64_t *state) {
+  uint64_t tmp[2 * KECCAK_LANES];
+  for (unsigned i = 0; i < 2; i++)
+    for (unsigned j = 0; j < KECCAK_LANES; j++) {
+      tmp[KECCAK_LANES * i + j] = state[2 * j + i];
+    }
 
-    memcpy(state, tmp, sizeof(tmp));
+  memcpy(state, tmp, sizeof(tmp));
 }
 #endif
 
-#if defined(MLKEM_USE_FIPS202_X4_ASM) && defined(MLKEM_USE_FIPS202_X4_ASM_ZIPPED)
+#if defined(MLKEM_USE_FIPS202_X4_ASM) && \
+    defined(MLKEM_USE_FIPS202_X4_ASM_ZIPPED)
 #include <string.h>
 // TODO: This should either be integrated into the batched Keccak ASM,
 // or we should keep the Keccak state in deinterleaved form throughout,
 // but transpose the inputs/outputs of {Extract,XOR}Bytes functions.
-static void keccakx4_zip(uint64_t *state)
-{
-    uint64_t tmp[4 * KECCAK_LANES];
-    for (unsigned i=0; i < 4; i++)
-        for (unsigned j=0; j < KECCAK_LANES; j++)
-        {
-            tmp[4*j + i] = state[KECCAK_LANES*i + j];
-        }
+static void keccakx4_zip(uint64_t *state) {
+  uint64_t tmp[4 * KECCAK_LANES];
+  for (unsigned i = 0; i < 4; i++)
+    for (unsigned j = 0; j < KECCAK_LANES; j++) {
+      tmp[4 * j + i] = state[KECCAK_LANES * i + j];
+    }
 
-    memcpy(state, tmp, sizeof(tmp));
+  memcpy(state, tmp, sizeof(tmp));
 }
 
-static void keccakx4_unzip(uint64_t *state)
-{
-    uint64_t tmp[4 * KECCAK_LANES];
-    for (unsigned i=0; i < 4; i++)
-        for (unsigned j=0; j < KECCAK_LANES; j++)
-        {
-            tmp[KECCAK_LANES*i + j] = state[4*j + i];
-        }
+static void keccakx4_unzip(uint64_t *state) {
+  uint64_t tmp[4 * KECCAK_LANES];
+  for (unsigned i = 0; i < 4; i++)
+    for (unsigned j = 0; j < KECCAK_LANES; j++) {
+      tmp[KECCAK_LANES * i + j] = state[4 * j + i];
+    }
 
-    memcpy(state, tmp, sizeof(tmp));
+  memcpy(state, tmp, sizeof(tmp));
 }
 #endif
 
-void KeccakF1600x4_StatePermute(uint64_t *state)
-{
-    #if defined(MLKEM_USE_FIPS202_X4_ASM)
+void KeccakF1600x4_StatePermute(uint64_t *state) {
+#if defined(MLKEM_USE_FIPS202_X4_ASM)
 
-    #if defined(MLKEM_USE_FIPS202_X4_ASM_ZIPPED)
-    keccakx4_zip(state);
-    #endif /* MLKEM_USE_FIPS202_X4_ASM_ZIPPED */
-    keccak_f1600_x4_asm(state);
-    #if defined(MLKEM_USE_FIPS202_X4_ASM_ZIPPED)
-    keccakx4_unzip(state);
-    #endif /* MLKEM_USE_FIPS202_X4_ASM_ZIPPED */
+#if defined(MLKEM_USE_FIPS202_X4_ASM_ZIPPED)
+  keccakx4_zip(state);
+#endif /* MLKEM_USE_FIPS202_X4_ASM_ZIPPED */
+  keccak_f1600_x4_asm(state);
+#if defined(MLKEM_USE_FIPS202_X4_ASM_ZIPPED)
+  keccakx4_unzip(state);
+#endif /* MLKEM_USE_FIPS202_X4_ASM_ZIPPED */
 
-    #elif defined(MLKEM_USE_FIPS202_X2_ASM)
+#elif defined(MLKEM_USE_FIPS202_X2_ASM)
 
-    #if defined(MLKEM_USE_FIPS202_X2_ASM_ZIPPED)
-    keccakx2_zip(state + 0 * KECCAK_LANES);
-    keccakx2_zip(state + 2 * KECCAK_LANES);
-    #endif /* MLKEM_USE_FIPS202_X2_ASM_ZIPPED */
-    keccak_f1600_x2_asm(state + 0 * KECCAK_LANES);
-    keccak_f1600_x2_asm(state + 2 * KECCAK_LANES);
-    #if defined(MLKEM_USE_FIPS202_X2_ASM_ZIPPED)
-    keccakx2_unzip(state + 0 * KECCAK_LANES);
-    keccakx2_unzip(state + 2 * KECCAK_LANES);
-    #endif /* MLKEM_USE_FIPS202_X2_ASM_ZIPPED */
+#if defined(MLKEM_USE_FIPS202_X2_ASM_ZIPPED)
+  keccakx2_zip(state + 0 * KECCAK_LANES);
+  keccakx2_zip(state + 2 * KECCAK_LANES);
+#endif /* MLKEM_USE_FIPS202_X2_ASM_ZIPPED */
+  keccak_f1600_x2_asm(state + 0 * KECCAK_LANES);
+  keccak_f1600_x2_asm(state + 2 * KECCAK_LANES);
+#if defined(MLKEM_USE_FIPS202_X2_ASM_ZIPPED)
+  keccakx2_unzip(state + 0 * KECCAK_LANES);
+  keccakx2_unzip(state + 2 * KECCAK_LANES);
+#endif /* MLKEM_USE_FIPS202_X2_ASM_ZIPPED */
 
-    #else /* !MLKEM_USE_FIPS202_X2_ASM && !MLKEM_USE_FIPS202_X4_ASM */
+#else /* !MLKEM_USE_FIPS202_X2_ASM && !MLKEM_USE_FIPS202_X4_ASM */
 
-    KeccakF1600_StatePermute(state + KECCAK_LANES * 0);
-    KeccakF1600_StatePermute(state + KECCAK_LANES * 1);
-    KeccakF1600_StatePermute(state + KECCAK_LANES * 2);
-    KeccakF1600_StatePermute(state + KECCAK_LANES * 3);
+  KeccakF1600_StatePermute(state + KECCAK_LANES * 0);
+  KeccakF1600_StatePermute(state + KECCAK_LANES * 1);
+  KeccakF1600_StatePermute(state + KECCAK_LANES * 2);
+  KeccakF1600_StatePermute(state + KECCAK_LANES * 3);
 
-    #endif
+#endif
 }
 
 #if !defined(MLKEM_USE_FIPS202_X1_ASM)
-static const uint64_t KeccakF_RoundConstants[NROUNDS] =
-{
-    (uint64_t)0x0000000000000001ULL,
-    (uint64_t)0x0000000000008082ULL,
-    (uint64_t)0x800000000000808aULL,
-    (uint64_t)0x8000000080008000ULL,
-    (uint64_t)0x000000000000808bULL,
-    (uint64_t)0x0000000080000001ULL,
-    (uint64_t)0x8000000080008081ULL,
-    (uint64_t)0x8000000000008009ULL,
-    (uint64_t)0x000000000000008aULL,
-    (uint64_t)0x0000000000000088ULL,
-    (uint64_t)0x0000000080008009ULL,
-    (uint64_t)0x000000008000000aULL,
-    (uint64_t)0x000000008000808bULL,
-    (uint64_t)0x800000000000008bULL,
-    (uint64_t)0x8000000000008089ULL,
-    (uint64_t)0x8000000000008003ULL,
-    (uint64_t)0x8000000000008002ULL,
-    (uint64_t)0x8000000000000080ULL,
-    (uint64_t)0x000000000000800aULL,
-    (uint64_t)0x800000008000000aULL,
-    (uint64_t)0x8000000080008081ULL,
-    (uint64_t)0x8000000000008080ULL,
-    (uint64_t)0x0000000080000001ULL,
-    (uint64_t)0x8000000080008008ULL
-};
+static const uint64_t KeccakF_RoundConstants[NROUNDS] = {
+    (uint64_t)0x0000000000000001ULL, (uint64_t)0x0000000000008082ULL,
+    (uint64_t)0x800000000000808aULL, (uint64_t)0x8000000080008000ULL,
+    (uint64_t)0x000000000000808bULL, (uint64_t)0x0000000080000001ULL,
+    (uint64_t)0x8000000080008081ULL, (uint64_t)0x8000000000008009ULL,
+    (uint64_t)0x000000000000008aULL, (uint64_t)0x0000000000000088ULL,
+    (uint64_t)0x0000000080008009ULL, (uint64_t)0x000000008000000aULL,
+    (uint64_t)0x000000008000808bULL, (uint64_t)0x800000000000008bULL,
+    (uint64_t)0x8000000000008089ULL, (uint64_t)0x8000000000008003ULL,
+    (uint64_t)0x8000000000008002ULL, (uint64_t)0x8000000000000080ULL,
+    (uint64_t)0x000000000000800aULL, (uint64_t)0x800000008000000aULL,
+    (uint64_t)0x8000000080008081ULL, (uint64_t)0x8000000000008080ULL,
+    (uint64_t)0x0000000080000001ULL, (uint64_t)0x8000000080008008ULL};
 
-void KeccakF1600_StatePermute(uint64_t *state)
-{
-    int round;
+void KeccakF1600_StatePermute(uint64_t *state) {
+  int round;
 
-    uint64_t Aba, Abe, Abi, Abo, Abu;
-    uint64_t Aga, Age, Agi, Ago, Agu;
-    uint64_t Aka, Ake, Aki, Ako, Aku;
-    uint64_t Ama, Ame, Ami, Amo, Amu;
-    uint64_t Asa, Ase, Asi, Aso, Asu;
-    uint64_t BCa, BCe, BCi, BCo, BCu;
-    uint64_t Da, De, Di, Do, Du;
-    uint64_t Eba, Ebe, Ebi, Ebo, Ebu;
-    uint64_t Ega, Ege, Egi, Ego, Egu;
-    uint64_t Eka, Eke, Eki, Eko, Eku;
-    uint64_t Ema, Eme, Emi, Emo, Emu;
-    uint64_t Esa, Ese, Esi, Eso, Esu;
+  uint64_t Aba, Abe, Abi, Abo, Abu;
+  uint64_t Aga, Age, Agi, Ago, Agu;
+  uint64_t Aka, Ake, Aki, Ako, Aku;
+  uint64_t Ama, Ame, Ami, Amo, Amu;
+  uint64_t Asa, Ase, Asi, Aso, Asu;
+  uint64_t BCa, BCe, BCi, BCo, BCu;
+  uint64_t Da, De, Di, Do, Du;
+  uint64_t Eba, Ebe, Ebi, Ebo, Ebu;
+  uint64_t Ega, Ege, Egi, Ego, Egu;
+  uint64_t Eka, Eke, Eki, Eko, Eku;
+  uint64_t Ema, Eme, Emi, Emo, Emu;
+  uint64_t Esa, Ese, Esi, Eso, Esu;
 
-    //copyFromState(A, state)
-    Aba = state[ 0];
-    Abe = state[ 1];
-    Abi = state[ 2];
-    Abo = state[ 3];
-    Abu = state[ 4];
-    Aga = state[ 5];
-    Age = state[ 6];
-    Agi = state[ 7];
-    Ago = state[ 8];
-    Agu = state[ 9];
-    Aka = state[10];
-    Ake = state[11];
-    Aki = state[12];
-    Ako = state[13];
-    Aku = state[14];
-    Ama = state[15];
-    Ame = state[16];
-    Ami = state[17];
-    Amo = state[18];
-    Amu = state[19];
-    Asa = state[20];
-    Ase = state[21];
-    Asi = state[22];
-    Aso = state[23];
-    Asu = state[24];
+  // copyFromState(A, state)
+  Aba = state[0];
+  Abe = state[1];
+  Abi = state[2];
+  Abo = state[3];
+  Abu = state[4];
+  Aga = state[5];
+  Age = state[6];
+  Agi = state[7];
+  Ago = state[8];
+  Agu = state[9];
+  Aka = state[10];
+  Ake = state[11];
+  Aki = state[12];
+  Ako = state[13];
+  Aku = state[14];
+  Ama = state[15];
+  Ame = state[16];
+  Ami = state[17];
+  Amo = state[18];
+  Amu = state[19];
+  Asa = state[20];
+  Ase = state[21];
+  Asi = state[22];
+  Aso = state[23];
+  Asu = state[24];
 
-    for ( round = 0; round < NROUNDS; round += 2 )
-    {
-        //    prepareTheta
-        BCa = Aba ^ Aga ^ Aka ^ Ama ^ Asa;
-        BCe = Abe ^ Age ^ Ake ^ Ame ^ Ase;
-        BCi = Abi ^ Agi ^ Aki ^ Ami ^ Asi;
-        BCo = Abo ^ Ago ^ Ako ^ Amo ^ Aso;
-        BCu = Abu ^ Agu ^ Aku ^ Amu ^ Asu;
+  for (round = 0; round < NROUNDS; round += 2) {
+    //    prepareTheta
+    BCa = Aba ^ Aga ^ Aka ^ Ama ^ Asa;
+    BCe = Abe ^ Age ^ Ake ^ Ame ^ Ase;
+    BCi = Abi ^ Agi ^ Aki ^ Ami ^ Asi;
+    BCo = Abo ^ Ago ^ Ako ^ Amo ^ Aso;
+    BCu = Abu ^ Agu ^ Aku ^ Amu ^ Asu;
 
-        //thetaRhoPiChiIotaPrepareTheta(round  , A, E)
-        Da = BCu ^ ROL(BCe, 1);
-        De = BCa ^ ROL(BCi, 1);
-        Di = BCe ^ ROL(BCo, 1);
-        Do = BCi ^ ROL(BCu, 1);
-        Du = BCo ^ ROL(BCa, 1);
+    // thetaRhoPiChiIotaPrepareTheta(round  , A, E)
+    Da = BCu ^ ROL(BCe, 1);
+    De = BCa ^ ROL(BCi, 1);
+    Di = BCe ^ ROL(BCo, 1);
+    Do = BCi ^ ROL(BCu, 1);
+    Du = BCo ^ ROL(BCa, 1);
 
-        Aba ^= Da;
-        BCa = Aba;
-        Age ^= De;
-        BCe = ROL(Age, 44);
-        Aki ^= Di;
-        BCi = ROL(Aki, 43);
-        Amo ^= Do;
-        BCo = ROL(Amo, 21);
-        Asu ^= Du;
-        BCu = ROL(Asu, 14);
-        Eba =   BCa ^ ((~BCe)&  BCi );
-        Eba ^= (uint64_t)KeccakF_RoundConstants[round];
-        Ebe =   BCe ^ ((~BCi)&  BCo );
-        Ebi =   BCi ^ ((~BCo)&  BCu );
-        Ebo =   BCo ^ ((~BCu)&  BCa );
-        Ebu =   BCu ^ ((~BCa)&  BCe );
+    Aba ^= Da;
+    BCa = Aba;
+    Age ^= De;
+    BCe = ROL(Age, 44);
+    Aki ^= Di;
+    BCi = ROL(Aki, 43);
+    Amo ^= Do;
+    BCo = ROL(Amo, 21);
+    Asu ^= Du;
+    BCu = ROL(Asu, 14);
+    Eba = BCa ^ ((~BCe) & BCi);
+    Eba ^= (uint64_t)KeccakF_RoundConstants[round];
+    Ebe = BCe ^ ((~BCi) & BCo);
+    Ebi = BCi ^ ((~BCo) & BCu);
+    Ebo = BCo ^ ((~BCu) & BCa);
+    Ebu = BCu ^ ((~BCa) & BCe);
 
-        Abo ^= Do;
-        BCa = ROL(Abo, 28);
-        Agu ^= Du;
-        BCe = ROL(Agu, 20);
-        Aka ^= Da;
-        BCi = ROL(Aka,  3);
-        Ame ^= De;
-        BCo = ROL(Ame, 45);
-        Asi ^= Di;
-        BCu = ROL(Asi, 61);
-        Ega =   BCa ^ ((~BCe)&  BCi );
-        Ege =   BCe ^ ((~BCi)&  BCo );
-        Egi =   BCi ^ ((~BCo)&  BCu );
-        Ego =   BCo ^ ((~BCu)&  BCa );
-        Egu =   BCu ^ ((~BCa)&  BCe );
+    Abo ^= Do;
+    BCa = ROL(Abo, 28);
+    Agu ^= Du;
+    BCe = ROL(Agu, 20);
+    Aka ^= Da;
+    BCi = ROL(Aka, 3);
+    Ame ^= De;
+    BCo = ROL(Ame, 45);
+    Asi ^= Di;
+    BCu = ROL(Asi, 61);
+    Ega = BCa ^ ((~BCe) & BCi);
+    Ege = BCe ^ ((~BCi) & BCo);
+    Egi = BCi ^ ((~BCo) & BCu);
+    Ego = BCo ^ ((~BCu) & BCa);
+    Egu = BCu ^ ((~BCa) & BCe);
 
-        Abe ^= De;
-        BCa = ROL(Abe,  1);
-        Agi ^= Di;
-        BCe = ROL(Agi,  6);
-        Ako ^= Do;
-        BCi = ROL(Ako, 25);
-        Amu ^= Du;
-        BCo = ROL(Amu,  8);
-        Asa ^= Da;
-        BCu = ROL(Asa, 18);
-        Eka =   BCa ^ ((~BCe)&  BCi );
-        Eke =   BCe ^ ((~BCi)&  BCo );
-        Eki =   BCi ^ ((~BCo)&  BCu );
-        Eko =   BCo ^ ((~BCu)&  BCa );
-        Eku =   BCu ^ ((~BCa)&  BCe );
+    Abe ^= De;
+    BCa = ROL(Abe, 1);
+    Agi ^= Di;
+    BCe = ROL(Agi, 6);
+    Ako ^= Do;
+    BCi = ROL(Ako, 25);
+    Amu ^= Du;
+    BCo = ROL(Amu, 8);
+    Asa ^= Da;
+    BCu = ROL(Asa, 18);
+    Eka = BCa ^ ((~BCe) & BCi);
+    Eke = BCe ^ ((~BCi) & BCo);
+    Eki = BCi ^ ((~BCo) & BCu);
+    Eko = BCo ^ ((~BCu) & BCa);
+    Eku = BCu ^ ((~BCa) & BCe);
 
-        Abu ^= Du;
-        BCa = ROL(Abu, 27);
-        Aga ^= Da;
-        BCe = ROL(Aga, 36);
-        Ake ^= De;
-        BCi = ROL(Ake, 10);
-        Ami ^= Di;
-        BCo = ROL(Ami, 15);
-        Aso ^= Do;
-        BCu = ROL(Aso, 56);
-        Ema =   BCa ^ ((~BCe)&  BCi );
-        Eme =   BCe ^ ((~BCi)&  BCo );
-        Emi =   BCi ^ ((~BCo)&  BCu );
-        Emo =   BCo ^ ((~BCu)&  BCa );
-        Emu =   BCu ^ ((~BCa)&  BCe );
+    Abu ^= Du;
+    BCa = ROL(Abu, 27);
+    Aga ^= Da;
+    BCe = ROL(Aga, 36);
+    Ake ^= De;
+    BCi = ROL(Ake, 10);
+    Ami ^= Di;
+    BCo = ROL(Ami, 15);
+    Aso ^= Do;
+    BCu = ROL(Aso, 56);
+    Ema = BCa ^ ((~BCe) & BCi);
+    Eme = BCe ^ ((~BCi) & BCo);
+    Emi = BCi ^ ((~BCo) & BCu);
+    Emo = BCo ^ ((~BCu) & BCa);
+    Emu = BCu ^ ((~BCa) & BCe);
 
-        Abi ^= Di;
-        BCa = ROL(Abi, 62);
-        Ago ^= Do;
-        BCe = ROL(Ago, 55);
-        Aku ^= Du;
-        BCi = ROL(Aku, 39);
-        Ama ^= Da;
-        BCo = ROL(Ama, 41);
-        Ase ^= De;
-        BCu = ROL(Ase,  2);
-        Esa =   BCa ^ ((~BCe)&  BCi );
-        Ese =   BCe ^ ((~BCi)&  BCo );
-        Esi =   BCi ^ ((~BCo)&  BCu );
-        Eso =   BCo ^ ((~BCu)&  BCa );
-        Esu =   BCu ^ ((~BCa)&  BCe );
+    Abi ^= Di;
+    BCa = ROL(Abi, 62);
+    Ago ^= Do;
+    BCe = ROL(Ago, 55);
+    Aku ^= Du;
+    BCi = ROL(Aku, 39);
+    Ama ^= Da;
+    BCo = ROL(Ama, 41);
+    Ase ^= De;
+    BCu = ROL(Ase, 2);
+    Esa = BCa ^ ((~BCe) & BCi);
+    Ese = BCe ^ ((~BCi) & BCo);
+    Esi = BCi ^ ((~BCo) & BCu);
+    Eso = BCo ^ ((~BCu) & BCa);
+    Esu = BCu ^ ((~BCa) & BCe);
 
-        //    prepareTheta
-        BCa = Eba ^ Ega ^ Eka ^ Ema ^ Esa;
-        BCe = Ebe ^ Ege ^ Eke ^ Eme ^ Ese;
-        BCi = Ebi ^ Egi ^ Eki ^ Emi ^ Esi;
-        BCo = Ebo ^ Ego ^ Eko ^ Emo ^ Eso;
-        BCu = Ebu ^ Egu ^ Eku ^ Emu ^ Esu;
+    //    prepareTheta
+    BCa = Eba ^ Ega ^ Eka ^ Ema ^ Esa;
+    BCe = Ebe ^ Ege ^ Eke ^ Eme ^ Ese;
+    BCi = Ebi ^ Egi ^ Eki ^ Emi ^ Esi;
+    BCo = Ebo ^ Ego ^ Eko ^ Emo ^ Eso;
+    BCu = Ebu ^ Egu ^ Eku ^ Emu ^ Esu;
 
-        //thetaRhoPiChiIotaPrepareTheta(round+1, E, A)
-        Da = BCu ^ ROL(BCe, 1);
-        De = BCa ^ ROL(BCi, 1);
-        Di = BCe ^ ROL(BCo, 1);
-        Do = BCi ^ ROL(BCu, 1);
-        Du = BCo ^ ROL(BCa, 1);
+    // thetaRhoPiChiIotaPrepareTheta(round+1, E, A)
+    Da = BCu ^ ROL(BCe, 1);
+    De = BCa ^ ROL(BCi, 1);
+    Di = BCe ^ ROL(BCo, 1);
+    Do = BCi ^ ROL(BCu, 1);
+    Du = BCo ^ ROL(BCa, 1);
 
-        Eba ^= Da;
-        BCa = Eba;
-        Ege ^= De;
-        BCe = ROL(Ege, 44);
-        Eki ^= Di;
-        BCi = ROL(Eki, 43);
-        Emo ^= Do;
-        BCo = ROL(Emo, 21);
-        Esu ^= Du;
-        BCu = ROL(Esu, 14);
-        Aba =   BCa ^ ((~BCe)&  BCi );
-        Aba ^= (uint64_t)KeccakF_RoundConstants[round + 1];
-        Abe =   BCe ^ ((~BCi)&  BCo );
-        Abi =   BCi ^ ((~BCo)&  BCu );
-        Abo =   BCo ^ ((~BCu)&  BCa );
-        Abu =   BCu ^ ((~BCa)&  BCe );
+    Eba ^= Da;
+    BCa = Eba;
+    Ege ^= De;
+    BCe = ROL(Ege, 44);
+    Eki ^= Di;
+    BCi = ROL(Eki, 43);
+    Emo ^= Do;
+    BCo = ROL(Emo, 21);
+    Esu ^= Du;
+    BCu = ROL(Esu, 14);
+    Aba = BCa ^ ((~BCe) & BCi);
+    Aba ^= (uint64_t)KeccakF_RoundConstants[round + 1];
+    Abe = BCe ^ ((~BCi) & BCo);
+    Abi = BCi ^ ((~BCo) & BCu);
+    Abo = BCo ^ ((~BCu) & BCa);
+    Abu = BCu ^ ((~BCa) & BCe);
 
-        Ebo ^= Do;
-        BCa = ROL(Ebo, 28);
-        Egu ^= Du;
-        BCe = ROL(Egu, 20);
-        Eka ^= Da;
-        BCi = ROL(Eka, 3);
-        Eme ^= De;
-        BCo = ROL(Eme, 45);
-        Esi ^= Di;
-        BCu = ROL(Esi, 61);
-        Aga =   BCa ^ ((~BCe)&  BCi );
-        Age =   BCe ^ ((~BCi)&  BCo );
-        Agi =   BCi ^ ((~BCo)&  BCu );
-        Ago =   BCo ^ ((~BCu)&  BCa );
-        Agu =   BCu ^ ((~BCa)&  BCe );
+    Ebo ^= Do;
+    BCa = ROL(Ebo, 28);
+    Egu ^= Du;
+    BCe = ROL(Egu, 20);
+    Eka ^= Da;
+    BCi = ROL(Eka, 3);
+    Eme ^= De;
+    BCo = ROL(Eme, 45);
+    Esi ^= Di;
+    BCu = ROL(Esi, 61);
+    Aga = BCa ^ ((~BCe) & BCi);
+    Age = BCe ^ ((~BCi) & BCo);
+    Agi = BCi ^ ((~BCo) & BCu);
+    Ago = BCo ^ ((~BCu) & BCa);
+    Agu = BCu ^ ((~BCa) & BCe);
 
-        Ebe ^= De;
-        BCa = ROL(Ebe, 1);
-        Egi ^= Di;
-        BCe = ROL(Egi, 6);
-        Eko ^= Do;
-        BCi = ROL(Eko, 25);
-        Emu ^= Du;
-        BCo = ROL(Emu, 8);
-        Esa ^= Da;
-        BCu = ROL(Esa, 18);
-        Aka =   BCa ^ ((~BCe)&  BCi );
-        Ake =   BCe ^ ((~BCi)&  BCo );
-        Aki =   BCi ^ ((~BCo)&  BCu );
-        Ako =   BCo ^ ((~BCu)&  BCa );
-        Aku =   BCu ^ ((~BCa)&  BCe );
+    Ebe ^= De;
+    BCa = ROL(Ebe, 1);
+    Egi ^= Di;
+    BCe = ROL(Egi, 6);
+    Eko ^= Do;
+    BCi = ROL(Eko, 25);
+    Emu ^= Du;
+    BCo = ROL(Emu, 8);
+    Esa ^= Da;
+    BCu = ROL(Esa, 18);
+    Aka = BCa ^ ((~BCe) & BCi);
+    Ake = BCe ^ ((~BCi) & BCo);
+    Aki = BCi ^ ((~BCo) & BCu);
+    Ako = BCo ^ ((~BCu) & BCa);
+    Aku = BCu ^ ((~BCa) & BCe);
 
-        Ebu ^= Du;
-        BCa = ROL(Ebu, 27);
-        Ega ^= Da;
-        BCe = ROL(Ega, 36);
-        Eke ^= De;
-        BCi = ROL(Eke, 10);
-        Emi ^= Di;
-        BCo = ROL(Emi, 15);
-        Eso ^= Do;
-        BCu = ROL(Eso, 56);
-        Ama =   BCa ^ ((~BCe)&  BCi );
-        Ame =   BCe ^ ((~BCi)&  BCo );
-        Ami =   BCi ^ ((~BCo)&  BCu );
-        Amo =   BCo ^ ((~BCu)&  BCa );
-        Amu =   BCu ^ ((~BCa)&  BCe );
+    Ebu ^= Du;
+    BCa = ROL(Ebu, 27);
+    Ega ^= Da;
+    BCe = ROL(Ega, 36);
+    Eke ^= De;
+    BCi = ROL(Eke, 10);
+    Emi ^= Di;
+    BCo = ROL(Emi, 15);
+    Eso ^= Do;
+    BCu = ROL(Eso, 56);
+    Ama = BCa ^ ((~BCe) & BCi);
+    Ame = BCe ^ ((~BCi) & BCo);
+    Ami = BCi ^ ((~BCo) & BCu);
+    Amo = BCo ^ ((~BCu) & BCa);
+    Amu = BCu ^ ((~BCa) & BCe);
 
-        Ebi ^= Di;
-        BCa = ROL(Ebi, 62);
-        Ego ^= Do;
-        BCe = ROL(Ego, 55);
-        Eku ^= Du;
-        BCi = ROL(Eku, 39);
-        Ema ^= Da;
-        BCo = ROL(Ema, 41);
-        Ese ^= De;
-        BCu = ROL(Ese, 2);
-        Asa =   BCa ^ ((~BCe)&  BCi );
-        Ase =   BCe ^ ((~BCi)&  BCo );
-        Asi =   BCi ^ ((~BCo)&  BCu );
-        Aso =   BCo ^ ((~BCu)&  BCa );
-        Asu =   BCu ^ ((~BCa)&  BCe );
-    }
+    Ebi ^= Di;
+    BCa = ROL(Ebi, 62);
+    Ego ^= Do;
+    BCe = ROL(Ego, 55);
+    Eku ^= Du;
+    BCi = ROL(Eku, 39);
+    Ema ^= Da;
+    BCo = ROL(Ema, 41);
+    Ese ^= De;
+    BCu = ROL(Ese, 2);
+    Asa = BCa ^ ((~BCe) & BCi);
+    Ase = BCe ^ ((~BCi) & BCo);
+    Asi = BCi ^ ((~BCo) & BCu);
+    Aso = BCo ^ ((~BCu) & BCa);
+    Asu = BCu ^ ((~BCa) & BCe);
+  }
 
-    //copyToState(state, A)
-    state[ 0] = Aba;
-    state[ 1] = Abe;
-    state[ 2] = Abi;
-    state[ 3] = Abo;
-    state[ 4] = Abu;
-    state[ 5] = Aga;
-    state[ 6] = Age;
-    state[ 7] = Agi;
-    state[ 8] = Ago;
-    state[ 9] = Agu;
-    state[10] = Aka;
-    state[11] = Ake;
-    state[12] = Aki;
-    state[13] = Ako;
-    state[14] = Aku;
-    state[15] = Ama;
-    state[16] = Ame;
-    state[17] = Ami;
-    state[18] = Amo;
-    state[19] = Amu;
-    state[20] = Asa;
-    state[21] = Ase;
-    state[22] = Asi;
-    state[23] = Aso;
-    state[24] = Asu;
+  // copyToState(state, A)
+  state[0] = Aba;
+  state[1] = Abe;
+  state[2] = Abi;
+  state[3] = Abo;
+  state[4] = Abu;
+  state[5] = Aga;
+  state[6] = Age;
+  state[7] = Agi;
+  state[8] = Ago;
+  state[9] = Agu;
+  state[10] = Aka;
+  state[11] = Ake;
+  state[12] = Aki;
+  state[13] = Ako;
+  state[14] = Aku;
+  state[15] = Ama;
+  state[16] = Ame;
+  state[17] = Ami;
+  state[18] = Amo;
+  state[19] = Amu;
+  state[20] = Asa;
+  state[21] = Ase;
+  state[22] = Asi;
+  state[23] = Aso;
+  state[24] = Asu;
 
-#undef    round
+#undef round
 }
 #endif /* !MLKEM_USE_FIPS202_X1_ASM */

--- a/fips202/keccakf1600.h
+++ b/fips202/keccakf1600.h
@@ -2,8 +2,8 @@
 #ifndef KECCAKF1600_H
 #define KECCAKF1600_H
 
-#include "asm/asm.h"
 #include <stdint.h>
+#include "asm/asm.h"
 
 #define KECCAK_WAY 4
 #define KECCAK_LANES 25
@@ -17,18 +17,16 @@
 //
 typedef uint64_t keccakx4_state[KECCAK_WAY * KECCAK_LANES];
 
-void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data, unsigned int offset, unsigned int length);
-void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data, unsigned int offset, unsigned int length);
+void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data,
+                                   unsigned int offset, unsigned int length);
+void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data,
+                               unsigned int offset, unsigned int length);
 
-void KeccakF1600x4_StateExtractBytes(uint64_t *state,
-                                     unsigned char *data0,
-                                     unsigned char *data1,
-                                     unsigned char *data2,
-                                     unsigned char *data3,
-                                     unsigned int offset,
+void KeccakF1600x4_StateExtractBytes(uint64_t *state, unsigned char *data0,
+                                     unsigned char *data1, unsigned char *data2,
+                                     unsigned char *data3, unsigned int offset,
                                      unsigned int length);
-void KeccakF1600x4_StateXORBytes(uint64_t *state,
-                                 const unsigned char *data0,
+void KeccakF1600x4_StateXORBytes(uint64_t *state, const unsigned char *data0,
                                  const unsigned char *data1,
                                  const unsigned char *data2,
                                  const unsigned char *data3,

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
 
             inherit (pkgs)
               nixpkgs-fmt
+              clang-tools
               shfmt;
 
             inherit (pkgs.python3Packages)

--- a/mlkem/api.h
+++ b/mlkem/api.h
@@ -11,18 +11,25 @@
 #define pqcrystals_kyber512_ENCCOINBYTES 32
 #define pqcrystals_kyber512_BYTES 32
 
-#define pqcrystals_kyber512_ref_SECRETKEYBYTES pqcrystals_kyber512_SECRETKEYBYTES
-#define pqcrystals_kyber512_ref_PUBLICKEYBYTES pqcrystals_kyber512_PUBLICKEYBYTES
-#define pqcrystals_kyber512_ref_CIPHERTEXTBYTES pqcrystals_kyber512_CIPHERTEXTBYTES
-#define pqcrystals_kyber512_ref_KEYPAIRCOINBYTES pqcrystals_kyber512_KEYPAIRCOINBYTES
+#define pqcrystals_kyber512_ref_SECRETKEYBYTES \
+  pqcrystals_kyber512_SECRETKEYBYTES
+#define pqcrystals_kyber512_ref_PUBLICKEYBYTES \
+  pqcrystals_kyber512_PUBLICKEYBYTES
+#define pqcrystals_kyber512_ref_CIPHERTEXTBYTES \
+  pqcrystals_kyber512_CIPHERTEXTBYTES
+#define pqcrystals_kyber512_ref_KEYPAIRCOINBYTES \
+  pqcrystals_kyber512_KEYPAIRCOINBYTES
 #define pqcrystals_kyber512_ref_ENCCOINBYTES pqcrystals_kyber512_ENCCOINBYTES
 #define pqcrystals_kyber512_ref_BYTES pqcrystals_kyber512_BYTES
 
-int pqcrystals_kyber512_ref_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins);
+int pqcrystals_kyber512_ref_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                           const uint8_t *coins);
 int pqcrystals_kyber512_ref_keypair(uint8_t *pk, uint8_t *sk);
-int pqcrystals_kyber512_ref_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk, const uint8_t *coins);
+int pqcrystals_kyber512_ref_enc_derand(uint8_t *ct, uint8_t *ss,
+                                       const uint8_t *pk, const uint8_t *coins);
 int pqcrystals_kyber512_ref_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
-int pqcrystals_kyber512_ref_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+int pqcrystals_kyber512_ref_dec(uint8_t *ss, const uint8_t *ct,
+                                const uint8_t *sk);
 
 #define pqcrystals_kyber768_SECRETKEYBYTES 2400
 #define pqcrystals_kyber768_PUBLICKEYBYTES 1184
@@ -31,18 +38,25 @@ int pqcrystals_kyber512_ref_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *s
 #define pqcrystals_kyber768_ENCCOINBYTES 32
 #define pqcrystals_kyber768_BYTES 32
 
-#define pqcrystals_kyber768_ref_SECRETKEYBYTES pqcrystals_kyber768_SECRETKEYBYTES
-#define pqcrystals_kyber768_ref_PUBLICKEYBYTES pqcrystals_kyber768_PUBLICKEYBYTES
-#define pqcrystals_kyber768_ref_CIPHERTEXTBYTES pqcrystals_kyber768_CIPHERTEXTBYTES
-#define pqcrystals_kyber768_ref_KEYPAIRCOINBYTES pqcrystals_kyber768_KEYPAIRCOINBYTES
+#define pqcrystals_kyber768_ref_SECRETKEYBYTES \
+  pqcrystals_kyber768_SECRETKEYBYTES
+#define pqcrystals_kyber768_ref_PUBLICKEYBYTES \
+  pqcrystals_kyber768_PUBLICKEYBYTES
+#define pqcrystals_kyber768_ref_CIPHERTEXTBYTES \
+  pqcrystals_kyber768_CIPHERTEXTBYTES
+#define pqcrystals_kyber768_ref_KEYPAIRCOINBYTES \
+  pqcrystals_kyber768_KEYPAIRCOINBYTES
 #define pqcrystals_kyber768_ref_ENCCOINBYTES pqcrystals_kyber768_ENCCOINBYTES
 #define pqcrystals_kyber768_ref_BYTES pqcrystals_kyber768_BYTES
 
-int pqcrystals_kyber768_ref_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins);
+int pqcrystals_kyber768_ref_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                           const uint8_t *coins);
 int pqcrystals_kyber768_ref_keypair(uint8_t *pk, uint8_t *sk);
-int pqcrystals_kyber768_ref_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk, const uint8_t *coins);
+int pqcrystals_kyber768_ref_enc_derand(uint8_t *ct, uint8_t *ss,
+                                       const uint8_t *pk, const uint8_t *coins);
 int pqcrystals_kyber768_ref_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
-int pqcrystals_kyber768_ref_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+int pqcrystals_kyber768_ref_dec(uint8_t *ss, const uint8_t *ct,
+                                const uint8_t *sk);
 
 #define pqcrystals_kyber1024_SECRETKEYBYTES 3168
 #define pqcrystals_kyber1024_PUBLICKEYBYTES 1568
@@ -51,17 +65,25 @@ int pqcrystals_kyber768_ref_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *s
 #define pqcrystals_kyber1024_ENCCOINBYTES 32
 #define pqcrystals_kyber1024_BYTES 32
 
-#define pqcrystals_kyber1024_ref_SECRETKEYBYTES pqcrystals_kyber1024_SECRETKEYBYTES
-#define pqcrystals_kyber1024_ref_PUBLICKEYBYTES pqcrystals_kyber1024_PUBLICKEYBYTES
-#define pqcrystals_kyber1024_ref_CIPHERTEXTBYTES pqcrystals_kyber1024_CIPHERTEXTBYTES
-#define pqcrystals_kyber1024_ref_KEYPAIRCOINBYTES pqcrystals_kyber1024_KEYPAIRCOINBYTES
+#define pqcrystals_kyber1024_ref_SECRETKEYBYTES \
+  pqcrystals_kyber1024_SECRETKEYBYTES
+#define pqcrystals_kyber1024_ref_PUBLICKEYBYTES \
+  pqcrystals_kyber1024_PUBLICKEYBYTES
+#define pqcrystals_kyber1024_ref_CIPHERTEXTBYTES \
+  pqcrystals_kyber1024_CIPHERTEXTBYTES
+#define pqcrystals_kyber1024_ref_KEYPAIRCOINBYTES \
+  pqcrystals_kyber1024_KEYPAIRCOINBYTES
 #define pqcrystals_kyber1024_ref_ENCCOINBYTES pqcrystals_kyber1024_ENCCOINBYTES
 #define pqcrystals_kyber1024_ref_BYTES pqcrystals_kyber1024_BYTES
 
-int pqcrystals_kyber1024_ref_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins);
+int pqcrystals_kyber1024_ref_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                            const uint8_t *coins);
 int pqcrystals_kyber1024_ref_keypair(uint8_t *pk, uint8_t *sk);
-int pqcrystals_kyber1024_ref_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk, const uint8_t *coins);
+int pqcrystals_kyber1024_ref_enc_derand(uint8_t *ct, uint8_t *ss,
+                                        const uint8_t *pk,
+                                        const uint8_t *coins);
 int pqcrystals_kyber1024_ref_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
-int pqcrystals_kyber1024_ref_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk);
+int pqcrystals_kyber1024_ref_dec(uint8_t *ss, const uint8_t *ct,
+                                 const uint8_t *sk);
 
 #endif

--- a/mlkem/asm/asm.h
+++ b/mlkem/asm/asm.h
@@ -3,8 +3,8 @@
 #define MLKEM_ASM_H
 
 #include <stdint.h>
-#include "params.h"
 #include "config.h"
+#include "params.h"
 
 #ifdef MLKEM_USE_AARCH64_ASM
 void ntt_asm_clean(int16_t *);
@@ -19,34 +19,48 @@ void poly_reduce_asm_opt(int16_t *);
 void poly_tomont_asm_clean(int16_t *);
 void poly_tomont_asm_opt(int16_t *);
 
-void poly_mulcache_compute_asm_clean(int16_t *, const int16_t *, const int16_t *, const int16_t *);
-void poly_mulcache_compute_asm_opt(int16_t *, const int16_t *, const int16_t *, const int16_t *);
+void poly_mulcache_compute_asm_clean(int16_t *, const int16_t *,
+                                     const int16_t *, const int16_t *);
+void poly_mulcache_compute_asm_opt(int16_t *, const int16_t *, const int16_t *,
+                                   const int16_t *);
 
 void poly_tobytes_asm_clean(uint8_t *r, const int16_t *a);
 
-void polyvec_basemul_acc_montgomery_cached_asm_k2_clean(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
-void polyvec_basemul_acc_montgomery_cached_asm_k3_clean(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
-void polyvec_basemul_acc_montgomery_cached_asm_k4_clean(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+void polyvec_basemul_acc_montgomery_cached_asm_k2_clean(int16_t *r,
+                                                        const int16_t *a,
+                                                        const int16_t *b,
+                                                        const int16_t *b_cache);
+void polyvec_basemul_acc_montgomery_cached_asm_k3_clean(int16_t *r,
+                                                        const int16_t *a,
+                                                        const int16_t *b,
+                                                        const int16_t *b_cache);
+void polyvec_basemul_acc_montgomery_cached_asm_k4_clean(int16_t *r,
+                                                        const int16_t *a,
+                                                        const int16_t *b,
+                                                        const int16_t *b_cache);
 
-void polyvec_basemul_acc_montgomery_cached_asm_k2_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
-void polyvec_basemul_acc_montgomery_cached_asm_k3_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
-void polyvec_basemul_acc_montgomery_cached_asm_k4_opt(
-    int16_t *r, const int16_t *a, const int16_t *b, const int16_t *b_cache);
+void polyvec_basemul_acc_montgomery_cached_asm_k2_opt(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
+void polyvec_basemul_acc_montgomery_cached_asm_k3_opt(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
+void polyvec_basemul_acc_montgomery_cached_asm_k4_opt(int16_t *r,
+                                                      const int16_t *a,
+                                                      const int16_t *b,
+                                                      const int16_t *b_cache);
 
 #define _polyvec_basemul_acc_montgomery_cached_asm_clean_name(k) \
-    polyvec_basemul_acc_montgomery_cached_asm_k ## k ## _clean
+  polyvec_basemul_acc_montgomery_cached_asm_k##k##_clean
 #define polyvec_basemul_acc_montgomery_cached_asm_clean_name(k) \
-    _polyvec_basemul_acc_montgomery_cached_asm_clean_name(k)
+  _polyvec_basemul_acc_montgomery_cached_asm_clean_name(k)
 
 #define _polyvec_basemul_acc_montgomery_cached_asm_opt_name(k) \
-    polyvec_basemul_acc_montgomery_cached_asm_k ## k ## _opt
+  polyvec_basemul_acc_montgomery_cached_asm_k##k##_opt
 #define polyvec_basemul_acc_montgomery_cached_asm_opt_name(k) \
-    _polyvec_basemul_acc_montgomery_cached_asm_opt_name(k)
+  _polyvec_basemul_acc_montgomery_cached_asm_opt_name(k)
 
 #if !defined(MLKEM_USE_NTT_ASM_FORCE)
 
@@ -55,7 +69,7 @@ void polyvec_basemul_acc_montgomery_cached_asm_k4_opt(
 #define intt_asm intt_asm_clean
 #define poly_reduce_asm poly_reduce_asm_clean
 #define polyvec_basemul_acc_montgomery_cached_asm \
-    polyvec_basemul_acc_montgomery_cached_asm_clean_name(KYBER_K)
+  polyvec_basemul_acc_montgomery_cached_asm_clean_name(KYBER_K)
 #define poly_mulcache_compute_asm poly_mulcache_compute_asm_clean
 #define poly_tomont_asm poly_tomont_asm_clean
 #else /* MLKEM_USE_AARCH64_ASM_CLEAN */
@@ -63,7 +77,7 @@ void polyvec_basemul_acc_montgomery_cached_asm_k4_opt(
 #define intt_asm intt_asm_opt
 #define poly_reduce_asm poly_reduce_asm_opt
 #define polyvec_basemul_acc_montgomery_cached_asm \
-    polyvec_basemul_acc_montgomery_cached_asm_opt_name(KYBER_K)
+  polyvec_basemul_acc_montgomery_cached_asm_opt_name(KYBER_K)
 #define poly_mulcache_compute_asm poly_mulcache_compute_asm_opt
 #define poly_tomont_asm poly_tomont_asm_opt
 #endif /* !MLKEM_USE_AARCH64_ASM_CLEAN */

--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -1,132 +1,122 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "cbd.h"
 #include <stdint.h>
 #include "params.h"
-#include "cbd.h"
 
 /*************************************************
-* Name:        load32_littleendian
-*
-* Description: load 4 bytes into a 32-bit integer
-*              in little-endian order
-*
-* Arguments:   - const uint8_t *x: pointer to input byte array
-*
-* Returns 32-bit unsigned integer loaded from x
-**************************************************/
-static uint32_t load32_littleendian(const uint8_t x[4])
-{
-    uint32_t r;
-    r  = (uint32_t)x[0];
-    r |= (uint32_t)x[1] << 8;
-    r |= (uint32_t)x[2] << 16;
-    r |= (uint32_t)x[3] << 24;
-    return r;
+ * Name:        load32_littleendian
+ *
+ * Description: load 4 bytes into a 32-bit integer
+ *              in little-endian order
+ *
+ * Arguments:   - const uint8_t *x: pointer to input byte array
+ *
+ * Returns 32-bit unsigned integer loaded from x
+ **************************************************/
+static uint32_t load32_littleendian(const uint8_t x[4]) {
+  uint32_t r;
+  r = (uint32_t)x[0];
+  r |= (uint32_t)x[1] << 8;
+  r |= (uint32_t)x[2] << 16;
+  r |= (uint32_t)x[3] << 24;
+  return r;
 }
 
 /*************************************************
-* Name:        load24_littleendian
-*
-* Description: load 3 bytes into a 32-bit integer
-*              in little-endian order.
-*              This function is only needed for Kyber-512
-*
-* Arguments:   - const uint8_t *x: pointer to input byte array
-*
-* Returns 32-bit unsigned integer loaded from x (most significant byte is zero)
-**************************************************/
+ * Name:        load24_littleendian
+ *
+ * Description: load 3 bytes into a 32-bit integer
+ *              in little-endian order.
+ *              This function is only needed for Kyber-512
+ *
+ * Arguments:   - const uint8_t *x: pointer to input byte array
+ *
+ * Returns 32-bit unsigned integer loaded from x (most significant byte is zero)
+ **************************************************/
 #if KYBER_ETA1 == 3
-static uint32_t load24_littleendian(const uint8_t x[3])
-{
-    uint32_t r;
-    r  = (uint32_t)x[0];
-    r |= (uint32_t)x[1] << 8;
-    r |= (uint32_t)x[2] << 16;
-    return r;
+static uint32_t load24_littleendian(const uint8_t x[3]) {
+  uint32_t r;
+  r = (uint32_t)x[0];
+  r |= (uint32_t)x[1] << 8;
+  r |= (uint32_t)x[2] << 16;
+  return r;
 }
 #endif
 
 /*************************************************
-* Name:        cbd2
-*
-* Description: Given an array of uniformly random bytes, compute
-*              polynomial with coefficients distributed according to
-*              a centered binomial distribution with parameter eta=2
-*
-* Arguments:   - poly *r: pointer to output polynomial
-*              - const uint8_t *buf: pointer to input byte array
-**************************************************/
-static void cbd2(poly *r, const uint8_t buf[2 * KYBER_N / 4])
-{
-    unsigned int i, j;
-    uint32_t t, d;
-    int16_t a, b;
+ * Name:        cbd2
+ *
+ * Description: Given an array of uniformly random bytes, compute
+ *              polynomial with coefficients distributed according to
+ *              a centered binomial distribution with parameter eta=2
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *buf: pointer to input byte array
+ **************************************************/
+static void cbd2(poly *r, const uint8_t buf[2 * KYBER_N / 4]) {
+  unsigned int i, j;
+  uint32_t t, d;
+  int16_t a, b;
 
-    for (i = 0; i < KYBER_N / 8; i++)
-    {
-        t  = load32_littleendian(buf + 4 * i);
-        d  = t & 0x55555555;
-        d += (t >> 1) & 0x55555555;
+  for (i = 0; i < KYBER_N / 8; i++) {
+    t = load32_littleendian(buf + 4 * i);
+    d = t & 0x55555555;
+    d += (t >> 1) & 0x55555555;
 
-        for (j = 0; j < 8; j++)
-        {
-            a = (d >> (4 * j + 0)) & 0x3;
-            b = (d >> (4 * j + 2)) & 0x3;
-            r->coeffs[8 * i + j] = a - b;
-        }
+    for (j = 0; j < 8; j++) {
+      a = (d >> (4 * j + 0)) & 0x3;
+      b = (d >> (4 * j + 2)) & 0x3;
+      r->coeffs[8 * i + j] = a - b;
     }
+  }
 }
 
 /*************************************************
-* Name:        cbd3
-*
-* Description: Given an array of uniformly random bytes, compute
-*              polynomial with coefficients distributed according to
-*              a centered binomial distribution with parameter eta=3.
-*              This function is only needed for Kyber-512
-*
-* Arguments:   - poly *r: pointer to output polynomial
-*              - const uint8_t *buf: pointer to input byte array
-**************************************************/
+ * Name:        cbd3
+ *
+ * Description: Given an array of uniformly random bytes, compute
+ *              polynomial with coefficients distributed according to
+ *              a centered binomial distribution with parameter eta=3.
+ *              This function is only needed for Kyber-512
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *buf: pointer to input byte array
+ **************************************************/
 #if KYBER_ETA1 == 3
-static void cbd3(poly *r, const uint8_t buf[3 * KYBER_N / 4])
-{
-    unsigned int i, j;
-    uint32_t t, d;
-    int16_t a, b;
+static void cbd3(poly *r, const uint8_t buf[3 * KYBER_N / 4]) {
+  unsigned int i, j;
+  uint32_t t, d;
+  int16_t a, b;
 
-    for (i = 0; i < KYBER_N / 4; i++)
-    {
-        t  = load24_littleendian(buf + 3 * i);
-        d  = t & 0x00249249;
-        d += (t >> 1) & 0x00249249;
-        d += (t >> 2) & 0x00249249;
+  for (i = 0; i < KYBER_N / 4; i++) {
+    t = load24_littleendian(buf + 3 * i);
+    d = t & 0x00249249;
+    d += (t >> 1) & 0x00249249;
+    d += (t >> 2) & 0x00249249;
 
-        for (j = 0; j < 4; j++)
-        {
-            a = (d >> (6 * j + 0)) & 0x7;
-            b = (d >> (6 * j + 3)) & 0x7;
-            r->coeffs[4 * i + j] = a - b;
-        }
+    for (j = 0; j < 4; j++) {
+      a = (d >> (6 * j + 0)) & 0x7;
+      b = (d >> (6 * j + 3)) & 0x7;
+      r->coeffs[4 * i + j] = a - b;
     }
+  }
 }
 #endif
 
-void poly_cbd_eta1(poly *r, const uint8_t buf[KYBER_ETA1 * KYBER_N / 4])
-{
-    #if KYBER_ETA1 == 2
-    cbd2(r, buf);
-    #elif KYBER_ETA1 == 3
-    cbd3(r, buf);
-    #else
+void poly_cbd_eta1(poly *r, const uint8_t buf[KYBER_ETA1 * KYBER_N / 4]) {
+#if KYBER_ETA1 == 2
+  cbd2(r, buf);
+#elif KYBER_ETA1 == 3
+  cbd3(r, buf);
+#else
 #error "This implementation requires eta1 in {2,3}"
-    #endif
+#endif
 }
 
-void poly_cbd_eta2(poly *r, const uint8_t buf[KYBER_ETA2 * KYBER_N / 4])
-{
-    #if KYBER_ETA2 == 2
-    cbd2(r, buf);
-    #else
+void poly_cbd_eta2(poly *r, const uint8_t buf[KYBER_ETA2 * KYBER_N / 4]) {
+#if KYBER_ETA2 == 2
+  cbd2(r, buf);
+#else
 #error "This implementation requires eta2 = 2"
-    #endif
+#endif
 }

--- a/mlkem/cbmc.h
+++ b/mlkem/cbmc.h
@@ -15,24 +15,24 @@
 #define ASSERT(...)
 #define ASSUME(...)
 
-#else // CBMC _is_ defined, therefore we're doing proof
+#else  // CBMC _is_ defined, therefore we're doing proof
 
 // https://diffblue.github.io/cbmc/contracts-assigns.html
-#define ASSIGNS(...)     __CPROVER_assigns(__VA_ARGS__)
+#define ASSIGNS(...) __CPROVER_assigns(__VA_ARGS__)
 
 // https://diffblue.github.io/cbmc/contracts-requires-ensures.html
-#define REQUIRES(...)    __CPROVER_requires(__VA_ARGS__)
-#define ENSURES(...)     __CPROVER_ensures(__VA_ARGS__)
+#define REQUIRES(...) __CPROVER_requires(__VA_ARGS__)
+#define ENSURES(...) __CPROVER_ensures(__VA_ARGS__)
 
 // note we drop "loop_" here since there are no other kind of invariants
 // in CBMC. An "invariant" is _always_ a "loop invariant" so no need to
 // keep that qualification
 // https://diffblue.github.io/cbmc/contracts-loops.html
-#define INVARIANT(...)   __CPROVER_loop_invariant(__VA_ARGS__)
-#define DECREASES(...)   __CPROVER_decreases(__VA_ARGS__)
+#define INVARIANT(...) __CPROVER_loop_invariant(__VA_ARGS__)
+#define DECREASES(...) __CPROVER_decreases(__VA_ARGS__)
 
-#define ASSERT(...)      __CPROVER_assert(__VA_ARGS__)
-#define ASSUME(...)      __CPROVER_assume(__VA_ARGS__)
+#define ASSERT(...) __CPROVER_assert(__VA_ARGS__)
+#define ASSUME(...) __CPROVER_assume(__VA_ARGS__)
 
 ///////////////////////////////////////////////////
 // Macros for "expression" forms that may appear
@@ -41,46 +41,74 @@
 
 // function return value - useful inside ENSURES
 // https://diffblue.github.io/cbmc/contracts-functions.html
-#define RETURN_VALUE     (__CPROVER_return_value)
+#define RETURN_VALUE (__CPROVER_return_value)
 
 // ASSIGNS l-value targets
 // https://diffblue.github.io/cbmc/contracts-assigns.html
 #define TYPED_TARGET(...) __CPROVER_typed_target(__VA_ARGS__)
 #define OBJECT_WHOLE(...) __CPROVER_object_whole(__VA_ARGS__)
-#define OBJECT_FROM(...)  __CPROVER_object_from(__VA_ARGS__)
-#define OBJECT_UPTO(...)  __CPROVER_object_upto(__VA_ARGS__)
+#define OBJECT_FROM(...) __CPROVER_object_from(__VA_ARGS__)
+#define OBJECT_UPTO(...) __CPROVER_object_upto(__VA_ARGS__)
 
 // Pointer-related predicates
 // https://diffblue.github.io/cbmc/contracts-memory-predicates.html
-#define IS_FRESH(...)          __CPROVER_is_fresh(__VA_ARGS__)
-#define POINTER_IN_RANGE(...)  __CPROVER_pointer_in_range_dfcc(__VA_ARGS__)
+#define IS_FRESH(...) __CPROVER_is_fresh(__VA_ARGS__)
+#define POINTER_IN_RANGE(...) __CPROVER_pointer_in_range_dfcc(__VA_ARGS__)
 
 // Function pointer/contract establishment
 // https://diffblue.github.io/cbmc/contracts-function-pointer-predicates.html
-#define OBEYS_CONTRACT(...)      __CPROVER_obeys_contract(__VA_ARGS__)
+#define OBEYS_CONTRACT(...) __CPROVER_obeys_contract(__VA_ARGS__)
 
 // History variables
 // https://diffblue.github.io/cbmc/contracts-history-variables.html
-#define OLD(...)             __CPROVER_old(__VA_ARGS__)
-#define LOOP_ENTRY(...)      __CPROVER_loop_entry(__VA_ARGS__)
+#define OLD(...) __CPROVER_old(__VA_ARGS__)
+#define LOOP_ENTRY(...) __CPROVER_loop_entry(__VA_ARGS__)
 
 // Quantifiers
 // Note that the range on qvar is _inclusive_ between qvar_lb .. qvar_ub
 // https://diffblue.github.io/cbmc/contracts-quantifiers.html
-#define FORALL(type, qvar, qvar_lb, qvar_ub, predicate) __CPROVER_forall { type qvar; ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) ==> ( predicate ) }
-#define EXISTS(type, qvar, qvar_lb, qvar_ub, predicate) __CPROVER_exists { type qvar; ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub))  && ( predicate ) }
+
+// Prevent clang-format from corrupting CBMC's special ==> operator
+// clang-format off
+#define FORALL(type, qvar, qvar_lb, qvar_ub, predicate)          \
+  __CPROVER_forall                                               \
+  {                                                              \
+    type qvar;                                                   \
+    ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) ==> (predicate) \
+  }
+// clang-format on
+
+#define EXISTS(type, qvar, qvar_lb, qvar_ub, predicate)         \
+  __CPROVER_exists {                                            \
+    type qvar;                                                  \
+    ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) && (predicate) \
+  }
 
 ///////////////////////////////////////////////////
 // Convenience macros for common contract patterns
 ///////////////////////////////////////////////////
 
-// Boolean-value predidate that asserts that "all values of array_var are in range value_lb .. value_ub (inclusive)"
+// Boolean-value predidate that asserts that "all values of array_var are in
+// range value_lb .. value_ub (inclusive)"
 //
 // Example:
-//  ARRAY_IN_BOUNDS(unsigned, k, 0, KYBER_N-1, a->coeffs, -(KYBER_Q - 1), KYBER_Q - 1)
+//  ARRAY_IN_BOUNDS(unsigned, k, 0, KYBER_N-1, a->coeffs, -(KYBER_Q - 1),
+//  KYBER_Q - 1)
 // expands to
-//  __CPROVER_forall { unsigned k; (0 <= k && k <= KYBER_N-1) ==> ( (-(KYBER_Q - 1) <= a->coeffs[k]) && (a->coeffs[k] <= (KYBER_Q - 1))) }
+//  __CPROVER_forall { unsigned k; (0 <= k && k <= KYBER_N-1) ==> ( (-(KYBER_Q -
+//  1) <= a->coeffs[k]) && (a->coeffs[k] <= (KYBER_Q - 1))) }
 
-#define ARRAY_IN_BOUNDS(indextype, qvar, qvar_lb, qvar_ub, array_var, value_lb, value_ub) __CPROVER_forall { indextype qvar; ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) ==> ( ((value_lb) <= (array_var[(qvar)])) && ((array_var[(qvar)]) <= (value_ub))) }
+// Prevent clang-format from corrupting CBMC's special ==> operator
+// clang-format off
+#define ARRAY_IN_BOUNDS(indextype, qvar, qvar_lb, qvar_ub, array_var, \
+                        value_lb, value_ub)                           \
+  __CPROVER_forall                                                    \
+  {                                                                   \
+    indextype qvar;                                                   \
+    ((qvar_lb) <= (qvar) && (qvar) <= (qvar_ub)) ==>                  \
+          (((value_lb) <= (array_var[(qvar)])) &&                     \
+           ((array_var[(qvar)]) <= (value_ub)))                       \
+  }
+// clang-format on
 
 #endif

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -1,428 +1,421 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "indcpa.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include "params.h"
-#include "indcpa.h"
-#include "polyvec.h"
-#include "poly.h"
-#include "ntt.h"
-#include "symmetric.h"
-#include "randombytes.h"
-#include "fips202x4.h"
 #include "fips202.h"
+#include "fips202x4.h"
+#include "ntt.h"
+#include "params.h"
+#include "poly.h"
+#include "polyvec.h"
+#include "randombytes.h"
+#include "symmetric.h"
 
 /*************************************************
-* Name:        pack_pk
-*
-* Description: Serialize the public key as concatenation of the
-*              serialized vector of polynomials pk
-*              and the public seed used to generate the matrix A.
-*
-* Arguments:   uint8_t *r: pointer to the output serialized public key
-*              polyvec *pk: pointer to the input public-key polyvec
-*              const uint8_t *seed: pointer to the input public seed
-**************************************************/
-static void pack_pk(uint8_t r[KYBER_INDCPA_PUBLICKEYBYTES],
-                    polyvec *pk,
-                    const uint8_t seed[KYBER_SYMBYTES])
-{
-    polyvec_tobytes(r, pk);
-    memcpy(r + KYBER_POLYVECBYTES, seed, KYBER_SYMBYTES);
+ * Name:        pack_pk
+ *
+ * Description: Serialize the public key as concatenation of the
+ *              serialized vector of polynomials pk
+ *              and the public seed used to generate the matrix A.
+ *
+ * Arguments:   uint8_t *r: pointer to the output serialized public key
+ *              polyvec *pk: pointer to the input public-key polyvec
+ *              const uint8_t *seed: pointer to the input public seed
+ **************************************************/
+static void pack_pk(uint8_t r[KYBER_INDCPA_PUBLICKEYBYTES], polyvec *pk,
+                    const uint8_t seed[KYBER_SYMBYTES]) {
+  polyvec_tobytes(r, pk);
+  memcpy(r + KYBER_POLYVECBYTES, seed, KYBER_SYMBYTES);
 }
 
 /*************************************************
-* Name:        unpack_pk
-*
-* Description: De-serialize public key from a byte array;
-*              approximate inverse of pack_pk
-*
-* Arguments:   - polyvec *pk: pointer to output public-key polynomial vector
-*              - uint8_t *seed: pointer to output seed to generate matrix A
-*              - const uint8_t *packedpk: pointer to input serialized public key
-**************************************************/
-static void unpack_pk(polyvec *pk,
-                      uint8_t seed[KYBER_SYMBYTES],
-                      const uint8_t packedpk[KYBER_INDCPA_PUBLICKEYBYTES])
-{
-    polyvec_frombytes(pk, packedpk);
-    memcpy(seed, packedpk + KYBER_POLYVECBYTES, KYBER_SYMBYTES);
+ * Name:        unpack_pk
+ *
+ * Description: De-serialize public key from a byte array;
+ *              approximate inverse of pack_pk
+ *
+ * Arguments:   - polyvec *pk: pointer to output public-key polynomial vector
+ *              - uint8_t *seed: pointer to output seed to generate matrix A
+ *              - const uint8_t *packedpk: pointer to input serialized public
+ *key
+ **************************************************/
+static void unpack_pk(polyvec *pk, uint8_t seed[KYBER_SYMBYTES],
+                      const uint8_t packedpk[KYBER_INDCPA_PUBLICKEYBYTES]) {
+  polyvec_frombytes(pk, packedpk);
+  memcpy(seed, packedpk + KYBER_POLYVECBYTES, KYBER_SYMBYTES);
 }
 
 /*************************************************
-* Name:        pack_sk
-*
-* Description: Serialize the secret key
-*
-* Arguments:   - uint8_t *r: pointer to output serialized secret key
-*              - polyvec *sk: pointer to input vector of polynomials (secret key)
-**************************************************/
-static void pack_sk(uint8_t r[KYBER_INDCPA_SECRETKEYBYTES], polyvec *sk)
-{
-    polyvec_tobytes(r, sk);
+ * Name:        pack_sk
+ *
+ * Description: Serialize the secret key
+ *
+ * Arguments:   - uint8_t *r: pointer to output serialized secret key
+ *              - polyvec *sk: pointer to input vector of polynomials (secret
+ *key)
+ **************************************************/
+static void pack_sk(uint8_t r[KYBER_INDCPA_SECRETKEYBYTES], polyvec *sk) {
+  polyvec_tobytes(r, sk);
 }
 
 /*************************************************
-* Name:        unpack_sk
-*
-* Description: De-serialize the secret key; inverse of pack_sk
-*
-* Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret key)
-*              - const uint8_t *packedsk: pointer to input serialized secret key
-**************************************************/
-static void unpack_sk(polyvec *sk, const uint8_t packedsk[KYBER_INDCPA_SECRETKEYBYTES])
-{
-    polyvec_frombytes(sk, packedsk);
+ * Name:        unpack_sk
+ *
+ * Description: De-serialize the secret key; inverse of pack_sk
+ *
+ * Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret
+ *key)
+ *              - const uint8_t *packedsk: pointer to input serialized secret
+ *key
+ **************************************************/
+static void unpack_sk(polyvec *sk,
+                      const uint8_t packedsk[KYBER_INDCPA_SECRETKEYBYTES]) {
+  polyvec_frombytes(sk, packedsk);
 }
 
 /*************************************************
-* Name:        pack_ciphertext
-*
-* Description: Serialize the ciphertext as concatenation of the
-*              compressed and serialized vector of polynomials b
-*              and the compressed and serialized polynomial v
-*
-* Arguments:   uint8_t *r: pointer to the output serialized ciphertext
-*              poly *pk: pointer to the input vector of polynomials b
-*              poly *v: pointer to the input polynomial v
-**************************************************/
-static void pack_ciphertext(uint8_t r[KYBER_INDCPA_BYTES], polyvec *b, poly *v)
-{
-    polyvec_compress(r, b);
-    poly_compress(r + KYBER_POLYVECCOMPRESSEDBYTES, v);
+ * Name:        pack_ciphertext
+ *
+ * Description: Serialize the ciphertext as concatenation of the
+ *              compressed and serialized vector of polynomials b
+ *              and the compressed and serialized polynomial v
+ *
+ * Arguments:   uint8_t *r: pointer to the output serialized ciphertext
+ *              poly *pk: pointer to the input vector of polynomials b
+ *              poly *v: pointer to the input polynomial v
+ **************************************************/
+static void pack_ciphertext(uint8_t r[KYBER_INDCPA_BYTES], polyvec *b,
+                            poly *v) {
+  polyvec_compress(r, b);
+  poly_compress(r + KYBER_POLYVECCOMPRESSEDBYTES, v);
 }
 
 /*************************************************
-* Name:        unpack_ciphertext
-*
-* Description: De-serialize and decompress ciphertext from a byte array;
-*              approximate inverse of pack_ciphertext
-*
-* Arguments:   - polyvec *b: pointer to the output vector of polynomials b
-*              - poly *v: pointer to the output polynomial v
-*              - const uint8_t *c: pointer to the input serialized ciphertext
-**************************************************/
-static void unpack_ciphertext(polyvec *b, poly *v, const uint8_t c[KYBER_INDCPA_BYTES])
-{
-    polyvec_decompress(b, c);
-    poly_decompress(v, c + KYBER_POLYVECCOMPRESSEDBYTES);
+ * Name:        unpack_ciphertext
+ *
+ * Description: De-serialize and decompress ciphertext from a byte array;
+ *              approximate inverse of pack_ciphertext
+ *
+ * Arguments:   - polyvec *b: pointer to the output vector of polynomials b
+ *              - poly *v: pointer to the output polynomial v
+ *              - const uint8_t *c: pointer to the input serialized ciphertext
+ **************************************************/
+static void unpack_ciphertext(polyvec *b, poly *v,
+                              const uint8_t c[KYBER_INDCPA_BYTES]) {
+  polyvec_decompress(b, c);
+  poly_decompress(v, c + KYBER_POLYVECCOMPRESSEDBYTES);
 }
 
 /*************************************************
-* Name:        rej_uniform
-*
-* Description: Run rejection sampling on uniform random bytes to generate
-*              uniform random integers mod q
-*
-* Arguments:   - int16_t *r: pointer to output buffer
-*              - unsigned int len: requested number of 16-bit integers (uniform mod q)
-*              - const uint8_t *buf: pointer to input buffer (assumed to be uniformly random bytes)
-*              - unsigned int buflen: length of input buffer in bytes
-*
-* Returns number of sampled 16-bit integers (at most len)
-**************************************************/
-static unsigned int rej_uniform(int16_t *r,
-                                unsigned int len,
-                                const uint8_t *buf,
-                                unsigned int buflen)
-{
-    unsigned int ctr, pos;
-    uint16_t val0, val1;
+ * Name:        rej_uniform
+ *
+ * Description: Run rejection sampling on uniform random bytes to generate
+ *              uniform random integers mod q
+ *
+ * Arguments:   - int16_t *r: pointer to output buffer
+ *              - unsigned int len: requested number of 16-bit integers (uniform
+ *mod q)
+ *              - const uint8_t *buf: pointer to input buffer (assumed to be
+ *uniformly random bytes)
+ *              - unsigned int buflen: length of input buffer in bytes
+ *
+ * Returns number of sampled 16-bit integers (at most len)
+ **************************************************/
+static unsigned int rej_uniform(int16_t *r, unsigned int len,
+                                const uint8_t *buf, unsigned int buflen) {
+  unsigned int ctr, pos;
+  uint16_t val0, val1;
 
-    ctr = pos = 0;
-    while (ctr < len && pos + 3 <= buflen)
-    {
-        val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
-        val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;
-        pos += 3;
+  ctr = pos = 0;
+  while (ctr < len && pos + 3 <= buflen) {
+    val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
+    val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;
+    pos += 3;
 
-        if (val0 < KYBER_Q)
-        {
-            r[ctr++] = val0;
-        }
-        if (ctr < len && val1 < KYBER_Q)
-        {
-            r[ctr++] = val1;
-        }
+    if (val0 < KYBER_Q) {
+      r[ctr++] = val0;
     }
+    if (ctr < len && val1 < KYBER_Q) {
+      r[ctr++] = val1;
+    }
+  }
 
-    return ctr;
+  return ctr;
 }
 
-#define gen_a(A,B)  gen_matrix(A,B,0)
-#define gen_at(A,B) gen_matrix(A,B,1)
+#define gen_a(A, B) gen_matrix(A, B, 0)
+#define gen_at(A, B) gen_matrix(A, B, 1)
 
 /*************************************************
-* Name:        gen_matrix
-*
-* Description: Deterministically generate matrix A (or the transpose of A)
-*              from a seed. Entries of the matrix are polynomials that look
-*              uniformly random. Performs rejection sampling on output of
-*              a XOF
-*
-* Arguments:   - polyvec *a: pointer to ouptput matrix A
-*              - const uint8_t *seed: pointer to input seed
-*              - int transposed: boolean deciding whether A or A^T is generated
-**************************************************/
-#define GEN_MATRIX_NBLOCKS ((12*KYBER_N/8*(1 << 12)/KYBER_Q + SHAKE128_RATE)/SHAKE128_RATE)
+ * Name:        gen_matrix
+ *
+ * Description: Deterministically generate matrix A (or the transpose of A)
+ *              from a seed. Entries of the matrix are polynomials that look
+ *              uniformly random. Performs rejection sampling on output of
+ *              a XOF
+ *
+ * Arguments:   - polyvec *a: pointer to ouptput matrix A
+ *              - const uint8_t *seed: pointer to input seed
+ *              - int transposed: boolean deciding whether A or A^T is generated
+ **************************************************/
+#define GEN_MATRIX_NBLOCKS \
+  ((12 * KYBER_N / 8 * (1 << 12) / KYBER_Q + SHAKE128_RATE) / SHAKE128_RATE)
 // Not static for benchmarking
-void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES], int transposed)
-{
-    unsigned int ctr[KECCAK_WAY], i;
-    unsigned int buflen;
-    uint8_t bufx[KECCAK_WAY][GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
-    int16_t *vec[KECCAK_WAY] = { NULL };
+void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES],
+                int transposed) {
+  unsigned int ctr[KECCAK_WAY], i;
+  unsigned int buflen;
+  uint8_t bufx[KECCAK_WAY][GEN_MATRIX_NBLOCKS * SHAKE128_RATE];
+  int16_t *vec[KECCAK_WAY] = {NULL};
 
-    keccakx4_state statex;
-    // The input data to each Keccak lane.
-    // Original size; KYBER_SYMBYTES + 2, we add padding to make align load/store.
-    uint8_t seedxy[KECCAK_WAY][KYBER_SYMBYTES + 16];
-    for (unsigned j = 0; j < KECCAK_WAY; j++)
-    {
-        memcpy(seedxy[j], seed, KYBER_SYMBYTES);
+  keccakx4_state statex;
+  // The input data to each Keccak lane.
+  // Original size; KYBER_SYMBYTES + 2, we add padding to make align load/store.
+  uint8_t seedxy[KECCAK_WAY][KYBER_SYMBYTES + 16];
+  for (unsigned j = 0; j < KECCAK_WAY; j++) {
+    memcpy(seedxy[j], seed, KYBER_SYMBYTES);
+  }
+
+  // TODO: All loops in this function should be unrolled for decent
+  // performance.
+  //
+  // Either add suitable pragmas, or split gen_matrix according to KYBER_K
+  // and unroll by hand.
+
+  for (i = 0; i < (KYBER_K * KYBER_K / KECCAK_WAY) * KECCAK_WAY;
+       i += KECCAK_WAY) {
+    uint8_t x, y;
+
+    for (unsigned int j = 0; j < KECCAK_WAY; j++) {
+      x = (i + j) / KYBER_K;
+      y = (i + j) % KYBER_K;
+      if (transposed) {
+        seedxy[j][KYBER_SYMBYTES + 0] = x;
+        seedxy[j][KYBER_SYMBYTES + 1] = y;
+      } else {
+        seedxy[j][KYBER_SYMBYTES + 0] = y;
+        seedxy[j][KYBER_SYMBYTES + 1] = x;
+      }
     }
 
-    // TODO: All loops in this function should be unrolled for decent
-    // performance.
-    //
-    // Either add suitable pragmas, or split gen_matrix according to KYBER_K
-    // and unroll by hand.
+    shake128x4_absorb(&statex, seedxy[0], seedxy[1], seedxy[2], seedxy[3],
+                      KYBER_SYMBYTES + 2);
+    shake128x4_squeezeblocks(bufx[0], bufx[1], bufx[2], bufx[3],
+                             GEN_MATRIX_NBLOCKS, &statex);
 
-    for (i = 0; i < (KYBER_K * KYBER_K / KECCAK_WAY) * KECCAK_WAY; i += KECCAK_WAY)
-    {
-        uint8_t x, y;
-
-        for (unsigned int j = 0; j < KECCAK_WAY; j++)
-        {
-            x = (i + j) / KYBER_K;
-            y = (i + j) % KYBER_K;
-            if (transposed)
-            {
-                seedxy[j][KYBER_SYMBYTES + 0] = x;
-                seedxy[j][KYBER_SYMBYTES + 1] = y;
-            }
-            else
-            {
-                seedxy[j][KYBER_SYMBYTES + 0] = y;
-                seedxy[j][KYBER_SYMBYTES + 1] = x;
-            }
-        }
-
-        shake128x4_absorb(&statex, seedxy[0], seedxy[1], seedxy[2], seedxy[3], KYBER_SYMBYTES + 2);
-        shake128x4_squeezeblocks(bufx[0], bufx[1], bufx[2], bufx[3], GEN_MATRIX_NBLOCKS, &statex);
-
-        for (unsigned int j = 0; j < KECCAK_WAY; j++)
-        {
-            x = (i + j) / KYBER_K;
-            y = (i + j) % KYBER_K;
-            vec[j] = a[x].vec[y].coeffs;
-            buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
-            ctr[j] = rej_uniform(vec[j], KYBER_N, bufx[j], buflen);
-        }
-
-        while (ctr[0] < KYBER_N || ctr[1] < KYBER_N || ctr[2] < KYBER_N || ctr[3] < KYBER_N )
-        {
-            shake128x4_squeezeblocks(bufx[0], bufx[1], bufx[2], bufx[3], GEN_MATRIX_NBLOCKS, &statex);
-            buflen = SHAKE128_RATE;
-
-            for (unsigned j = 0; j < KECCAK_WAY; j++)
-            {
-                ctr[j] += rej_uniform(vec[j] + ctr[j], KYBER_N - ctr[j], bufx[j], buflen);
-            }
-        }
+    for (unsigned int j = 0; j < KECCAK_WAY; j++) {
+      x = (i + j) / KYBER_K;
+      y = (i + j) % KYBER_K;
+      vec[j] = a[x].vec[y].coeffs;
+      buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
+      ctr[j] = rej_uniform(vec[j], KYBER_N, bufx[j], buflen);
     }
 
-    // For left over vector, we use single keccak.
-    for (; i < KYBER_K * KYBER_K; i++)
-    {
-        shake128ctx state;
-        uint8_t x, y;
+    while (ctr[0] < KYBER_N || ctr[1] < KYBER_N || ctr[2] < KYBER_N ||
+           ctr[3] < KYBER_N) {
+      shake128x4_squeezeblocks(bufx[0], bufx[1], bufx[2], bufx[3],
+                               GEN_MATRIX_NBLOCKS, &statex);
+      buflen = SHAKE128_RATE;
 
-        x = i / KYBER_K;
-        y = i % KYBER_K;
-        vec[0] = a[x].vec[y].coeffs;
-
-        if (transposed)
-        {
-            seedxy[0][KYBER_SYMBYTES + 0] = x;
-            seedxy[0][KYBER_SYMBYTES + 1] = y;
-            shake128_absorb(&state, seedxy[0], KYBER_SYMBYTES + 2);
-        }
-        else
-        {
-            seedxy[0][KYBER_SYMBYTES + 0] = y;
-            seedxy[0][KYBER_SYMBYTES + 1] = x;
-            shake128_absorb(&state, seedxy[0], KYBER_SYMBYTES + 2);
-        }
-
-        shake128_squeezeblocks(bufx[0], GEN_MATRIX_NBLOCKS, &state);
-        buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
-        ctr[0] = rej_uniform(vec[0], KYBER_N, bufx[0], buflen);
-
-        while (ctr[0] < KYBER_N)
-        {
-            shake128_squeezeblocks(bufx[0], 1, &state);
-            buflen = SHAKE128_RATE;
-            ctr[0] += rej_uniform(vec[0] + ctr[0], KYBER_N - ctr[0], bufx[0], buflen);
-        }
+      for (unsigned j = 0; j < KECCAK_WAY; j++) {
+        ctr[j] +=
+            rej_uniform(vec[j] + ctr[j], KYBER_N - ctr[j], bufx[j], buflen);
+      }
     }
+  }
+
+  // For left over vector, we use single keccak.
+  for (; i < KYBER_K * KYBER_K; i++) {
+    shake128ctx state;
+    uint8_t x, y;
+
+    x = i / KYBER_K;
+    y = i % KYBER_K;
+    vec[0] = a[x].vec[y].coeffs;
+
+    if (transposed) {
+      seedxy[0][KYBER_SYMBYTES + 0] = x;
+      seedxy[0][KYBER_SYMBYTES + 1] = y;
+      shake128_absorb(&state, seedxy[0], KYBER_SYMBYTES + 2);
+    } else {
+      seedxy[0][KYBER_SYMBYTES + 0] = y;
+      seedxy[0][KYBER_SYMBYTES + 1] = x;
+      shake128_absorb(&state, seedxy[0], KYBER_SYMBYTES + 2);
+    }
+
+    shake128_squeezeblocks(bufx[0], GEN_MATRIX_NBLOCKS, &state);
+    buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
+    ctr[0] = rej_uniform(vec[0], KYBER_N, bufx[0], buflen);
+
+    while (ctr[0] < KYBER_N) {
+      shake128_squeezeblocks(bufx[0], 1, &state);
+      buflen = SHAKE128_RATE;
+      ctr[0] += rej_uniform(vec[0] + ctr[0], KYBER_N - ctr[0], bufx[0], buflen);
+    }
+  }
 }
 
 /*************************************************
-* Name:        indcpa_keypair_derand
-*
-* Description: Generates public and private key for the CPA-secure
-*              public-key encryption scheme underlying Kyber
-*
-* Arguments:   - uint8_t *pk: pointer to output public key
-*                             (of length KYBER_INDCPA_PUBLICKEYBYTES bytes)
-*              - uint8_t *sk: pointer to output private key
-*                             (of length KYBER_INDCPA_SECRETKEYBYTES bytes)
-*              - const uint8_t *coins: pointer to input randomness
-*                             (of length KYBER_SYMBYTES bytes)
-**************************************************/
+ * Name:        indcpa_keypair_derand
+ *
+ * Description: Generates public and private key for the CPA-secure
+ *              public-key encryption scheme underlying Kyber
+ *
+ * Arguments:   - uint8_t *pk: pointer to output public key
+ *                             (of length KYBER_INDCPA_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk: pointer to output private key
+ *                             (of length KYBER_INDCPA_SECRETKEYBYTES bytes)
+ *              - const uint8_t *coins: pointer to input randomness
+ *                             (of length KYBER_SYMBYTES bytes)
+ **************************************************/
 void indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES],
-                           const uint8_t coins[KYBER_SYMBYTES])
-{
-    unsigned int i;
-    uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
-    const uint8_t *publicseed = buf;
-    const uint8_t *noiseseed = buf + KYBER_SYMBYTES;
-    polyvec a[KYBER_K], e, pkpv, skpv;
-    polyvec_mulcache skpv_cache;
+                           const uint8_t coins[KYBER_SYMBYTES]) {
+  unsigned int i;
+  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
+  const uint8_t *publicseed = buf;
+  const uint8_t *noiseseed = buf + KYBER_SYMBYTES;
+  polyvec a[KYBER_K], e, pkpv, skpv;
+  polyvec_mulcache skpv_cache;
 
-    // Add KYBER_K for domain separation of security levels
-    memcpy(buf, coins, KYBER_SYMBYTES);
-    buf[KYBER_SYMBYTES] = KYBER_K;
-    hash_g(buf, buf, KYBER_SYMBYTES+1);
+  // Add KYBER_K for domain separation of security levels
+  memcpy(buf, coins, KYBER_SYMBYTES);
+  buf[KYBER_SYMBYTES] = KYBER_K;
+  hash_g(buf, buf, KYBER_SYMBYTES + 1);
 
-    gen_a(a, publicseed);
+  gen_a(a, publicseed);
 
-    #if KYBER_K == 2
-    poly_getnoise_eta1_4x(skpv.vec+0, skpv.vec+1, e.vec+0, e.vec+1, noiseseed, 0, 1, 2, 3);
-    #elif KYBER_K == 3
-    poly_getnoise_eta1_4x(skpv.vec+0, skpv.vec+1, skpv.vec+2, e.vec+0, noiseseed, 0, 1, 2, 3);
-    poly_getnoise_eta1_4x(e.vec+1, e.vec+2, pkpv.vec+0, pkpv.vec+1, noiseseed, 4, 5, 6, 7);
-    #elif KYBER_K == 4
-    poly_getnoise_eta1_4x(skpv.vec+0, skpv.vec+1, skpv.vec+2, skpv.vec+3, noiseseed,  0, 1, 2, 3);
-    poly_getnoise_eta1_4x(e.vec+0, e.vec+1, e.vec+2, e.vec+3, noiseseed, 4, 5, 6, 7);
-    #endif
+#if KYBER_K == 2
+  poly_getnoise_eta1_4x(skpv.vec + 0, skpv.vec + 1, e.vec + 0, e.vec + 1,
+                        noiseseed, 0, 1, 2, 3);
+#elif KYBER_K == 3
+  poly_getnoise_eta1_4x(skpv.vec + 0, skpv.vec + 1, skpv.vec + 2, e.vec + 0,
+                        noiseseed, 0, 1, 2, 3);
+  poly_getnoise_eta1_4x(e.vec + 1, e.vec + 2, pkpv.vec + 0, pkpv.vec + 1,
+                        noiseseed, 4, 5, 6, 7);
+#elif KYBER_K == 4
+  poly_getnoise_eta1_4x(skpv.vec + 0, skpv.vec + 1, skpv.vec + 2, skpv.vec + 3,
+                        noiseseed, 0, 1, 2, 3);
+  poly_getnoise_eta1_4x(e.vec + 0, e.vec + 1, e.vec + 2, e.vec + 3, noiseseed,
+                        4, 5, 6, 7);
+#endif
 
-    polyvec_ntt(&skpv);
-    polyvec_ntt(&e);
+  polyvec_ntt(&skpv);
+  polyvec_ntt(&e);
 
-    polyvec_mulcache_compute(&skpv_cache, &skpv);
+  polyvec_mulcache_compute(&skpv_cache, &skpv);
 
-    // matrix-vector multiplication
-    for (i = 0; i < KYBER_K; i++)
-    {
-        polyvec_basemul_acc_montgomery_cached(&pkpv.vec[i], &a[i], &skpv, &skpv_cache);
-        poly_tomont(&pkpv.vec[i]);
-    }
+  // matrix-vector multiplication
+  for (i = 0; i < KYBER_K; i++) {
+    polyvec_basemul_acc_montgomery_cached(&pkpv.vec[i], &a[i], &skpv,
+                                          &skpv_cache);
+    poly_tomont(&pkpv.vec[i]);
+  }
 
-    polyvec_add(&pkpv, &pkpv, &e);
-    polyvec_reduce(&pkpv);
+  polyvec_add(&pkpv, &pkpv, &e);
+  polyvec_reduce(&pkpv);
 
-    pack_sk(sk, &skpv);
-    pack_pk(pk, &pkpv, publicseed);
+  pack_sk(sk, &skpv);
+  pack_pk(pk, &pkpv, publicseed);
 }
 
 /*************************************************
-* Name:        indcpa_enc
-*
-* Description: Encryption function of the CPA-secure
-*              public-key encryption scheme underlying Kyber.
-*
-* Arguments:   - uint8_t *c: pointer to output ciphertext
-*                            (of length KYBER_INDCPA_BYTES bytes)
-*              - const uint8_t *m: pointer to input message
-*                                  (of length KYBER_INDCPA_MSGBYTES bytes)
-*              - const uint8_t *pk: pointer to input public key
-*                                   (of length KYBER_INDCPA_PUBLICKEYBYTES)
-*              - const uint8_t *coins: pointer to input random coins used as seed
-*                                      (of length KYBER_SYMBYTES) to deterministically
-*                                      generate all randomness
-**************************************************/
+ * Name:        indcpa_enc
+ *
+ * Description: Encryption function of the CPA-secure
+ *              public-key encryption scheme underlying Kyber.
+ *
+ * Arguments:   - uint8_t *c: pointer to output ciphertext
+ *                            (of length KYBER_INDCPA_BYTES bytes)
+ *              - const uint8_t *m: pointer to input message
+ *                                  (of length KYBER_INDCPA_MSGBYTES bytes)
+ *              - const uint8_t *pk: pointer to input public key
+ *                                   (of length KYBER_INDCPA_PUBLICKEYBYTES)
+ *              - const uint8_t *coins: pointer to input random coins used as
+ *seed (of length KYBER_SYMBYTES) to deterministically generate all randomness
+ **************************************************/
 void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
                 const uint8_t m[KYBER_INDCPA_MSGBYTES],
                 const uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
-                const uint8_t coins[KYBER_SYMBYTES])
-{
-    unsigned int i;
-    uint8_t seed[KYBER_SYMBYTES] ALIGN(16);
-    polyvec sp, pkpv, ep, at[KYBER_K], b;
-    polyvec_mulcache sp_cache;
-    poly v, k, epp;
+                const uint8_t coins[KYBER_SYMBYTES]) {
+  unsigned int i;
+  uint8_t seed[KYBER_SYMBYTES] ALIGN(16);
+  polyvec sp, pkpv, ep, at[KYBER_K], b;
+  polyvec_mulcache sp_cache;
+  poly v, k, epp;
 
-    unpack_pk(&pkpv, seed, pk);
-    poly_frommsg(&k, m);
-    gen_at(at, seed);
+  unpack_pk(&pkpv, seed, pk);
+  poly_frommsg(&k, m);
+  gen_at(at, seed);
 
-    #if KYBER_K == 2
-    poly_getnoise_eta1122_4x(sp.vec+0, sp.vec+1, ep.vec+0, ep.vec+1, coins, 0, 1, 2, 3);
-    poly_getnoise_eta2(&epp, coins, 4);
-    #elif KYBER_K == 3
-    poly_getnoise_eta1_4x(sp.vec+0, sp.vec+1, sp.vec+2, ep.vec+0, coins, 0, 1, 2, 3);
-    poly_getnoise_eta1_4x(ep.vec+1, ep.vec+2, &epp, b.vec+0, coins,  4, 5, 6, 7);
-    #elif KYBER_K == 4
-    poly_getnoise_eta1_4x(sp.vec+0, sp.vec+1, sp.vec+2, sp.vec+3, coins, 0, 1, 2, 3);
-    poly_getnoise_eta1_4x(ep.vec+0, ep.vec+1, ep.vec+2, ep.vec+3, coins, 4, 5, 6, 7);
-    poly_getnoise_eta2(&epp, coins, 8);
-    #endif
+#if KYBER_K == 2
+  poly_getnoise_eta1122_4x(sp.vec + 0, sp.vec + 1, ep.vec + 0, ep.vec + 1,
+                           coins, 0, 1, 2, 3);
+  poly_getnoise_eta2(&epp, coins, 4);
+#elif KYBER_K == 3
+  poly_getnoise_eta1_4x(sp.vec + 0, sp.vec + 1, sp.vec + 2, ep.vec + 0, coins,
+                        0, 1, 2, 3);
+  poly_getnoise_eta1_4x(ep.vec + 1, ep.vec + 2, &epp, b.vec + 0, coins, 4, 5, 6,
+                        7);
+#elif KYBER_K == 4
+  poly_getnoise_eta1_4x(sp.vec + 0, sp.vec + 1, sp.vec + 2, sp.vec + 3, coins,
+                        0, 1, 2, 3);
+  poly_getnoise_eta1_4x(ep.vec + 0, ep.vec + 1, ep.vec + 2, ep.vec + 3, coins,
+                        4, 5, 6, 7);
+  poly_getnoise_eta2(&epp, coins, 8);
+#endif
 
-    polyvec_ntt(&sp);
-    polyvec_mulcache_compute(&sp_cache, &sp);
+  polyvec_ntt(&sp);
+  polyvec_mulcache_compute(&sp_cache, &sp);
 
-    // matrix-vector multiplication
-    for (i = 0; i < KYBER_K; i++)
-    {
-        polyvec_basemul_acc_montgomery_cached(&b.vec[i], &at[i], &sp, &sp_cache);
-    }
+  // matrix-vector multiplication
+  for (i = 0; i < KYBER_K; i++) {
+    polyvec_basemul_acc_montgomery_cached(&b.vec[i], &at[i], &sp, &sp_cache);
+  }
 
-    polyvec_basemul_acc_montgomery(&v, &pkpv, &sp);
+  polyvec_basemul_acc_montgomery(&v, &pkpv, &sp);
 
-    polyvec_invntt_tomont(&b);
-    poly_invntt_tomont(&v);
+  polyvec_invntt_tomont(&b);
+  poly_invntt_tomont(&v);
 
-    polyvec_add(&b, &b, &ep);
-    poly_add(&v, &v, &epp);
-    poly_add(&v, &v, &k);
-    polyvec_reduce(&b);
-    poly_reduce(&v);
+  polyvec_add(&b, &b, &ep);
+  poly_add(&v, &v, &epp);
+  poly_add(&v, &v, &k);
+  polyvec_reduce(&b);
+  poly_reduce(&v);
 
-    pack_ciphertext(c, &b, &v);
+  pack_ciphertext(c, &b, &v);
 }
 
 /*************************************************
-* Name:        indcpa_dec
-*
-* Description: Decryption function of the CPA-secure
-*              public-key encryption scheme underlying Kyber.
-*
-* Arguments:   - uint8_t *m: pointer to output decrypted message
-*                            (of length KYBER_INDCPA_MSGBYTES)
-*              - const uint8_t *c: pointer to input ciphertext
-*                                  (of length KYBER_INDCPA_BYTES)
-*              - const uint8_t *sk: pointer to input secret key
-*                                   (of length KYBER_INDCPA_SECRETKEYBYTES)
-**************************************************/
+ * Name:        indcpa_dec
+ *
+ * Description: Decryption function of the CPA-secure
+ *              public-key encryption scheme underlying Kyber.
+ *
+ * Arguments:   - uint8_t *m: pointer to output decrypted message
+ *                            (of length KYBER_INDCPA_MSGBYTES)
+ *              - const uint8_t *c: pointer to input ciphertext
+ *                                  (of length KYBER_INDCPA_BYTES)
+ *              - const uint8_t *sk: pointer to input secret key
+ *                                   (of length KYBER_INDCPA_SECRETKEYBYTES)
+ **************************************************/
 void indcpa_dec(uint8_t m[KYBER_INDCPA_MSGBYTES],
                 const uint8_t c[KYBER_INDCPA_BYTES],
-                const uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES])
-{
-    polyvec b, skpv;
-    poly v, mp;
+                const uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES]) {
+  polyvec b, skpv;
+  poly v, mp;
 
-    unpack_ciphertext(&b, &v, c);
-    unpack_sk(&skpv, sk);
+  unpack_ciphertext(&b, &v, c);
+  unpack_sk(&skpv, sk);
 
-    polyvec_ntt(&b);
-    polyvec_basemul_acc_montgomery(&mp, &skpv, &b);
-    poly_invntt_tomont(&mp);
+  polyvec_ntt(&b);
+  polyvec_basemul_acc_montgomery(&mp, &skpv, &b);
+  poly_invntt_tomont(&mp);
 
-    poly_sub(&mp, &v, &mp);
-    poly_reduce(&mp);
+  poly_sub(&mp, &v, &mp);
+  poly_reduce(&mp);
 
-    poly_tomsg(m, &mp);
+  poly_tomsg(m, &mp);
 }

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -1,170 +1,161 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "kem.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include "params.h"
-#include "kem.h"
 #include "indcpa.h"
-#include "verify.h"
-#include "symmetric.h"
+#include "params.h"
 #include "randombytes.h"
+#include "symmetric.h"
+#include "verify.h"
 /*************************************************
-* Name:        crypto_kem_keypair_derand
-*
-* Description: Generates public and private key
-*              for CCA-secure Kyber key encapsulation mechanism
-*
-* Arguments:   - uint8_t *pk: pointer to output public key
-*                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
-*              - uint8_t *sk: pointer to output private key
-*                (an already allocated array of KYBER_SECRETKEYBYTES bytes)
-*              - uint8_t *coins: pointer to input randomness
-*                (an already allocated array filled with 2*KYBER_SYMBYTES random bytes)
-**
-* Returns 0 (success)
-**************************************************/
-int crypto_kem_keypair_derand(uint8_t *pk,
-                              uint8_t *sk,
-                              const uint8_t *coins)
-{
-    indcpa_keypair_derand(pk, sk, coins);
-    memcpy(sk + KYBER_INDCPA_SECRETKEYBYTES, pk, KYBER_PUBLICKEYBYTES);
-    hash_h(sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);
-    /* Value z for pseudo-random output on reject */
-    memcpy(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, coins + KYBER_SYMBYTES, KYBER_SYMBYTES);
-    return 0;
+ * Name:        crypto_kem_keypair_derand
+ *
+ * Description: Generates public and private key
+ *              for CCA-secure Kyber key encapsulation mechanism
+ *
+ * Arguments:   - uint8_t *pk: pointer to output public key
+ *                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk: pointer to output private key
+ *                (an already allocated array of KYBER_SECRETKEYBYTES bytes)
+ *              - uint8_t *coins: pointer to input randomness
+ *                (an already allocated array filled with 2*KYBER_SYMBYTES
+ *random bytes)
+ **
+ * Returns 0 (success)
+ **************************************************/
+int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins) {
+  indcpa_keypair_derand(pk, sk, coins);
+  memcpy(sk + KYBER_INDCPA_SECRETKEYBYTES, pk, KYBER_PUBLICKEYBYTES);
+  hash_h(sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES, pk,
+         KYBER_PUBLICKEYBYTES);
+  /* Value z for pseudo-random output on reject */
+  memcpy(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, coins + KYBER_SYMBYTES,
+         KYBER_SYMBYTES);
+  return 0;
 }
 
 /*************************************************
-* Name:        crypto_kem_keypair
-*
-* Description: Generates public and private key
-*              for CCA-secure Kyber key encapsulation mechanism
-*
-* Arguments:   - uint8_t *pk: pointer to output public key
-*                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
-*              - uint8_t *sk: pointer to output private key
-*                (an already allocated array of KYBER_SECRETKEYBYTES bytes)
-*
-* Returns 0 (success)
-**************************************************/
-int crypto_kem_keypair(uint8_t *pk,
-                       uint8_t *sk)
-{
-    uint8_t coins[2 * KYBER_SYMBYTES] ALIGN(16);
-    randombytes(coins, 2 * KYBER_SYMBYTES);
-    crypto_kem_keypair_derand(pk, sk, coins);
-    return 0;
+ * Name:        crypto_kem_keypair
+ *
+ * Description: Generates public and private key
+ *              for CCA-secure Kyber key encapsulation mechanism
+ *
+ * Arguments:   - uint8_t *pk: pointer to output public key
+ *                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk: pointer to output private key
+ *                (an already allocated array of KYBER_SECRETKEYBYTES bytes)
+ *
+ * Returns 0 (success)
+ **************************************************/
+int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
+  uint8_t coins[2 * KYBER_SYMBYTES] ALIGN(16);
+  randombytes(coins, 2 * KYBER_SYMBYTES);
+  crypto_kem_keypair_derand(pk, sk, coins);
+  return 0;
 }
 
 /*************************************************
-* Name:        crypto_kem_enc_derand
-*
-* Description: Generates cipher text and shared
-*              secret for given public key
-*
-* Arguments:   - uint8_t *ct: pointer to output cipher text
-*                (an already allocated array of KYBER_CIPHERTEXTBYTES bytes)
-*              - uint8_t *ss: pointer to output shared secret
-*                (an already allocated array of KYBER_SSBYTES bytes)
-*              - const uint8_t *pk: pointer to input public key
-*                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
-*              - const uint8_t *coins: pointer to input randomness
-*                (an already allocated array filled with KYBER_SYMBYTES random bytes)
-**
-* Returns 0 (success)
-**************************************************/
-int crypto_kem_enc_derand(uint8_t *ct,
-                          uint8_t *ss,
-                          const uint8_t *pk,
-                          const uint8_t *coins)
-{
-    uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
-    /* Will contain key, coins */
-    uint8_t kr[2 * KYBER_SYMBYTES] ALIGN(16);
+ * Name:        crypto_kem_enc_derand
+ *
+ * Description: Generates cipher text and shared
+ *              secret for given public key
+ *
+ * Arguments:   - uint8_t *ct: pointer to output cipher text
+ *                (an already allocated array of KYBER_CIPHERTEXTBYTES bytes)
+ *              - uint8_t *ss: pointer to output shared secret
+ *                (an already allocated array of KYBER_SSBYTES bytes)
+ *              - const uint8_t *pk: pointer to input public key
+ *                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
+ *              - const uint8_t *coins: pointer to input randomness
+ *                (an already allocated array filled with KYBER_SYMBYTES random
+ *bytes)
+ **
+ * Returns 0 (success)
+ **************************************************/
+int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
+                          const uint8_t *coins) {
+  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
+  /* Will contain key, coins */
+  uint8_t kr[2 * KYBER_SYMBYTES] ALIGN(16);
 
-    memcpy(buf, coins, KYBER_SYMBYTES);
+  memcpy(buf, coins, KYBER_SYMBYTES);
 
-    /* Multitarget countermeasure for coins + contributory KEM */
-    hash_h(buf + KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);
-    hash_g(kr, buf, 2 * KYBER_SYMBYTES);
+  /* Multitarget countermeasure for coins + contributory KEM */
+  hash_h(buf + KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);
+  hash_g(kr, buf, 2 * KYBER_SYMBYTES);
 
-    /* coins are in kr+KYBER_SYMBYTES */
-    indcpa_enc(ct, buf, pk, kr + KYBER_SYMBYTES);
+  /* coins are in kr+KYBER_SYMBYTES */
+  indcpa_enc(ct, buf, pk, kr + KYBER_SYMBYTES);
 
-    memcpy(ss, kr, KYBER_SYMBYTES);
-    return 0;
+  memcpy(ss, kr, KYBER_SYMBYTES);
+  return 0;
 }
 
 /*************************************************
-* Name:        crypto_kem_enc
-*
-* Description: Generates cipher text and shared
-*              secret for given public key
-*
-* Arguments:   - uint8_t *ct: pointer to output cipher text
-*                (an already allocated array of KYBER_CIPHERTEXTBYTES bytes)
-*              - uint8_t *ss: pointer to output shared secret
-*                (an already allocated array of KYBER_SSBYTES bytes)
-*              - const uint8_t *pk: pointer to input public key
-*                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
-*
-* Returns 0 (success)
-**************************************************/
-int crypto_kem_enc(uint8_t *ct,
-                   uint8_t *ss,
-                   const uint8_t *pk)
-{
-    uint8_t coins[KYBER_SYMBYTES] ALIGN(16);
-    randombytes(coins, KYBER_SYMBYTES);
-    crypto_kem_enc_derand(ct, ss, pk, coins);
-    return 0;
+ * Name:        crypto_kem_enc
+ *
+ * Description: Generates cipher text and shared
+ *              secret for given public key
+ *
+ * Arguments:   - uint8_t *ct: pointer to output cipher text
+ *                (an already allocated array of KYBER_CIPHERTEXTBYTES bytes)
+ *              - uint8_t *ss: pointer to output shared secret
+ *                (an already allocated array of KYBER_SSBYTES bytes)
+ *              - const uint8_t *pk: pointer to input public key
+ *                (an already allocated array of KYBER_PUBLICKEYBYTES bytes)
+ *
+ * Returns 0 (success)
+ **************************************************/
+int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
+  uint8_t coins[KYBER_SYMBYTES] ALIGN(16);
+  randombytes(coins, KYBER_SYMBYTES);
+  crypto_kem_enc_derand(ct, ss, pk, coins);
+  return 0;
 }
 
 /*************************************************
-* Name:        crypto_kem_dec
-*
-* Description: Generates shared secret for given
-*              cipher text and private key
-*
-* Arguments:   - uint8_t *ss: pointer to output shared secret
-*                (an already allocated array of KYBER_SSBYTES bytes)
-*              - const uint8_t *ct: pointer to input cipher text
-*                (an already allocated array of KYBER_CIPHERTEXTBYTES bytes)
-*              - const uint8_t *sk: pointer to input private key
-*                (an already allocated array of KYBER_SECRETKEYBYTES bytes)
-*
-* Returns 0.
-*
-* On failure, ss will contain a pseudo-random value.
-**************************************************/
-int crypto_kem_dec(uint8_t *ss,
-                   const uint8_t *ct,
-                   const uint8_t *sk)
-{
-    int fail;
-    uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
-    /* Will contain key, coins */
-    uint8_t kr[2 * KYBER_SYMBYTES] ALIGN(16);
-    uint8_t cmp[KYBER_CIPHERTEXTBYTES + KYBER_SYMBYTES] ALIGN(16);
-    const uint8_t *pk = sk + KYBER_INDCPA_SECRETKEYBYTES;
+ * Name:        crypto_kem_dec
+ *
+ * Description: Generates shared secret for given
+ *              cipher text and private key
+ *
+ * Arguments:   - uint8_t *ss: pointer to output shared secret
+ *                (an already allocated array of KYBER_SSBYTES bytes)
+ *              - const uint8_t *ct: pointer to input cipher text
+ *                (an already allocated array of KYBER_CIPHERTEXTBYTES bytes)
+ *              - const uint8_t *sk: pointer to input private key
+ *                (an already allocated array of KYBER_SECRETKEYBYTES bytes)
+ *
+ * Returns 0.
+ *
+ * On failure, ss will contain a pseudo-random value.
+ **************************************************/
+int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
+  int fail;
+  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
+  /* Will contain key, coins */
+  uint8_t kr[2 * KYBER_SYMBYTES] ALIGN(16);
+  uint8_t cmp[KYBER_CIPHERTEXTBYTES + KYBER_SYMBYTES] ALIGN(16);
+  const uint8_t *pk = sk + KYBER_INDCPA_SECRETKEYBYTES;
 
-    indcpa_dec(buf, ct, sk);
+  indcpa_dec(buf, ct, sk);
 
-    /* Multitarget countermeasure for coins + contributory KEM */
-    memcpy(buf + KYBER_SYMBYTES, sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES, KYBER_SYMBYTES);
-    hash_g(kr, buf, 2 * KYBER_SYMBYTES);
+  /* Multitarget countermeasure for coins + contributory KEM */
+  memcpy(buf + KYBER_SYMBYTES, sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES,
+         KYBER_SYMBYTES);
+  hash_g(kr, buf, 2 * KYBER_SYMBYTES);
 
-    /* coins are in kr+KYBER_SYMBYTES */
-    indcpa_enc(cmp, buf, pk, kr + KYBER_SYMBYTES);
+  /* coins are in kr+KYBER_SYMBYTES */
+  indcpa_enc(cmp, buf, pk, kr + KYBER_SYMBYTES);
 
-    fail = verify(ct, cmp, KYBER_CIPHERTEXTBYTES);
+  fail = verify(ct, cmp, KYBER_CIPHERTEXTBYTES);
 
-    /* Compute rejection key */
-    rkprf(ss, sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, ct);
+  /* Compute rejection key */
+  rkprf(ss, sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, ct);
 
-    /* Copy true key to return buffer if fail is false */
-    cmov(ss, kr, KYBER_SYMBYTES, !fail);
+  /* Copy true key to return buffer if fail is false */
+  cmov(ss, kr, KYBER_SYMBYTES, !fail);
 
-    return 0;
+  return 0;
 }

--- a/mlkem/kem.h
+++ b/mlkem/kem.h
@@ -5,12 +5,12 @@
 #include <stdint.h>
 #include "params.h"
 
-#define CRYPTO_SECRETKEYBYTES  KYBER_SECRETKEYBYTES
-#define CRYPTO_PUBLICKEYBYTES  KYBER_PUBLICKEYBYTES
+#define CRYPTO_SECRETKEYBYTES KYBER_SECRETKEYBYTES
+#define CRYPTO_PUBLICKEYBYTES KYBER_PUBLICKEYBYTES
 #define CRYPTO_CIPHERTEXTBYTES KYBER_CIPHERTEXTBYTES
-#define CRYPTO_BYTES           KYBER_SSBYTES
+#define CRYPTO_BYTES KYBER_SSBYTES
 
-#if   (KYBER_K == 2)
+#if (KYBER_K == 2)
 #define CRYPTO_ALGNAME "Kyber512"
 #elif (KYBER_K == 3)
 #define CRYPTO_ALGNAME "Kyber768"
@@ -25,7 +25,8 @@ int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins);
 int crypto_kem_keypair(uint8_t *pk, uint8_t *sk);
 
 #define crypto_kem_enc_derand KYBER_NAMESPACE(enc_derand)
-int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk, const uint8_t *coins);
+int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
+                          const uint8_t *coins);
 
 #define crypto_kem_enc KYBER_NAMESPACE(enc)
 int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -16,9 +16,11 @@ void poly_ntt(poly *r);
 void poly_invntt_tomont(poly *r);
 
 #define basemul KYBER_NAMESPACE(basemul)
-void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta);
+void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2],
+             int16_t zeta);
 
 #define basemul_cached KYBER_NAMESPACE(basemul_cached)
-void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t b_cached);
+void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2],
+                    int16_t b_cached);
 
 #endif

--- a/mlkem/params.h
+++ b/mlkem/params.h
@@ -6,11 +6,11 @@
 #include "cpucap.h"
 
 #ifndef KYBER_K
-#define KYBER_K 3   /* Change this for different security strengths */
+#define KYBER_K 3 /* Change this for different security strengths */
 #endif
 
 /* Don't change parameters below this line */
-#if   (KYBER_K == 2)
+#if (KYBER_K == 2)
 #define KYBER_NAMESPACE(s) pqcrystals_kyber512_ref_##s
 #elif (KYBER_K == 3)
 #define KYBER_NAMESPACE(s) pqcrystals_kyber768_ref_##s
@@ -23,36 +23,39 @@
 #define KYBER_N 256
 #define KYBER_Q 3329
 
-#define KYBER_SYMBYTES 32   /* size in bytes of hashes, and seeds */
-#define KYBER_SSBYTES  32   /* size in bytes of shared key */
+#define KYBER_SYMBYTES 32 /* size in bytes of hashes, and seeds */
+#define KYBER_SSBYTES 32  /* size in bytes of shared key */
 
-#define KYBER_POLYBYTES     384
-#define KYBER_POLYVECBYTES  (KYBER_K * KYBER_POLYBYTES)
+#define KYBER_POLYBYTES 384
+#define KYBER_POLYVECBYTES (KYBER_K * KYBER_POLYBYTES)
 
 #if KYBER_K == 2
 #define KYBER_ETA1 3
-#define KYBER_POLYCOMPRESSEDBYTES    128
+#define KYBER_POLYCOMPRESSEDBYTES 128
 #define KYBER_POLYVECCOMPRESSEDBYTES (KYBER_K * 320)
 #elif KYBER_K == 3
 #define KYBER_ETA1 2
-#define KYBER_POLYCOMPRESSEDBYTES    128
+#define KYBER_POLYCOMPRESSEDBYTES 128
 #define KYBER_POLYVECCOMPRESSEDBYTES (KYBER_K * 320)
 #elif KYBER_K == 4
 #define KYBER_ETA1 2
-#define KYBER_POLYCOMPRESSEDBYTES    160
+#define KYBER_POLYCOMPRESSEDBYTES 160
 #define KYBER_POLYVECCOMPRESSEDBYTES (KYBER_K * 352)
 #endif
 
 #define KYBER_ETA2 2
 
-#define KYBER_INDCPA_MSGBYTES       (KYBER_SYMBYTES)
+#define KYBER_INDCPA_MSGBYTES (KYBER_SYMBYTES)
 #define KYBER_INDCPA_PUBLICKEYBYTES (KYBER_POLYVECBYTES + KYBER_SYMBYTES)
 #define KYBER_INDCPA_SECRETKEYBYTES (KYBER_POLYVECBYTES)
-#define KYBER_INDCPA_BYTES          (KYBER_POLYVECCOMPRESSEDBYTES + KYBER_POLYCOMPRESSEDBYTES)
+#define KYBER_INDCPA_BYTES \
+  (KYBER_POLYVECCOMPRESSEDBYTES + KYBER_POLYCOMPRESSEDBYTES)
 
-#define KYBER_PUBLICKEYBYTES  (KYBER_INDCPA_PUBLICKEYBYTES)
+#define KYBER_PUBLICKEYBYTES (KYBER_INDCPA_PUBLICKEYBYTES)
 /* 32 bytes of additional space to save H(pk) */
-#define KYBER_SECRETKEYBYTES  (KYBER_INDCPA_SECRETKEYBYTES + KYBER_INDCPA_PUBLICKEYBYTES + 2*KYBER_SYMBYTES)
+#define KYBER_SECRETKEYBYTES                                   \
+  (KYBER_INDCPA_SECRETKEYBYTES + KYBER_INDCPA_PUBLICKEYBYTES + \
+   2 * KYBER_SYMBYTES)
 #define KYBER_CIPHERTEXTBYTES (KYBER_INDCPA_BYTES)
 
 #endif

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -1,156 +1,170 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "poly.h"
 #include <stdint.h>
 #include <string.h>
-#include "cbmc.h"
-#include "params.h"
-#include "poly.h"
-#include "ntt.h"
-#include "reduce.h"
 #include "cbd.h"
+#include "cbmc.h"
+#include "fips202x4.h"
+#include "ntt.h"
+#include "params.h"
+#include "reduce.h"
 #include "symmetric.h"
 #include "verify.h"
-#include "fips202x4.h"
 
 #include "asm/asm.h"
 
 /*************************************************
-* Name:        poly_compress
-*
-* Description: Compression and subsequent serialization of a polynomial
-*
-* Arguments:   - uint8_t *r: pointer to output byte array
-*                            (of length KYBER_POLYCOMPRESSEDBYTES)
-*              - const poly *a: pointer to input polynomial
-**************************************************/
-void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a)
-{
-    uint8_t t[8] = { 0 };
+ * Name:        poly_compress
+ *
+ * Description: Compression and subsequent serialization of a polynomial
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                            (of length KYBER_POLYCOMPRESSEDBYTES)
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
+void poly_compress(uint8_t r[KYBER_POLYCOMPRESSEDBYTES], const poly *a) {
+  uint8_t t[8] = {0};
 
-    const int num_blocks = KYBER_N / 8;
+  const int num_blocks = KYBER_N / 8;
 
-    #if (KYBER_POLYCOMPRESSEDBYTES == 128)
-    for (int i = 0; i < num_blocks; i++)
+#if (KYBER_POLYCOMPRESSEDBYTES == 128)
+  for (int i = 0; i < num_blocks; i++)
+      // clang-format off
         ASSIGNS(i, OBJECT_WHOLE(t), OBJECT_WHOLE(r))
         INVARIANT(i >= 0 && i <= num_blocks)
         DECREASES(num_blocks - i)
+    // clang-format on
     {
-        for (int j = 0; j < 8; j++)
+      for (int j = 0; j < 8; j++)
+          // clang-format off
             ASSIGNS(j, OBJECT_WHOLE(t))
             INVARIANT(i >= 0 && i <= num_blocks)
             INVARIANT(j >= 0 && j <= 8)
             INVARIANT(ARRAY_IN_BOUNDS(int, k2, 0, (j-1), t, 0, 15))
             DECREASES(8 - j)
+        // clang-format on
         {
-            // map to positive standard representatives
-            // REF-CHANGE: Hoist signed-to-unsigned conversion into separate function
-            int32_t u;
-            u = (int32_t) scalar_signed_to_unsigned_q_16(a->coeffs[8 * i + j]);
-            // REF-CHANGE: Hoist scalar compression into separate function
-            t[j] = scalar_compress_q_16(u);
+          // map to positive standard representatives
+          // REF-CHANGE: Hoist signed-to-unsigned conversion into separate
+          // function
+          int32_t u;
+          u = (int32_t)scalar_signed_to_unsigned_q_16(a->coeffs[8 * i + j]);
+          // REF-CHANGE: Hoist scalar compression into separate function
+          t[j] = scalar_compress_q_16(u);
         }
 
-        // REF-CHANGE: Use array indexing into
-        // r rather than pointer-arithmetic to simplify verification
-        r[i * 4]     = t[0] | (t[1] << 4);
-        r[i * 4 + 1] = t[2] | (t[3] << 4);
-        r[i * 4 + 2] = t[4] | (t[5] << 4);
-        r[i * 4 + 3] = t[6] | (t[7] << 4);
+      // REF-CHANGE: Use array indexing into
+      // r rather than pointer-arithmetic to simplify verification
+      r[i * 4] = t[0] | (t[1] << 4);
+      r[i * 4 + 1] = t[2] | (t[3] << 4);
+      r[i * 4 + 2] = t[4] | (t[5] << 4);
+      r[i * 4 + 3] = t[6] | (t[7] << 4);
     }
-    #elif (KYBER_POLYCOMPRESSEDBYTES == 160)
-    for (int i = 0; i < num_blocks; i++)
+#elif (KYBER_POLYCOMPRESSEDBYTES == 160)
+  for (int i = 0; i < num_blocks; i++)
+      // clang-format off
         ASSIGNS(i, OBJECT_WHOLE(t), OBJECT_WHOLE(r))
         INVARIANT(i >= 0 && i <= num_blocks)
         DECREASES(num_blocks - i)
+    // clang-format on
     {
-        for (int j = 0; j < 8; j++)
+      for (int j = 0; j < 8; j++)
+          // clang-format off
             ASSIGNS(j, OBJECT_WHOLE(t))
             INVARIANT(i >= 0)
             INVARIANT(i <= num_blocks)
             INVARIANT(j >= 0 && j <= 8)
             INVARIANT(ARRAY_IN_BOUNDS(int, k2, 0, (j-1), t, 0, 31))
             DECREASES(8 - j)
+        // clang-format on
         {
-            // map to positive standard representatives
-            // REF-CHANGE: Hoist signed-to-unsigned conversion into separate function
-            int32_t u = (int32_t) scalar_signed_to_unsigned_q_16(a->coeffs[8 * i + j]);
-            // REF-CHANGE: Hoist scalar compression into separate function
-            t[j] = scalar_compress_q_32(u);
+          // map to positive standard representatives
+          // REF-CHANGE: Hoist signed-to-unsigned conversion into separate
+          // function
+          int32_t u =
+              (int32_t)scalar_signed_to_unsigned_q_16(a->coeffs[8 * i + j]);
+          // REF-CHANGE: Hoist scalar compression into separate function
+          t[j] = scalar_compress_q_32(u);
         }
 
-        // REF-CHANGE: Explicitly truncate to avoid warning about
-        // implicit truncation in CBMC, and use array indexing into
-        // r rather than pointer-arithmetic to simplify verification
-        r[i * 5]     = 0xFF & ((t[0] >> 0) | (t[1] << 5));
-        r[i * 5 + 1] = 0xFF & ((t[1] >> 3) | (t[2] << 2) | (t[3] << 7));
-        r[i * 5 + 2] = 0xFF & ((t[3] >> 1) | (t[4] << 4));
-        r[i * 5 + 3] = 0xFF & ((t[4] >> 4) | (t[5] << 1) | (t[6] << 6));
-        r[i * 5 + 4] = 0xFF & ((t[6] >> 2) | (t[7] << 3));
+      // REF-CHANGE: Explicitly truncate to avoid warning about
+      // implicit truncation in CBMC, and use array indexing into
+      // r rather than pointer-arithmetic to simplify verification
+      r[i * 5] = 0xFF & ((t[0] >> 0) | (t[1] << 5));
+      r[i * 5 + 1] = 0xFF & ((t[1] >> 3) | (t[2] << 2) | (t[3] << 7));
+      r[i * 5 + 2] = 0xFF & ((t[3] >> 1) | (t[4] << 4));
+      r[i * 5 + 3] = 0xFF & ((t[4] >> 4) | (t[5] << 1) | (t[6] << 6));
+      r[i * 5 + 4] = 0xFF & ((t[6] >> 2) | (t[7] << 3));
     }
-    #else
+#else
 #error "KYBER_POLYCOMPRESSEDBYTES needs to be in {128, 160}"
-    #endif
+#endif
 }
 
 /*************************************************
-* Name:        poly_decompress
-*
-* Description: De-serialization and subsequent decompression of a polynomial;
-*              approximate inverse of poly_compress
-*
-* Arguments:   - poly *r: pointer to output polynomial
-*              - const uint8_t *a: pointer to input byte array
-*                                  (of length KYBER_POLYCOMPRESSEDBYTES bytes)
-*
-* Upon return, the coefficients of the output polynomial are unsigned-canonical
-* (non-negative and smaller than KYBER_Q).
-*
-**************************************************/
-void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
-{
-    #if (KYBER_POLYCOMPRESSEDBYTES == 128)
-    for (int i = 0; i < KYBER_N / 2; i++)
+ * Name:        poly_decompress
+ *
+ * Description: De-serialization and subsequent decompression of a polynomial;
+ *              approximate inverse of poly_compress
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *a: pointer to input byte array
+ *                                  (of length KYBER_POLYCOMPRESSEDBYTES bytes)
+ *
+ * Upon return, the coefficients of the output polynomial are unsigned-canonical
+ * (non-negative and smaller than KYBER_Q).
+ *
+ **************************************************/
+void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES]) {
+#if (KYBER_POLYCOMPRESSEDBYTES == 128)
+  for (int i = 0; i < KYBER_N / 2; i++)
+      // clang-format off
         ASSIGNS(i, OBJECT_WHOLE(r))
         INVARIANT(i >= 0)
         INVARIANT(i <= KYBER_N / 2)
         INVARIANT(ARRAY_IN_BOUNDS(int, k, 0, (2 * i - 1), r->coeffs, 0, (KYBER_Q - 1)))
         DECREASES(KYBER_N / 2 - i)
+    // clang-format on
     {
-        // REF-CHANGE: Hoist scalar decompression into separate function
-        r->coeffs[2 * i + 0] = scalar_decompress_q_16((a[i] >> 0) & 0xF);
-        r->coeffs[2 * i + 1] = scalar_decompress_q_16((a[i] >> 4) & 0xF);
+      // REF-CHANGE: Hoist scalar decompression into separate function
+      r->coeffs[2 * i + 0] = scalar_decompress_q_16((a[i] >> 0) & 0xF);
+      r->coeffs[2 * i + 1] = scalar_decompress_q_16((a[i] >> 4) & 0xF);
     }
 
 
 
-    #elif (KYBER_POLYCOMPRESSEDBYTES == 160)
-    const int num_blocks = KYBER_N / 8;
-    for (int i = 0; i < num_blocks; i++)
+#elif (KYBER_POLYCOMPRESSEDBYTES == 160)
+  const int num_blocks = KYBER_N / 8;
+  for (int i = 0; i < num_blocks; i++)
+      // clang-format off
         ASSIGNS(i, OBJECT_WHOLE(r))
         INVARIANT(i >= 0)
         INVARIANT(i <= num_blocks)
         INVARIANT(num_blocks == 32)
         INVARIANT(ARRAY_IN_BOUNDS(int, k, 0, (8 * i - 1), r->coeffs, 0, (KYBER_Q - 1)))
         DECREASES(num_blocks - i)
+    // clang-format on
     {
-        uint8_t t[8];
-        const int offset = i * 5;
-        // REF-CHANGE: Explicitly truncate to avoid warning about
-        // implicit truncation in CBMC and unwind loop for ease
-        // of proof.
+      uint8_t t[8];
+      const int offset = i * 5;
+      // REF-CHANGE: Explicitly truncate to avoid warning about
+      // implicit truncation in CBMC and unwind loop for ease
+      // of proof.
 
-        // Decompress 5 8-bit bytes (so 40 bits) into
-        // 8 5-bit values stored in t[]
-        t[0] = 0x1F &  (a[offset + 0] >> 0);
-        t[1] = 0x1F & ((a[offset + 0] >> 5) | (a[offset + 1] << 3));
-        t[2] = 0x1F &  (a[offset + 1] >> 2);
-        t[3] = 0x1F & ((a[offset + 1] >> 7) | (a[offset + 2] << 1));
-        t[4] = 0x1F & ((a[offset + 2] >> 4) | (a[offset + 3] << 4));
-        t[5] = 0x1F &  (a[offset + 3] >> 1);
-        t[6] = 0x1F & ((a[offset + 3] >> 6) | (a[offset + 4] << 2));
-        t[7] = 0x1F &  (a[offset + 4] >> 3);
+      // Decompress 5 8-bit bytes (so 40 bits) into
+      // 8 5-bit values stored in t[]
+      t[0] = 0x1F & (a[offset + 0] >> 0);
+      t[1] = 0x1F & ((a[offset + 0] >> 5) | (a[offset + 1] << 3));
+      t[2] = 0x1F & (a[offset + 1] >> 2);
+      t[3] = 0x1F & ((a[offset + 1] >> 7) | (a[offset + 2] << 1));
+      t[4] = 0x1F & ((a[offset + 2] >> 4) | (a[offset + 3] << 4));
+      t[5] = 0x1F & (a[offset + 3] >> 1);
+      t[6] = 0x1F & ((a[offset + 3] >> 6) | (a[offset + 4] << 2));
+      t[7] = 0x1F & (a[offset + 4] >> 3);
 
-        // and copy to the correct slice in r[]
-        for (int j = 0; j < 8; j++)
+      // and copy to the correct slice in r[]
+      for (int j = 0; j < 8; j++)
+          // clang-format off
             ASSIGNS(j, OBJECT_WHOLE(r))
             INVARIANT(j >= 0)
             INVARIANT(j <= 8)
@@ -158,466 +172,423 @@ void poly_decompress(poly *r, const uint8_t a[KYBER_POLYCOMPRESSEDBYTES])
             INVARIANT(i <= num_blocks)
             INVARIANT(ARRAY_IN_BOUNDS(int, k, 0, (8 * i + j - 1), r->coeffs, 0, (KYBER_Q - 1)))
             DECREASES(8 - j)
+        // clang-format on
         {
-            // REF-CHANGE: Hoist scalar decompression into separate function
-            r->coeffs[8 * i + j] = scalar_decompress_q_32(t[j]);
+          // REF-CHANGE: Hoist scalar decompression into separate function
+          r->coeffs[8 * i + j] = scalar_decompress_q_32(t[j]);
         }
     }
-    #else
+#else
 #error "KYBER_POLYCOMPRESSEDBYTES needs to be in {128, 160}"
-    #endif
+#endif
 }
 
 /*************************************************
-* Name:        poly_tobytes
-*
-* Description: Serialization of a polynomial.
-*              Signed coefficients are converted to
-*              unsigned form before serialization.
-*
-* Arguments:   INPUT:
-*              - a: const pointer to input polynomial,
-*                with each coefficient in the range -Q+1 .. Q-1
-*              OUTPUT
-*              - r: pointer to output byte array
-*                   (of KYBER_POLYBYTES bytes)
-**************************************************/
+ * Name:        poly_tobytes
+ *
+ * Description: Serialization of a polynomial.
+ *              Signed coefficients are converted to
+ *              unsigned form before serialization.
+ *
+ * Arguments:   INPUT:
+ *              - a: const pointer to input polynomial,
+ *                with each coefficient in the range -Q+1 .. Q-1
+ *              OUTPUT
+ *              - r: pointer to output byte array
+ *                   (of KYBER_POLYBYTES bytes)
+ **************************************************/
 #if !defined(MLKEM_USE_AARCH64_ASM)
-void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a)
-{
-    unsigned int i;
-    uint16_t t0, t1;
+void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a) {
+  unsigned int i;
+  uint16_t t0, t1;
 
-    for (i = 0; i < KYBER_N / 2; i++)
-    {
-        // map to positive standard representatives
-        // REF-CHANGE: Hoist signed-to-unsigned conversion into separate function
-        t0 = scalar_signed_to_unsigned_q_16(a->coeffs[2 * i]);
-        t1 = scalar_signed_to_unsigned_q_16(a->coeffs[2 * i + 1]);
-        r[3 * i + 0] = (t0 >> 0);
-        r[3 * i + 1] = (t0 >> 8) | (t1 << 4);
-        r[3 * i + 2] = (t1 >> 4);
-    }
+  for (i = 0; i < KYBER_N / 2; i++) {
+    // map to positive standard representatives
+    // REF-CHANGE: Hoist signed-to-unsigned conversion into separate function
+    t0 = scalar_signed_to_unsigned_q_16(a->coeffs[2 * i]);
+    t1 = scalar_signed_to_unsigned_q_16(a->coeffs[2 * i + 1]);
+    r[3 * i + 0] = (t0 >> 0);
+    r[3 * i + 1] = (t0 >> 8) | (t1 << 4);
+    r[3 * i + 2] = (t1 >> 4);
+  }
 }
-#else /* MLKEM_USE_AARCH64_ASM */
-void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a)
-{
-    poly_tobytes_asm(r, a->coeffs);
+#else  /* MLKEM_USE_AARCH64_ASM */
+void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a) {
+  poly_tobytes_asm(r, a->coeffs);
 }
 #endif /* MLKEM_USE_AARCH64_ASM */
 /*************************************************
-* Name:        poly_frombytes
-*
-* Description: De-serialization of a polynomial.
-*
-*              Note that this is not a strict inverse to poly_tobytes() since
-*              the latter includes normalization to unsigned coefficients.
-*
-* Arguments:   INPUT
-*              - a: pointer to input byte array
-*                   (of KYBER_POLYBYTES bytes)
-*              OUTPUT
-*              - r: pointer to output polynomial, with
-*                   each coefficient unsigned and in the range
-*                   0 .. 4095
-**************************************************/
-void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES])
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_N / 2; i++)
-    {
-        r->coeffs[2 * i]   = ((a[3 * i + 0] >> 0) | ((uint16_t)a[3 * i + 1] << 8)) & 0xFFF;
-        r->coeffs[2 * i + 1] = ((a[3 * i + 1] >> 4) | ((uint16_t)a[3 * i + 2] << 4)) & 0xFFF;
-    }
+ * Name:        poly_frombytes
+ *
+ * Description: De-serialization of a polynomial.
+ *
+ *              Note that this is not a strict inverse to poly_tobytes() since
+ *              the latter includes normalization to unsigned coefficients.
+ *
+ * Arguments:   INPUT
+ *              - a: pointer to input byte array
+ *                   (of KYBER_POLYBYTES bytes)
+ *              OUTPUT
+ *              - r: pointer to output polynomial, with
+ *                   each coefficient unsigned and in the range
+ *                   0 .. 4095
+ **************************************************/
+void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]) {
+  unsigned int i;
+  for (i = 0; i < KYBER_N / 2; i++) {
+    r->coeffs[2 * i] =
+        ((a[3 * i + 0] >> 0) | ((uint16_t)a[3 * i + 1] << 8)) & 0xFFF;
+    r->coeffs[2 * i + 1] =
+        ((a[3 * i + 1] >> 4) | ((uint16_t)a[3 * i + 2] << 4)) & 0xFFF;
+  }
 }
 
 /*************************************************
-* Name:        poly_frommsg
-*
-* Description: Convert 32-byte message to polynomial
-*
-* Arguments:   - poly *r: pointer to output polynomial
-*              - const uint8_t *msg: pointer to input message
-**************************************************/
-void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES])
-{
-    unsigned int i, j;
+ * Name:        poly_frommsg
+ *
+ * Description: Convert 32-byte message to polynomial
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *msg: pointer to input message
+ **************************************************/
+void poly_frommsg(poly *r, const uint8_t msg[KYBER_INDCPA_MSGBYTES]) {
+  unsigned int i, j;
 
-    #if (KYBER_INDCPA_MSGBYTES != KYBER_N/8)
+#if (KYBER_INDCPA_MSGBYTES != KYBER_N / 8)
 #error "KYBER_INDCPA_MSGBYTES must be equal to KYBER_N/8 bytes!"
-    #endif
+#endif
 
-    for (i = 0; i < KYBER_N / 8; i++)
-    {
-        for (j = 0; j < 8; j++)
-        {
-            r->coeffs[8 * i + j] = 0;
-            cmov_int16(r->coeffs + 8 * i + j, ((KYBER_Q + 1) / 2), (msg[i] >> j) & 1);
-        }
+  for (i = 0; i < KYBER_N / 8; i++) {
+    for (j = 0; j < 8; j++) {
+      r->coeffs[8 * i + j] = 0;
+      cmov_int16(r->coeffs + 8 * i + j, ((KYBER_Q + 1) / 2), (msg[i] >> j) & 1);
     }
+  }
 }
 
 /*************************************************
-* Name:        poly_tomsg
-*
-* Description: Convert polynomial to 32-byte message
-*
-* Arguments:   - uint8_t *msg: pointer to output message
-*              - const poly *a: pointer to input polynomial
-**************************************************/
-void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a)
-{
-    unsigned int i, j;
-    uint32_t t;
+ * Name:        poly_tomsg
+ *
+ * Description: Convert polynomial to 32-byte message
+ *
+ * Arguments:   - uint8_t *msg: pointer to output message
+ *              - const poly *a: pointer to input polynomial
+ **************************************************/
+void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a) {
+  unsigned int i, j;
+  uint32_t t;
 
-    for (i = 0; i < KYBER_N / 8; i++)
-    {
-        msg[i] = 0;
-        for (j = 0; j < 8; j++)
-        {
-            t  = a->coeffs[8 * i + j];
-            // t += ((int16_t)t >> 15) & KYBER_Q;
-            // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
-            t <<= 1;
-            t += 1665;
-            t *= 80635;
-            t >>= 28;
-            t &= 1;
-            msg[i] |= t << j;
-        }
+  for (i = 0; i < KYBER_N / 8; i++) {
+    msg[i] = 0;
+    for (j = 0; j < 8; j++) {
+      t = a->coeffs[8 * i + j];
+      // t += ((int16_t)t >> 15) & KYBER_Q;
+      // t  = (((t << 1) + KYBER_Q/2)/KYBER_Q) & 1;
+      t <<= 1;
+      t += 1665;
+      t *= 80635;
+      t >>= 28;
+      t &= 1;
+      msg[i] |= t << j;
     }
+  }
 }
 
 /*************************************************
-* Name:        poly_getnoise_eta1_4x
-*
-* Description: Batch sample four polynomials deterministically from a seed and nonces,
-*              with output polynomials close to centered binomial distribution
-*              with parameter KYBER_ETA1
-*
-* Arguments:   - poly *r{0,1,2,3}: pointer to output polynomial
-*              - const uint8_t *seed: pointer to input seed
-*                                     (of length KYBER_SYMBYTES bytes)
-*              - uint8_t nonce{0,1,2,3}: one-byte input nonce
-**************************************************/
-void poly_getnoise_eta1_4x(poly *r0,
-                           poly *r1,
-                           poly *r2,
-                           poly *r3,
-                           const uint8_t seed[KYBER_SYMBYTES],
-                           uint8_t nonce0,
-                           uint8_t nonce1,
-                           uint8_t nonce2,
-                           uint8_t nonce3)
-{
-    uint8_t buf[KECCAK_WAY][KYBER_ETA1 * KYBER_N / 4] ALIGN(16);
-    uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
-    memcpy(extkey[0], seed, KYBER_SYMBYTES);
-    memcpy(extkey[1], seed, KYBER_SYMBYTES);
-    memcpy(extkey[2], seed, KYBER_SYMBYTES);
-    memcpy(extkey[3], seed, KYBER_SYMBYTES);
-    extkey[0][KYBER_SYMBYTES] = nonce0;
-    extkey[1][KYBER_SYMBYTES] = nonce1;
-    extkey[2][KYBER_SYMBYTES] = nonce2;
-    extkey[3][KYBER_SYMBYTES] = nonce3;
-    shake256x4(buf[0], buf[1], buf[2], buf[3], KYBER_ETA1 * KYBER_N / 4,
-               extkey[0], extkey[1], extkey[2], extkey[3], KYBER_SYMBYTES + 1);
-    poly_cbd_eta1(r0, buf[0]);
-    poly_cbd_eta1(r1, buf[1]);
-    poly_cbd_eta1(r2, buf[2]);
-    poly_cbd_eta1(r3, buf[3]);
+ * Name:        poly_getnoise_eta1_4x
+ *
+ * Description: Batch sample four polynomials deterministically from a seed and
+ *nonces, with output polynomials close to centered binomial distribution with
+ *parameter KYBER_ETA1
+ *
+ * Arguments:   - poly *r{0,1,2,3}: pointer to output polynomial
+ *              - const uint8_t *seed: pointer to input seed
+ *                                     (of length KYBER_SYMBYTES bytes)
+ *              - uint8_t nonce{0,1,2,3}: one-byte input nonce
+ **************************************************/
+void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
+                           const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce0,
+                           uint8_t nonce1, uint8_t nonce2, uint8_t nonce3) {
+  uint8_t buf[KECCAK_WAY][KYBER_ETA1 * KYBER_N / 4] ALIGN(16);
+  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
+  memcpy(extkey[0], seed, KYBER_SYMBYTES);
+  memcpy(extkey[1], seed, KYBER_SYMBYTES);
+  memcpy(extkey[2], seed, KYBER_SYMBYTES);
+  memcpy(extkey[3], seed, KYBER_SYMBYTES);
+  extkey[0][KYBER_SYMBYTES] = nonce0;
+  extkey[1][KYBER_SYMBYTES] = nonce1;
+  extkey[2][KYBER_SYMBYTES] = nonce2;
+  extkey[3][KYBER_SYMBYTES] = nonce3;
+  shake256x4(buf[0], buf[1], buf[2], buf[3], KYBER_ETA1 * KYBER_N / 4,
+             extkey[0], extkey[1], extkey[2], extkey[3], KYBER_SYMBYTES + 1);
+  poly_cbd_eta1(r0, buf[0]);
+  poly_cbd_eta1(r1, buf[1]);
+  poly_cbd_eta1(r2, buf[2]);
+  poly_cbd_eta1(r3, buf[3]);
 }
 
 /*************************************************
-* Name:        poly_getnoise_eta2
-*
-* Description: Sample a polynomial deterministically from a seed and a nonce,
-*              with output polynomial close to centered binomial distribution
-*              with parameter KYBER_ETA2
-*
-* Arguments:   - poly *r: pointer to output polynomial
-*              - const uint8_t *seed: pointer to input seed
-*                                     (of length KYBER_SYMBYTES bytes)
-*              - uint8_t nonce: one-byte input nonce
-**************************************************/
-void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce)
-{
-    uint8_t buf[KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
-    prf(buf, sizeof(buf), seed, nonce);
-    poly_cbd_eta2(r, buf);
+ * Name:        poly_getnoise_eta2
+ *
+ * Description: Sample a polynomial deterministically from a seed and a nonce,
+ *              with output polynomial close to centered binomial distribution
+ *              with parameter KYBER_ETA2
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *seed: pointer to input seed
+ *                                     (of length KYBER_SYMBYTES bytes)
+ *              - uint8_t nonce: one-byte input nonce
+ **************************************************/
+void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES],
+                        uint8_t nonce) {
+  uint8_t buf[KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
+  prf(buf, sizeof(buf), seed, nonce);
+  poly_cbd_eta2(r, buf);
 }
 
 /*************************************************
-* Name:        poly_getnoise_eta2_4x
-*
-* Description: Batch sample four polynomials deterministically from a seed and nonces,
-*              with output polynomials close to centered binomial distribution
-*              with parameter KYBER_ETA2
-*
-* Arguments:   - poly *r{0,1,2,3}: pointer to output polynomial
-*              - const uint8_t *seed: pointer to input seed
-*                                     (of length KYBER_SYMBYTES bytes)
-*              - uint8_t nonce{0,1,2,3}: one-byte input nonce
-**************************************************/
-void poly_getnoise_eta2_4x(poly *r0,
-                           poly *r1,
-                           poly *r2,
-                           poly *r3,
-                           const uint8_t seed[KYBER_SYMBYTES],
-                           uint8_t nonce0,
-                           uint8_t nonce1,
-                           uint8_t nonce2,
-                           uint8_t nonce3)
-{
-    uint8_t buf[KECCAK_WAY][KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
-    uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
-    memcpy(extkey[0], seed, KYBER_SYMBYTES);
-    memcpy(extkey[1], seed, KYBER_SYMBYTES);
-    memcpy(extkey[2], seed, KYBER_SYMBYTES);
-    memcpy(extkey[3], seed, KYBER_SYMBYTES);
-    extkey[0][KYBER_SYMBYTES] = nonce0;
-    extkey[1][KYBER_SYMBYTES] = nonce1;
-    extkey[2][KYBER_SYMBYTES] = nonce2;
-    extkey[3][KYBER_SYMBYTES] = nonce3;
-    shake256x4(buf[0], buf[1], buf[2], buf[3], KYBER_ETA2 * KYBER_N / 4,
-               extkey[0], extkey[1], extkey[2], extkey[3], KYBER_SYMBYTES + 1);
-    poly_cbd_eta2(r0, buf[0]);
-    poly_cbd_eta2(r1, buf[1]);
-    poly_cbd_eta2(r2, buf[2]);
-    poly_cbd_eta2(r3, buf[3]);
+ * Name:        poly_getnoise_eta2_4x
+ *
+ * Description: Batch sample four polynomials deterministically from a seed and
+ *nonces, with output polynomials close to centered binomial distribution with
+ *parameter KYBER_ETA2
+ *
+ * Arguments:   - poly *r{0,1,2,3}: pointer to output polynomial
+ *              - const uint8_t *seed: pointer to input seed
+ *                                     (of length KYBER_SYMBYTES bytes)
+ *              - uint8_t nonce{0,1,2,3}: one-byte input nonce
+ **************************************************/
+void poly_getnoise_eta2_4x(poly *r0, poly *r1, poly *r2, poly *r3,
+                           const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce0,
+                           uint8_t nonce1, uint8_t nonce2, uint8_t nonce3) {
+  uint8_t buf[KECCAK_WAY][KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
+  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
+  memcpy(extkey[0], seed, KYBER_SYMBYTES);
+  memcpy(extkey[1], seed, KYBER_SYMBYTES);
+  memcpy(extkey[2], seed, KYBER_SYMBYTES);
+  memcpy(extkey[3], seed, KYBER_SYMBYTES);
+  extkey[0][KYBER_SYMBYTES] = nonce0;
+  extkey[1][KYBER_SYMBYTES] = nonce1;
+  extkey[2][KYBER_SYMBYTES] = nonce2;
+  extkey[3][KYBER_SYMBYTES] = nonce3;
+  shake256x4(buf[0], buf[1], buf[2], buf[3], KYBER_ETA2 * KYBER_N / 4,
+             extkey[0], extkey[1], extkey[2], extkey[3], KYBER_SYMBYTES + 1);
+  poly_cbd_eta2(r0, buf[0]);
+  poly_cbd_eta2(r1, buf[1]);
+  poly_cbd_eta2(r2, buf[2]);
+  poly_cbd_eta2(r3, buf[3]);
 }
 
 /*************************************************
-* Name:        poly_getnoise_eta1122_4x
-*
-* Description: Batch sample four polynomials deterministically from a seed and a nonces,
-*              with output polynomials close to centered binomial distribution
-*              with parameter KYBER_ETA1 and KYBER_ETA2
-*
-* Arguments:   - poly *r{0,1,2,3}: pointer to output polynomial
-*              - const uint8_t *seed: pointer to input seed
-*                                     (of length KYBER_SYMBYTES bytes)
-*              - uint8_t nonce{0,1,2,3}: one-byte input nonce
-**************************************************/
-void poly_getnoise_eta1122_4x(poly *r0,
-                              poly *r1,
-                              poly *r2,
-                              poly *r3,
+ * Name:        poly_getnoise_eta1122_4x
+ *
+ * Description: Batch sample four polynomials deterministically from a seed and
+ *a nonces, with output polynomials close to centered binomial distribution with
+ *parameter KYBER_ETA1 and KYBER_ETA2
+ *
+ * Arguments:   - poly *r{0,1,2,3}: pointer to output polynomial
+ *              - const uint8_t *seed: pointer to input seed
+ *                                     (of length KYBER_SYMBYTES bytes)
+ *              - uint8_t nonce{0,1,2,3}: one-byte input nonce
+ **************************************************/
+void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                               const uint8_t seed[KYBER_SYMBYTES],
-                              uint8_t nonce0,
-                              uint8_t nonce1,
-                              uint8_t nonce2,
-                              uint8_t nonce3)
-{
-    uint8_t buf1[KECCAK_WAY/2][KYBER_ETA1 * KYBER_N / 4] ALIGN(16);
-    uint8_t buf2[KECCAK_WAY/2][KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
-    uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
-    memcpy(extkey[0], seed, KYBER_SYMBYTES);
-    memcpy(extkey[1], seed, KYBER_SYMBYTES);
-    memcpy(extkey[2], seed, KYBER_SYMBYTES);
-    memcpy(extkey[3], seed, KYBER_SYMBYTES);
-    extkey[0][KYBER_SYMBYTES] = nonce0;
-    extkey[1][KYBER_SYMBYTES] = nonce1;
-    extkey[2][KYBER_SYMBYTES] = nonce2;
-    extkey[3][KYBER_SYMBYTES] = nonce3;
+                              uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
+                              uint8_t nonce3) {
+  uint8_t buf1[KECCAK_WAY / 2][KYBER_ETA1 * KYBER_N / 4] ALIGN(16);
+  uint8_t buf2[KECCAK_WAY / 2][KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
+  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
+  memcpy(extkey[0], seed, KYBER_SYMBYTES);
+  memcpy(extkey[1], seed, KYBER_SYMBYTES);
+  memcpy(extkey[2], seed, KYBER_SYMBYTES);
+  memcpy(extkey[3], seed, KYBER_SYMBYTES);
+  extkey[0][KYBER_SYMBYTES] = nonce0;
+  extkey[1][KYBER_SYMBYTES] = nonce1;
+  extkey[2][KYBER_SYMBYTES] = nonce2;
+  extkey[3][KYBER_SYMBYTES] = nonce3;
 
-    #if KYBER_ETA1 == KYBER_ETA2
-    shake256x4(buf1[0], buf1[1], buf2[0], buf2[1], KYBER_ETA1 * KYBER_N / 4,
-               extkey[0], extkey[1], extkey[2], extkey[3], KYBER_SYMBYTES + 1);
-    #else
-    shake256(buf1[0], sizeof(buf1[0]), extkey[0], sizeof(extkey[0]));
-    shake256(buf1[1], sizeof(buf1[1]), extkey[1], sizeof(extkey[1]));
-    shake256(buf2[0], sizeof(buf2[0]), extkey[2], sizeof(extkey[2]));
-    shake256(buf2[1], sizeof(buf2[1]), extkey[3], sizeof(extkey[3]));
-    #endif
+#if KYBER_ETA1 == KYBER_ETA2
+  shake256x4(buf1[0], buf1[1], buf2[0], buf2[1], KYBER_ETA1 * KYBER_N / 4,
+             extkey[0], extkey[1], extkey[2], extkey[3], KYBER_SYMBYTES + 1);
+#else
+  shake256(buf1[0], sizeof(buf1[0]), extkey[0], sizeof(extkey[0]));
+  shake256(buf1[1], sizeof(buf1[1]), extkey[1], sizeof(extkey[1]));
+  shake256(buf2[0], sizeof(buf2[0]), extkey[2], sizeof(extkey[2]));
+  shake256(buf2[1], sizeof(buf2[1]), extkey[3], sizeof(extkey[3]));
+#endif
 
-    poly_cbd_eta1(r0, buf1[0]);
-    poly_cbd_eta1(r1, buf1[1]);
-    poly_cbd_eta2(r2, buf2[0]);
-    poly_cbd_eta2(r3, buf2[1]);
+  poly_cbd_eta1(r0, buf1[0]);
+  poly_cbd_eta1(r1, buf1[1]);
+  poly_cbd_eta2(r2, buf2[0]);
+  poly_cbd_eta2(r3, buf2[1]);
 }
 
 /*************************************************
-* Name:        poly_basemul_montgomery
-*
-* Description: Multiplication of two polynomials in NTT domain
-*
-* Arguments:   - poly *r: pointer to output polynomial
-*              - const poly *a: pointer to first input polynomial
-*              - const poly *b: pointer to second input polynomial
-**************************************************/
-void poly_basemul_montgomery(poly *r, const poly *a, const poly *b)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_N / 4; i++)
-    {
-        basemul(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i], zetas[64 + i]);
-        basemul(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2], -zetas[64 + i]);
-    }
+ * Name:        poly_basemul_montgomery
+ *
+ * Description: Multiplication of two polynomials in NTT domain
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const poly *a: pointer to first input polynomial
+ *              - const poly *b: pointer to second input polynomial
+ **************************************************/
+void poly_basemul_montgomery(poly *r, const poly *a, const poly *b) {
+  unsigned int i;
+  for (i = 0; i < KYBER_N / 4; i++) {
+    basemul(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i],
+            zetas[64 + i]);
+    basemul(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2],
+            -zetas[64 + i]);
+  }
 }
 
 /*************************************************
-* Name:        poly_basemul_montgomery_cached
-*
-* Description: Multiplication of two polynomials in NTT domain,
-*              using mulcache for second operand.
-*
-* Arguments:   - poly *r: pointer to output polynomial
-*              - const poly *a: pointer to first input polynomial
-*              - const poly *b: pointer to second input polynomial
-*              - const poly_mulcache *b_cache: pointer to mulcache
-*                  for second input polynomial. Can be computed
-*                  via poly_mulcache_compute().
-**************************************************/
-void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b, const poly_mulcache *b_cache)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_N / 4; i++)
-    {
-        basemul_cached(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i],
-                       b_cache->coeffs[2 * i]);
-        basemul_cached(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2],
-                       b_cache->coeffs[2 * i + 1]);
-    }
+ * Name:        poly_basemul_montgomery_cached
+ *
+ * Description: Multiplication of two polynomials in NTT domain,
+ *              using mulcache for second operand.
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const poly *a: pointer to first input polynomial
+ *              - const poly *b: pointer to second input polynomial
+ *              - const poly_mulcache *b_cache: pointer to mulcache
+ *                  for second input polynomial. Can be computed
+ *                  via poly_mulcache_compute().
+ **************************************************/
+void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,
+                                    const poly_mulcache *b_cache) {
+  unsigned int i;
+  for (i = 0; i < KYBER_N / 4; i++) {
+    basemul_cached(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i],
+                   b_cache->coeffs[2 * i]);
+    basemul_cached(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2],
+                   &b->coeffs[4 * i + 2], b_cache->coeffs[2 * i + 1]);
+  }
 }
 
 /*************************************************
-* Name:        poly_tomont
-*
-* Description: Inplace conversion of all coefficients of a polynomial
-*              from normal domain to Montgomery domain
-*
-* Arguments:   - poly *r: pointer to input/output polynomial
-**************************************************/
+ * Name:        poly_tomont
+ *
+ * Description: Inplace conversion of all coefficients of a polynomial
+ *              from normal domain to Montgomery domain
+ *
+ * Arguments:   - poly *r: pointer to input/output polynomial
+ **************************************************/
 #if !defined(MLKEM_USE_AARCH64_ASM)
-void poly_tomont(poly *r)
-{
-    unsigned int i;
-    const int16_t f = (1ULL << 32) % KYBER_Q;
-    for (i = 0; i < KYBER_N; i++)
-    {
-        r->coeffs[i] = montgomery_reduce((int32_t)r->coeffs[i] * f);
-    }
+void poly_tomont(poly *r) {
+  unsigned int i;
+  const int16_t f = (1ULL << 32) % KYBER_Q;
+  for (i = 0; i < KYBER_N; i++) {
+    r->coeffs[i] = montgomery_reduce((int32_t)r->coeffs[i] * f);
+  }
 }
-#else /* MLKEM_USE_AARCH64_ASM */
-void poly_tomont(poly *r)
-{
-    poly_tomont_asm(r->coeffs);
-}
+#else  /* MLKEM_USE_AARCH64_ASM */
+void poly_tomont(poly *r) { poly_tomont_asm(r->coeffs); }
 #endif /* MLKEM_USE_AARCH64_ASM */
 
 /*************************************************
-* Name:        poly_reduce
-*
-* Description: Applies Barrett reduction to all coefficients of a polynomial
-*              for details of the Barrett reduction see comments in reduce.c
-*
-* Arguments:   - poly *r: pointer to input/output polynomial
-**************************************************/
+ * Name:        poly_reduce
+ *
+ * Description: Applies Barrett reduction to all coefficients of a polynomial
+ *              for details of the Barrett reduction see comments in reduce.c
+ *
+ * Arguments:   - poly *r: pointer to input/output polynomial
+ **************************************************/
 #if !defined(MLKEM_USE_AARCH64_ASM)
-void poly_reduce(poly *r)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_N; i++)
-    {
-        r->coeffs[i] = barrett_reduce(r->coeffs[i]);
-    }
+void poly_reduce(poly *r) {
+  unsigned int i;
+  for (i = 0; i < KYBER_N; i++) {
+    r->coeffs[i] = barrett_reduce(r->coeffs[i]);
+  }
 }
-#else /* MLKEM_USE_AARCH64_ASM */
-void poly_reduce(poly *r)
-{
-    poly_reduce_asm(r->coeffs);
-}
+#else  /* MLKEM_USE_AARCH64_ASM */
+void poly_reduce(poly *r) { poly_reduce_asm(r->coeffs); }
 #endif /* MLKEM_USE_AARCH64_ASM */
 
 /*************************************************
-* Name:        poly_add
-*
-* Description: Add two polynomials; no modular reduction is performed
-*
-* Arguments: - poly *r: pointer to output polynomial
-*            - const poly *a: pointer to first input polynomial
-*            - const poly *b: pointer to second input polynomial
-**************************************************/
-void poly_add(poly *r, const poly *a, const poly *b)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_N; i++)
-    {
-        r->coeffs[i] = a->coeffs[i] + b->coeffs[i];
-    }
+ * Name:        poly_add
+ *
+ * Description: Add two polynomials; no modular reduction is performed
+ *
+ * Arguments: - poly *r: pointer to output polynomial
+ *            - const poly *a: pointer to first input polynomial
+ *            - const poly *b: pointer to second input polynomial
+ **************************************************/
+void poly_add(poly *r, const poly *a, const poly *b) {
+  unsigned int i;
+  for (i = 0; i < KYBER_N; i++) {
+    r->coeffs[i] = a->coeffs[i] + b->coeffs[i];
+  }
 }
 
 /*************************************************
-* Name:        poly_sub
-*
-* Description: Subtract two polynomials; no modular reduction is performed
-*
-* Arguments: - poly *r:       pointer to output polynomial
-*            - const poly *a: pointer to first input polynomial
-*            - const poly *b: pointer to second input polynomial
-**************************************************/
-void poly_sub(poly *r, const poly *a, const poly *b)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_N; i++)
-    {
-        r->coeffs[i] = a->coeffs[i] - b->coeffs[i];
-    }
+ * Name:        poly_sub
+ *
+ * Description: Subtract two polynomials; no modular reduction is performed
+ *
+ * Arguments: - poly *r:       pointer to output polynomial
+ *            - const poly *a: pointer to first input polynomial
+ *            - const poly *b: pointer to second input polynomial
+ **************************************************/
+void poly_sub(poly *r, const poly *a, const poly *b) {
+  unsigned int i;
+  for (i = 0; i < KYBER_N; i++) {
+    r->coeffs[i] = a->coeffs[i] - b->coeffs[i];
+  }
 }
 
 /*************************************************
-* Name:        poly_mulcache_compute
-*
-* Description: Precompute values speeding up
-*              base multiplications of polynomials
-*              in NTT domain.
-*
-* Arguments: - poly_mulcache *x: pointer to output cache.
-*            - const poly *a: pointer to input polynomial
-**************************************************/
+ * Name:        poly_mulcache_compute
+ *
+ * Description: Precompute values speeding up
+ *              base multiplications of polynomials
+ *              in NTT domain.
+ *
+ * Arguments: - poly_mulcache *x: pointer to output cache.
+ *            - const poly *a: pointer to input polynomial
+ **************************************************/
 #if !defined(MLKEM_USE_AARCH64_ASM)
-void poly_mulcache_compute(poly_mulcache *x, const poly *a)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_N/4; i++)
-    {
-        x->coeffs[2*i+0] = fqmul(a->coeffs[4*i+1],  zetas[64 + i]);
-        x->coeffs[2*i+1] = fqmul(a->coeffs[4*i+3], -zetas[64 + i]);
-    }
+void poly_mulcache_compute(poly_mulcache *x, const poly *a) {
+  unsigned int i;
+  for (i = 0; i < KYBER_N / 4; i++) {
+    x->coeffs[2 * i + 0] = fqmul(a->coeffs[4 * i + 1], zetas[64 + i]);
+    x->coeffs[2 * i + 1] = fqmul(a->coeffs[4 * i + 3], -zetas[64 + i]);
+  }
 }
-#else /* MLKEM_USE_AARCH64_ASM */
-static const int16_t zetas_mulcache_asm[256] =
-{
-    17, -17, -568, 568, 583, -583, -680, 680, 1637, -1637, 723, -723, -1041, 1041, 1100,
-    -1100, 1409, -1409, -667, 667, -48, 48, 233, -233, 756, -756, -1173, 1173, -314, 314,
-    -279, 279, -1626, 1626, 1651, -1651, -540, 540, -1540, 1540, -1482, 1482, 952, -952,
-    1461, -1461, -642, 642, 939, -939, -1021, 1021, -892, 892, -941, 941, 733, -733,
-    -992, 992, 268, -268, 641, -641, 1584, -1584, -1031, 1031, -1292, 1292, -109, 109,
-    375, -375, -780, 780, -1239, 1239, 1645, -1645, 1063, -1063, 319, -319, -556, 556,
-    757, -757, -1230, 1230, 561, -561, -863, 863, -735, 735, -525, 525, 1092, -1092,
-    403, -403, 1026, -1026, 1143, -1143, -1179, 1179, -554, 554, 886, -886, -1607, 1607,
-    1212, -1212, -1455, 1455, 1029, -1029, -1219, 1219, -394, 394, 885, -885, -1175, 1175
-};
+#else  /* MLKEM_USE_AARCH64_ASM */
+static const int16_t zetas_mulcache_asm[256] = {
+    17,    -17,   -568,  568,  583,   -583,  -680,  680,   1637, -1637, 723,
+    -723,  -1041, 1041,  1100, -1100, 1409,  -1409, -667,  667,  -48,   48,
+    233,   -233,  756,   -756, -1173, 1173,  -314,  314,   -279, 279,   -1626,
+    1626,  1651,  -1651, -540, 540,   -1540, 1540,  -1482, 1482, 952,   -952,
+    1461,  -1461, -642,  642,  939,   -939,  -1021, 1021,  -892, 892,   -941,
+    941,   733,   -733,  -992, 992,   268,   -268,  641,   -641, 1584,  -1584,
+    -1031, 1031,  -1292, 1292, -109,  109,   375,   -375,  -780, 780,   -1239,
+    1239,  1645,  -1645, 1063, -1063, 319,   -319,  -556,  556,  757,   -757,
+    -1230, 1230,  561,   -561, -863,  863,   -735,  735,   -525, 525,   1092,
+    -1092, 403,   -403,  1026, -1026, 1143,  -1143, -1179, 1179, -554,  554,
+    886,   -886,  -1607, 1607, 1212,  -1212, -1455, 1455,  1029, -1029, -1219,
+    1219,  -394,  394,   885,  -885,  -1175, 1175};
 
-static const int16_t zetas_mulcache_twisted_asm[256] =
-{
-    167, -167, -5591, 5591, 5739, -5739, -6693, 6693, 16113, -16113, 7117, -7117, -10247,
-    10247, 10828, -10828, 13869, -13869, -6565, 6565, -472, 472, 2293, -2293, 7441, -7441,
-    -11546, 11546, -3091, 3091, -2746, 2746, -16005, 16005, 16251, -16251, -5315, 5315,
-    -15159, 15159, -14588, 14588, 9371, -9371, 14381, -14381, -6319, 6319, 9243, -9243,
-    -10050, 10050, -8780, 8780, -9262, 9262, 7215, -7215, -9764, 9764, 2638, -2638,
-    6309, -6309, 15592, -15592, -10148, 10148, -12717, 12717, -1073, 1073, 3691, -3691,
-    -7678, 7678, -12196, 12196, 16192, -16192, 10463, -10463, 3140, -3140, -5473, 5473,
-    7451, -7451, -12107, 12107, 5522, -5522, -8495, 8495, -7235, 7235, -5168, 5168,
-    10749, -10749, 3967, -3967, 10099, -10099, 11251, -11251, -11605, 11605, -5453, 5453,
-    8721, -8721, -15818, 15818, 11930, -11930, -14322, 14322, 10129, -10129, -11999, 11999,
-    -3878, 3878, 8711, -8711, -11566, 11566
-};
+static const int16_t zetas_mulcache_twisted_asm[256] = {
+    167,    -167,  -5591,  5591,   5739,   -5739,  -6693,  6693,   16113,
+    -16113, 7117,  -7117,  -10247, 10247,  10828,  -10828, 13869,  -13869,
+    -6565,  6565,  -472,   472,    2293,   -2293,  7441,   -7441,  -11546,
+    11546,  -3091, 3091,   -2746,  2746,   -16005, 16005,  16251,  -16251,
+    -5315,  5315,  -15159, 15159,  -14588, 14588,  9371,   -9371,  14381,
+    -14381, -6319, 6319,   9243,   -9243,  -10050, 10050,  -8780,  8780,
+    -9262,  9262,  7215,   -7215,  -9764,  9764,   2638,   -2638,  6309,
+    -6309,  15592, -15592, -10148, 10148,  -12717, 12717,  -1073,  1073,
+    3691,   -3691, -7678,  7678,   -12196, 12196,  16192,  -16192, 10463,
+    -10463, 3140,  -3140,  -5473,  5473,   7451,   -7451,  -12107, 12107,
+    5522,   -5522, -8495,  8495,   -7235,  7235,   -5168,  5168,   10749,
+    -10749, 3967,  -3967,  10099,  -10099, 11251,  -11251, -11605, 11605,
+    -5453,  5453,  8721,   -8721,  -15818, 15818,  11930,  -11930, -14322,
+    14322,  10129, -10129, -11999, 11999,  -3878,  3878,   8711,   -8711,
+    -11566, 11566};
 
-void poly_mulcache_compute(poly_mulcache *x, const poly *a)
-{
-    poly_mulcache_compute_asm(x->coeffs, a->coeffs, zetas_mulcache_asm,
-                              zetas_mulcache_twisted_asm);
+void poly_mulcache_compute(poly_mulcache *x, const poly *a) {
+  poly_mulcache_compute_asm(x->coeffs, a->coeffs, zetas_mulcache_asm,
+                            zetas_mulcache_twisted_asm);
 }
 #endif /* MLKEM_USE_AARCH64_ASM */

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -1,325 +1,301 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "polyvec.h"
 #include <stdint.h>
+#include "asm/asm.h"
+#include "config.h"
+#include "ntt.h"
 #include "params.h"
 #include "poly.h"
-#include "ntt.h"
-#include "polyvec.h"
-#include "config.h"
-#include "asm/asm.h"
 /*************************************************
-* Name:        polyvec_compress
-*
-* Description: Compress and serialize vector of polynomials
-*
-* Arguments:   - uint8_t *r: pointer to output byte array
-*                            (needs space for KYBER_POLYVECCOMPRESSEDBYTES)
-*              - const polyvec *a: pointer to input vector of polynomials
-**************************************************/
-void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES], const polyvec *a)
-{
-    unsigned int i, j, k;
-    uint64_t d0;
+ * Name:        polyvec_compress
+ *
+ * Description: Compress and serialize vector of polynomials
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                            (needs space for KYBER_POLYVECCOMPRESSEDBYTES)
+ *              - const polyvec *a: pointer to input vector of polynomials
+ **************************************************/
+void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES],
+                      const polyvec *a) {
+  unsigned int i, j, k;
+  uint64_t d0;
 
-    #if (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 352))
-    uint16_t t[8];
-    for (i = 0; i < KYBER_K; i++)
-    {
-        for (j = 0; j < KYBER_N / 8; j++)
-        {
-            for (k = 0; k < 8; k++)
-            {
-                t[k]  = a->vec[i].coeffs[8 * j + k];
-                t[k] += ((int16_t)t[k] >> 15) & KYBER_Q;
-                /*      t[k]  = ((((uint32_t)t[k] << 11) + KYBER_Q/2)/KYBER_Q) & 0x7ff; */
-                d0 = t[k];
-                d0 <<= 11;
-                d0 += 1664;
-                d0 *= 645084;
-                d0 >>= 31;
-                t[k] = d0 & 0x7ff;
+#if (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 352))
+  uint16_t t[8];
+  for (i = 0; i < KYBER_K; i++) {
+    for (j = 0; j < KYBER_N / 8; j++) {
+      for (k = 0; k < 8; k++) {
+        t[k] = a->vec[i].coeffs[8 * j + k];
+        t[k] += ((int16_t)t[k] >> 15) & KYBER_Q;
+        /*      t[k]  = ((((uint32_t)t[k] << 11) + KYBER_Q/2)/KYBER_Q) & 0x7ff;
+         */
+        d0 = t[k];
+        d0 <<= 11;
+        d0 += 1664;
+        d0 *= 645084;
+        d0 >>= 31;
+        t[k] = d0 & 0x7ff;
+      }
 
-            }
-
-            r[ 0] = (t[0] >>  0);
-            r[ 1] = (t[0] >>  8) | (t[1] << 3);
-            r[ 2] = (t[1] >>  5) | (t[2] << 6);
-            r[ 3] = (t[2] >>  2);
-            r[ 4] = (t[2] >> 10) | (t[3] << 1);
-            r[ 5] = (t[3] >>  7) | (t[4] << 4);
-            r[ 6] = (t[4] >>  4) | (t[5] << 7);
-            r[ 7] = (t[5] >>  1);
-            r[ 8] = (t[5] >>  9) | (t[6] << 2);
-            r[ 9] = (t[6] >>  6) | (t[7] << 5);
-            r[10] = (t[7] >>  3);
-            r += 11;
-        }
+      r[0] = (t[0] >> 0);
+      r[1] = (t[0] >> 8) | (t[1] << 3);
+      r[2] = (t[1] >> 5) | (t[2] << 6);
+      r[3] = (t[2] >> 2);
+      r[4] = (t[2] >> 10) | (t[3] << 1);
+      r[5] = (t[3] >> 7) | (t[4] << 4);
+      r[6] = (t[4] >> 4) | (t[5] << 7);
+      r[7] = (t[5] >> 1);
+      r[8] = (t[5] >> 9) | (t[6] << 2);
+      r[9] = (t[6] >> 6) | (t[7] << 5);
+      r[10] = (t[7] >> 3);
+      r += 11;
     }
-    #elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 320))
-    uint16_t t[4];
-    for (i = 0; i < KYBER_K; i++)
-    {
-        for (j = 0; j < KYBER_N / 4; j++)
-        {
-            for (k = 0; k < 4; k++)
-            {
-                t[k]  = a->vec[i].coeffs[4 * j + k];
-                t[k] += ((int16_t)t[k] >> 15) & KYBER_Q;
-                /*      t[k]  = ((((uint32_t)t[k] << 10) + KYBER_Q/2)/ KYBER_Q) & 0x3ff; */
-                d0 = t[k];
-                d0 <<= 10;
-                d0 += 1665;
-                d0 *= 1290167;
-                d0 >>= 32;
-                t[k] = d0 & 0x3ff;
-            }
+  }
+#elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 320))
+  uint16_t t[4];
+  for (i = 0; i < KYBER_K; i++) {
+    for (j = 0; j < KYBER_N / 4; j++) {
+      for (k = 0; k < 4; k++) {
+        t[k] = a->vec[i].coeffs[4 * j + k];
+        t[k] += ((int16_t)t[k] >> 15) & KYBER_Q;
+        /*      t[k]  = ((((uint32_t)t[k] << 10) + KYBER_Q/2)/ KYBER_Q) & 0x3ff;
+         */
+        d0 = t[k];
+        d0 <<= 10;
+        d0 += 1665;
+        d0 *= 1290167;
+        d0 >>= 32;
+        t[k] = d0 & 0x3ff;
+      }
 
-            r[0] = (t[0] >> 0);
-            r[1] = (t[0] >> 8) | (t[1] << 2);
-            r[2] = (t[1] >> 6) | (t[2] << 4);
-            r[3] = (t[2] >> 4) | (t[3] << 6);
-            r[4] = (t[3] >> 2);
-            r += 5;
-        }
+      r[0] = (t[0] >> 0);
+      r[1] = (t[0] >> 8) | (t[1] << 2);
+      r[2] = (t[1] >> 6) | (t[2] << 4);
+      r[3] = (t[2] >> 4) | (t[3] << 6);
+      r[4] = (t[3] >> 2);
+      r += 5;
     }
-    #else
+  }
+#else
 #error "KYBER_POLYVECCOMPRESSEDBYTES needs to be in {320*KYBER_K, 352*KYBER_K}"
-    #endif
+#endif
 }
 
 /*************************************************
-* Name:        polyvec_decompress
-*
-* Description: De-serialize and decompress vector of polynomials;
-*              approximate inverse of polyvec_compress
-*
-* Arguments:   - polyvec *r:       pointer to output vector of polynomials
-*              - const uint8_t *a: pointer to input byte array
-*                                  (of length KYBER_POLYVECCOMPRESSEDBYTES)
-**************************************************/
-void polyvec_decompress(polyvec *r, const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES])
-{
-    unsigned int i, j, k;
+ * Name:        polyvec_decompress
+ *
+ * Description: De-serialize and decompress vector of polynomials;
+ *              approximate inverse of polyvec_compress
+ *
+ * Arguments:   - polyvec *r:       pointer to output vector of polynomials
+ *              - const uint8_t *a: pointer to input byte array
+ *                                  (of length KYBER_POLYVECCOMPRESSEDBYTES)
+ **************************************************/
+void polyvec_decompress(polyvec *r,
+                        const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES]) {
+  unsigned int i, j, k;
 
-    #if (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 352))
-    uint16_t t[8];
-    for (i = 0; i < KYBER_K; i++)
-    {
-        for (j = 0; j < KYBER_N / 8; j++)
-        {
-            t[0] = (a[0] >> 0) | ((uint16_t)a[ 1] << 8);
-            t[1] = (a[1] >> 3) | ((uint16_t)a[ 2] << 5);
-            t[2] = (a[2] >> 6) | ((uint16_t)a[ 3] << 2) | ((uint16_t)a[4] << 10);
-            t[3] = (a[4] >> 1) | ((uint16_t)a[ 5] << 7);
-            t[4] = (a[5] >> 4) | ((uint16_t)a[ 6] << 4);
-            t[5] = (a[6] >> 7) | ((uint16_t)a[ 7] << 1) | ((uint16_t)a[8] << 9);
-            t[6] = (a[8] >> 2) | ((uint16_t)a[ 9] << 6);
-            t[7] = (a[9] >> 5) | ((uint16_t)a[10] << 3);
-            a += 11;
+#if (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 352))
+  uint16_t t[8];
+  for (i = 0; i < KYBER_K; i++) {
+    for (j = 0; j < KYBER_N / 8; j++) {
+      t[0] = (a[0] >> 0) | ((uint16_t)a[1] << 8);
+      t[1] = (a[1] >> 3) | ((uint16_t)a[2] << 5);
+      t[2] = (a[2] >> 6) | ((uint16_t)a[3] << 2) | ((uint16_t)a[4] << 10);
+      t[3] = (a[4] >> 1) | ((uint16_t)a[5] << 7);
+      t[4] = (a[5] >> 4) | ((uint16_t)a[6] << 4);
+      t[5] = (a[6] >> 7) | ((uint16_t)a[7] << 1) | ((uint16_t)a[8] << 9);
+      t[6] = (a[8] >> 2) | ((uint16_t)a[9] << 6);
+      t[7] = (a[9] >> 5) | ((uint16_t)a[10] << 3);
+      a += 11;
 
-            for (k = 0; k < 8; k++)
-            {
-                r->vec[i].coeffs[8 * j + k] = ((uint32_t)(t[k] & 0x7FF) * KYBER_Q + 1024) >> 11;
-            }
-        }
+      for (k = 0; k < 8; k++) {
+        r->vec[i].coeffs[8 * j + k] =
+            ((uint32_t)(t[k] & 0x7FF) * KYBER_Q + 1024) >> 11;
+      }
     }
-    #elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 320))
-    uint16_t t[4];
-    for (i = 0; i < KYBER_K; i++)
-    {
-        for (j = 0; j < KYBER_N / 4; j++)
-        {
-            t[0] = (a[0] >> 0) | ((uint16_t)a[1] << 8);
-            t[1] = (a[1] >> 2) | ((uint16_t)a[2] << 6);
-            t[2] = (a[2] >> 4) | ((uint16_t)a[3] << 4);
-            t[3] = (a[3] >> 6) | ((uint16_t)a[4] << 2);
-            a += 5;
+  }
+#elif (KYBER_POLYVECCOMPRESSEDBYTES == (KYBER_K * 320))
+  uint16_t t[4];
+  for (i = 0; i < KYBER_K; i++) {
+    for (j = 0; j < KYBER_N / 4; j++) {
+      t[0] = (a[0] >> 0) | ((uint16_t)a[1] << 8);
+      t[1] = (a[1] >> 2) | ((uint16_t)a[2] << 6);
+      t[2] = (a[2] >> 4) | ((uint16_t)a[3] << 4);
+      t[3] = (a[3] >> 6) | ((uint16_t)a[4] << 2);
+      a += 5;
 
-            for (k = 0; k < 4; k++)
-            {
-                r->vec[i].coeffs[4 * j + k] = ((uint32_t)(t[k] & 0x3FF) * KYBER_Q + 512) >> 10;
-            }
-        }
+      for (k = 0; k < 4; k++) {
+        r->vec[i].coeffs[4 * j + k] =
+            ((uint32_t)(t[k] & 0x3FF) * KYBER_Q + 512) >> 10;
+      }
     }
-    #else
+  }
+#else
 #error "KYBER_POLYVECCOMPRESSEDBYTES needs to be in {320*KYBER_K, 352*KYBER_K}"
-    #endif
+#endif
 }
 
 /*************************************************
-* Name:        polyvec_tobytes
-*
-* Description: Serialize vector of polynomials
-*
-* Arguments:   - uint8_t *r: pointer to output byte array
-*                            (needs space for KYBER_POLYVECBYTES)
-*              - const polyvec *a: pointer to input vector of polynomials
-**************************************************/
-void polyvec_tobytes(uint8_t r[KYBER_POLYVECBYTES], const polyvec *a)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_K; i++)
-    {
-        poly_tobytes(r + i * KYBER_POLYBYTES, &a->vec[i]);
-    }
+ * Name:        polyvec_tobytes
+ *
+ * Description: Serialize vector of polynomials
+ *
+ * Arguments:   - uint8_t *r: pointer to output byte array
+ *                            (needs space for KYBER_POLYVECBYTES)
+ *              - const polyvec *a: pointer to input vector of polynomials
+ **************************************************/
+void polyvec_tobytes(uint8_t r[KYBER_POLYVECBYTES], const polyvec *a) {
+  unsigned int i;
+  for (i = 0; i < KYBER_K; i++) {
+    poly_tobytes(r + i * KYBER_POLYBYTES, &a->vec[i]);
+  }
 }
 
 /*************************************************
-* Name:        polyvec_frombytes
-*
-* Description: De-serialize vector of polynomials;
-*              inverse of polyvec_tobytes
-*
-* Arguments:   - uint8_t *r:       pointer to output byte array
-*              - const polyvec *a: pointer to input vector of polynomials
-*                                  (of length KYBER_POLYVECBYTES)
-**************************************************/
-void polyvec_frombytes(polyvec *r, const uint8_t a[KYBER_POLYVECBYTES])
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_K; i++)
-    {
-        poly_frombytes(&r->vec[i], a + i * KYBER_POLYBYTES);
-    }
+ * Name:        polyvec_frombytes
+ *
+ * Description: De-serialize vector of polynomials;
+ *              inverse of polyvec_tobytes
+ *
+ * Arguments:   - uint8_t *r:       pointer to output byte array
+ *              - const polyvec *a: pointer to input vector of polynomials
+ *                                  (of length KYBER_POLYVECBYTES)
+ **************************************************/
+void polyvec_frombytes(polyvec *r, const uint8_t a[KYBER_POLYVECBYTES]) {
+  unsigned int i;
+  for (i = 0; i < KYBER_K; i++) {
+    poly_frombytes(&r->vec[i], a + i * KYBER_POLYBYTES);
+  }
 }
 
 /*************************************************
-* Name:        polyvec_ntt
-*
-* Description: Apply forward NTT to all elements of a vector of polynomials
-*
-* Arguments:   - polyvec *r: pointer to in/output vector of polynomials
-**************************************************/
-void polyvec_ntt(polyvec *r)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_K; i++)
-    {
-        poly_ntt(&r->vec[i]);
-    }
+ * Name:        polyvec_ntt
+ *
+ * Description: Apply forward NTT to all elements of a vector of polynomials
+ *
+ * Arguments:   - polyvec *r: pointer to in/output vector of polynomials
+ **************************************************/
+void polyvec_ntt(polyvec *r) {
+  unsigned int i;
+  for (i = 0; i < KYBER_K; i++) {
+    poly_ntt(&r->vec[i]);
+  }
 }
 
 /*************************************************
-* Name:        polyvec_invntt_tomont
-*
-* Description: Apply inverse NTT to all elements of a vector of polynomials
-*              and multiply by Montgomery factor 2^16
-*
-* Arguments:   - polyvec *r: pointer to in/output vector of polynomials
-**************************************************/
-void polyvec_invntt_tomont(polyvec *r)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_K; i++)
-    {
-        poly_invntt_tomont(&r->vec[i]);
-    }
+ * Name:        polyvec_invntt_tomont
+ *
+ * Description: Apply inverse NTT to all elements of a vector of polynomials
+ *              and multiply by Montgomery factor 2^16
+ *
+ * Arguments:   - polyvec *r: pointer to in/output vector of polynomials
+ **************************************************/
+void polyvec_invntt_tomont(polyvec *r) {
+  unsigned int i;
+  for (i = 0; i < KYBER_K; i++) {
+    poly_invntt_tomont(&r->vec[i]);
+  }
 }
 
 /*************************************************
-* Name:        polyvec_basemul_acc_montgomery
-*
-* Description: Multiply elements of a and b in NTT domain, accumulate into r,
-*              and multiply by 2^-16.
-*
-* Arguments: - poly *r: pointer to output polynomial
-*            - const polyvec *a: pointer to first input vector of polynomials
-*            - const polyvec *b: pointer to second input vector of polynomials
-**************************************************/
+ * Name:        polyvec_basemul_acc_montgomery
+ *
+ * Description: Multiply elements of a and b in NTT domain, accumulate into r,
+ *              and multiply by 2^-16.
+ *
+ * Arguments: - poly *r: pointer to output polynomial
+ *            - const polyvec *a: pointer to first input vector of polynomials
+ *            - const polyvec *b: pointer to second input vector of polynomials
+ **************************************************/
 #if !defined(MLKEM_USE_AARCH64_ASM)
-void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a, const polyvec *b,
-        const polyvec_mulcache *b_cache)
-{
-    unsigned int i;
-    poly t;
+void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
+                                           const polyvec *b,
+                                           const polyvec_mulcache *b_cache) {
+  unsigned int i;
+  poly t;
 
-    poly_basemul_montgomery(r, &a->vec[0], &b->vec[0]);
-    for (i = 1; i < KYBER_K; i++)
-    {
-        poly_basemul_montgomery_cached(&t, &a->vec[i], &b->vec[i], &b_cache->vec[i]);
-        poly_add(r, r, &t);
-    }
+  poly_basemul_montgomery(r, &a->vec[0], &b->vec[0]);
+  for (i = 1; i < KYBER_K; i++) {
+    poly_basemul_montgomery_cached(&t, &a->vec[i], &b->vec[i],
+                                   &b_cache->vec[i]);
+    poly_add(r, r, &t);
+  }
 
-    poly_reduce(r);
+  poly_reduce(r);
 }
-#else /* MLKEM_USE_AARCH64_ASM */
-void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a, const polyvec *b,
-        const polyvec_mulcache *b_cache)
-{
-    polyvec_basemul_acc_montgomery_cached_asm(r->coeffs, a->vec[0].coeffs,
-            b->vec[0].coeffs,
-            b_cache->vec[0].coeffs);
+#else  /* MLKEM_USE_AARCH64_ASM */
+void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
+                                           const polyvec *b,
+                                           const polyvec_mulcache *b_cache) {
+  polyvec_basemul_acc_montgomery_cached_asm(
+      r->coeffs, a->vec[0].coeffs, b->vec[0].coeffs, b_cache->vec[0].coeffs);
 }
 #endif /* MLKEM_USE_AARCH64_ASM */
 
 /*************************************************
-* Name:        polyvec_basemul_acc_montgomery
-*
-* Description: Multiply elements of a and b in NTT domain, accumulate into r,
-*              and multiply by 2^-16.
-*
-* Arguments: - poly *r: pointer to output polynomial
-*            - const polyvec *a: pointer to first input vector of polynomials
-*            - const polyvec *b: pointer to second input vector of polynomials
-**************************************************/
-void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
-{
-    polyvec_mulcache b_cache;
-    polyvec_mulcache_compute(&b_cache, b);
-    polyvec_basemul_acc_montgomery_cached(r, a, b, &b_cache);
+ * Name:        polyvec_basemul_acc_montgomery
+ *
+ * Description: Multiply elements of a and b in NTT domain, accumulate into r,
+ *              and multiply by 2^-16.
+ *
+ * Arguments: - poly *r: pointer to output polynomial
+ *            - const polyvec *a: pointer to first input vector of polynomials
+ *            - const polyvec *b: pointer to second input vector of polynomials
+ **************************************************/
+void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a,
+                                    const polyvec *b) {
+  polyvec_mulcache b_cache;
+  polyvec_mulcache_compute(&b_cache, b);
+  polyvec_basemul_acc_montgomery_cached(r, a, b, &b_cache);
 }
 
 /*************************************************
-* Name:        polyvec_mulcache_compute
-*
-* Description: Precompute values speeding up
-*              base multiplications of polynomials
-*              in NTT domain.
-*
-* Arguments: - polyvec_mulcache *x: pointer to output cache.
-*            - const poly *a: pointer to input polynomial
-**************************************************/
-void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_K; i++)
-    {
-        poly_mulcache_compute(&x->vec[i], &a->vec[i]);
-    }
+ * Name:        polyvec_mulcache_compute
+ *
+ * Description: Precompute values speeding up
+ *              base multiplications of polynomials
+ *              in NTT domain.
+ *
+ * Arguments: - polyvec_mulcache *x: pointer to output cache.
+ *            - const poly *a: pointer to input polynomial
+ **************************************************/
+void polyvec_mulcache_compute(polyvec_mulcache *x, const polyvec *a) {
+  unsigned int i;
+  for (i = 0; i < KYBER_K; i++) {
+    poly_mulcache_compute(&x->vec[i], &a->vec[i]);
+  }
 }
 
 
 /*************************************************
-* Name:        polyvec_reduce
-*
-* Description: Applies Barrett reduction to each coefficient
-*              of each element of a vector of polynomials;
-*              for details of the Barrett reduction see comments in reduce.c
-*
-* Arguments:   - polyvec *r: pointer to input/output polynomial
-**************************************************/
-void polyvec_reduce(polyvec *r)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_K; i++)
-    {
-        poly_reduce(&r->vec[i]);
-    }
+ * Name:        polyvec_reduce
+ *
+ * Description: Applies Barrett reduction to each coefficient
+ *              of each element of a vector of polynomials;
+ *              for details of the Barrett reduction see comments in reduce.c
+ *
+ * Arguments:   - polyvec *r: pointer to input/output polynomial
+ **************************************************/
+void polyvec_reduce(polyvec *r) {
+  unsigned int i;
+  for (i = 0; i < KYBER_K; i++) {
+    poly_reduce(&r->vec[i]);
+  }
 }
 
 /*************************************************
-* Name:        polyvec_add
-*
-* Description: Add vectors of polynomials
-*
-* Arguments: - polyvec *r: pointer to output vector of polynomials
-*            - const polyvec *a: pointer to first input vector of polynomials
-*            - const polyvec *b: pointer to second input vector of polynomials
-**************************************************/
-void polyvec_add(polyvec *r, const polyvec *a, const polyvec *b)
-{
-    unsigned int i;
-    for (i = 0; i < KYBER_K; i++)
-    {
-        poly_add(&r->vec[i], &a->vec[i], &b->vec[i]);
-    }
+ * Name:        polyvec_add
+ *
+ * Description: Add vectors of polynomials
+ *
+ * Arguments: - polyvec *r: pointer to output vector of polynomials
+ *            - const polyvec *a: pointer to first input vector of polynomials
+ *            - const polyvec *b: pointer to second input vector of polynomials
+ **************************************************/
+void polyvec_add(polyvec *r, const polyvec *a, const polyvec *b) {
+  unsigned int i;
+  for (i = 0; i < KYBER_K; i++) {
+    poly_add(&r->vec[i], &a->vec[i], &b->vec[i]);
+  }
 }

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -6,21 +6,21 @@
 #include "params.h"
 #include "poly.h"
 
-typedef struct
-{
-    poly vec[KYBER_K];
+typedef struct {
+  poly vec[KYBER_K];
 } ALIGN(16) polyvec;
 
 // REF-CHANGE: This struct does not exist in the reference implementation
-typedef struct
-{
-    poly_mulcache vec[KYBER_K];
+typedef struct {
+  poly_mulcache vec[KYBER_K];
 } polyvec_mulcache;
 
 #define polyvec_compress KYBER_NAMESPACE(polyvec_compress)
-void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES], const polyvec *a);
+void polyvec_compress(uint8_t r[KYBER_POLYVECCOMPRESSEDBYTES],
+                      const polyvec *a);
 #define polyvec_decompress KYBER_NAMESPACE(polyvec_decompress)
-void polyvec_decompress(polyvec *r, const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES]);
+void polyvec_decompress(polyvec *r,
+                        const uint8_t a[KYBER_POLYVECCOMPRESSEDBYTES]);
 
 #define polyvec_tobytes KYBER_NAMESPACE(polyvec_tobytes)
 void polyvec_tobytes(uint8_t r[KYBER_POLYVECBYTES], const polyvec *a);
@@ -32,12 +32,17 @@ void polyvec_ntt(polyvec *r);
 #define polyvec_invntt_tomont KYBER_NAMESPACE(polyvec_invntt_tomont)
 void polyvec_invntt_tomont(polyvec *r);
 
-#define polyvec_basemul_acc_montgomery KYBER_NAMESPACE(polyvec_basemul_acc_montgomery)
-void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b);
+#define polyvec_basemul_acc_montgomery \
+  KYBER_NAMESPACE(polyvec_basemul_acc_montgomery)
+void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a,
+                                    const polyvec *b);
 
 // REF-CHANGE: This function does not exist in the reference implementation
-#define polyvec_basemul_acc_montgomery_cached KYBER_NAMESPACE(polyvec_basemul_acc_montgomery_cached)
-void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a, const polyvec *b, const polyvec_mulcache *b_cache);
+#define polyvec_basemul_acc_montgomery_cached \
+  KYBER_NAMESPACE(polyvec_basemul_acc_montgomery_cached)
+void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
+                                           const polyvec *b,
+                                           const polyvec_mulcache *b_cache);
 
 // REF-CHANGE: This function does not exist in the reference implementation
 #define polyvec_mulcache_compute KYBER_NAMESPACE(polyvec_mulcache_compute)

--- a/mlkem/reduce.c
+++ b/mlkem/reduce.c
@@ -1,44 +1,43 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "reduce.h"
 #include <stdint.h>
 #include "params.h"
-#include "reduce.h"
 
 /*************************************************
-* Name:        montgomery_reduce
-*
-* Description: Montgomery reduction; given a 32-bit integer a, computes
-*              16-bit integer congruent to a * R^-1 mod q, where R=2^16
-*
-* Arguments:   - int32_t a: input integer to be reduced;
-*                           has to be in {-q2^15,...,q2^15-1}
-*
-* Returns:     integer in {-q+1,...,q-1} congruent to a * R^-1 modulo q.
-**************************************************/
-int16_t montgomery_reduce(int32_t a)
-{
-    int16_t t;
+ * Name:        montgomery_reduce
+ *
+ * Description: Montgomery reduction; given a 32-bit integer a, computes
+ *              16-bit integer congruent to a * R^-1 mod q, where R=2^16
+ *
+ * Arguments:   - int32_t a: input integer to be reduced;
+ *                           has to be in {-q2^15,...,q2^15-1}
+ *
+ * Returns:     integer in {-q+1,...,q-1} congruent to a * R^-1 modulo q.
+ **************************************************/
+int16_t montgomery_reduce(int32_t a) {
+  int16_t t;
 
-    t = (int16_t)a * QINV;
-    t = (a - (int32_t)t * KYBER_Q) >> 16;
-    return t;
+  t = (int16_t)a * QINV;
+  t = (a - (int32_t)t * KYBER_Q) >> 16;
+  return t;
 }
 
 /*************************************************
-* Name:        barrett_reduce
-*
-* Description: Barrett reduction; given a 16-bit integer a, computes
-*              centered representative congruent to a mod q in {-(q-1)/2,...,(q-1)/2}
-*
-* Arguments:   - int16_t a: input integer to be reduced
-*
-* Returns:     integer in {-(q-1)/2,...,(q-1)/2} congruent to a modulo q.
-**************************************************/
-int16_t barrett_reduce(int16_t a)
-{
-    int16_t t;
-    const int16_t v = ((1 << 26) + KYBER_Q / 2) / KYBER_Q;
+ * Name:        barrett_reduce
+ *
+ * Description: Barrett reduction; given a 16-bit integer a, computes
+ *              centered representative congruent to a mod q in
+ *{-(q-1)/2,...,(q-1)/2}
+ *
+ * Arguments:   - int16_t a: input integer to be reduced
+ *
+ * Returns:     integer in {-(q-1)/2,...,(q-1)/2} congruent to a modulo q.
+ **************************************************/
+int16_t barrett_reduce(int16_t a) {
+  int16_t t;
+  const int16_t v = ((1 << 26) + KYBER_Q / 2) / KYBER_Q;
 
-    t  = ((int32_t)v * a + (1 << 25)) >> 26;
-    t *= KYBER_Q;
-    return a - t;
+  t = ((int32_t)v * a + (1 << 25)) >> 26;
+  t *= KYBER_Q;
+  return a - t;
 }

--- a/mlkem/reduce.h
+++ b/mlkem/reduce.h
@@ -5,8 +5,8 @@
 #include <stdint.h>
 #include "params.h"
 
-#define MONT -1044 // 2^16 mod q
-#define QINV -3327 // q^-1 mod 2^16
+#define MONT -1044  // 2^16 mod q
+#define QINV -3327  // q^-1 mod 2^16
 
 #define montgomery_reduce KYBER_NAMESPACE(montgomery_reduce)
 int16_t montgomery_reduce(int32_t a);
@@ -24,9 +24,8 @@ int16_t barrett_reduce(int16_t a);
  *
  * Returns 16-bit integer congruent to a*b*R^{-1} mod q
  **************************************************/
-static inline int16_t fqmul(int16_t a, int16_t b)
-{
-    return montgomery_reduce((int32_t)a * b);
+static inline int16_t fqmul(int16_t a, int16_t b) {
+  return montgomery_reduce((int32_t)a * b);
 }
 
 #endif

--- a/mlkem/symmetric-shake.c
+++ b/mlkem/symmetric-shake.c
@@ -2,49 +2,52 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include "fips202.h"
 #include "params.h"
 #include "symmetric.h"
-#include "fips202.h"
 
 /*************************************************
-* Name:        kyber_shake256_prf
-*
-* Description: Usage of SHAKE256 as a PRF, concatenates secret and public input
-*              and then generates outlen bytes of SHAKE256 output
-*
-* Arguments:   - uint8_t *out: pointer to output
-*              - size_t outlen: number of requested output bytes
-*              - const uint8_t *key: pointer to the key (of length KYBER_SYMBYTES)
-*              - uint8_t nonce: single-byte nonce (public PRF input)
-**************************************************/
-void kyber_shake256_prf(uint8_t *out, size_t outlen, const uint8_t key[KYBER_SYMBYTES], uint8_t nonce)
-{
-    uint8_t extkey[KYBER_SYMBYTES + 1];
+ * Name:        kyber_shake256_prf
+ *
+ * Description: Usage of SHAKE256 as a PRF, concatenates secret and public input
+ *              and then generates outlen bytes of SHAKE256 output
+ *
+ * Arguments:   - uint8_t *out: pointer to output
+ *              - size_t outlen: number of requested output bytes
+ *              - const uint8_t *key: pointer to the key (of length
+ *KYBER_SYMBYTES)
+ *              - uint8_t nonce: single-byte nonce (public PRF input)
+ **************************************************/
+void kyber_shake256_prf(uint8_t *out, size_t outlen,
+                        const uint8_t key[KYBER_SYMBYTES], uint8_t nonce) {
+  uint8_t extkey[KYBER_SYMBYTES + 1];
 
-    memcpy(extkey, key, KYBER_SYMBYTES);
-    extkey[KYBER_SYMBYTES] = nonce;
+  memcpy(extkey, key, KYBER_SYMBYTES);
+  extkey[KYBER_SYMBYTES] = nonce;
 
-    shake256(out, outlen, extkey, sizeof(extkey));
+  shake256(out, outlen, extkey, sizeof(extkey));
 }
 
 /*************************************************
-* Name:        kyber_shake256_rkprf
-*
-* Description: Usage of SHAKE256 as a PRF, concatenates secret and public input
-*              and then generates outlen bytes of SHAKE256 output
-*
-* Arguments:   - uint8_t *out: pointer to output
-*              - size_t outlen: number of requested output bytes
-*              - const uint8_t *key: pointer to the key (of length KYBER_SYMBYTES)
-*              - uint8_t nonce: single-byte nonce (public PRF input)
-**************************************************/
-void kyber_shake256_rkprf(uint8_t out[KYBER_SSBYTES], const uint8_t key[KYBER_SYMBYTES], const uint8_t input[KYBER_CIPHERTEXTBYTES])
-{
-    shake256incctx s;
+ * Name:        kyber_shake256_rkprf
+ *
+ * Description: Usage of SHAKE256 as a PRF, concatenates secret and public input
+ *              and then generates outlen bytes of SHAKE256 output
+ *
+ * Arguments:   - uint8_t *out: pointer to output
+ *              - size_t outlen: number of requested output bytes
+ *              - const uint8_t *key: pointer to the key (of length
+ *KYBER_SYMBYTES)
+ *              - uint8_t nonce: single-byte nonce (public PRF input)
+ **************************************************/
+void kyber_shake256_rkprf(uint8_t out[KYBER_SSBYTES],
+                          const uint8_t key[KYBER_SYMBYTES],
+                          const uint8_t input[KYBER_CIPHERTEXTBYTES]) {
+  shake256incctx s;
 
-    shake256_inc_init(&s);
-    shake256_inc_absorb(&s, key, KYBER_SYMBYTES);
-    shake256_inc_absorb(&s, input, KYBER_CIPHERTEXTBYTES);
-    shake256_inc_finalize(&s);
-    shake256_inc_squeeze(out, KYBER_SSBYTES, &s);
+  shake256_inc_init(&s);
+  shake256_inc_absorb(&s, key, KYBER_SYMBYTES);
+  shake256_inc_absorb(&s, input, KYBER_CIPHERTEXTBYTES);
+  shake256_inc_finalize(&s);
+  shake256_inc_squeeze(out, KYBER_SSBYTES, &s);
 }

--- a/mlkem/symmetric.h
+++ b/mlkem/symmetric.h
@@ -9,14 +9,18 @@
 #include "fips202.h"
 
 #define kyber_shake256_prf KYBER_NAMESPACE(kyber_shake256_prf)
-void kyber_shake256_prf(uint8_t *out, size_t outlen, const uint8_t key[KYBER_SYMBYTES], uint8_t nonce);
+void kyber_shake256_prf(uint8_t *out, size_t outlen,
+                        const uint8_t key[KYBER_SYMBYTES], uint8_t nonce);
 
 #define kyber_shake256_rkprf KYBER_NAMESPACE(kyber_shake256_rkprf)
-void kyber_shake256_rkprf(uint8_t out[KYBER_SSBYTES], const uint8_t key[KYBER_SYMBYTES], const uint8_t input[KYBER_CIPHERTEXTBYTES]);
+void kyber_shake256_rkprf(uint8_t out[KYBER_SSBYTES],
+                          const uint8_t key[KYBER_SYMBYTES],
+                          const uint8_t input[KYBER_CIPHERTEXTBYTES]);
 
 #define hash_h(OUT, IN, INBYTES) sha3_256(OUT, IN, INBYTES)
 #define hash_g(OUT, IN, INBYTES) sha3_512(OUT, IN, INBYTES)
-#define prf(OUT, OUTBYTES, KEY, NONCE) kyber_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
+#define prf(OUT, OUTBYTES, KEY, NONCE) \
+  kyber_shake256_prf(OUT, OUTBYTES, KEY, NONCE)
 #define rkprf(OUT, KEY, INPUT) kyber_shake256_rkprf(OUT, KEY, INPUT)
 
 #endif /* SYMMETRIC_H */

--- a/mlkem/verify.c
+++ b/mlkem/verify.c
@@ -1,76 +1,70 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "verify.h"
 #include <stddef.h>
 #include <stdint.h>
-#include "verify.h"
 
 /*************************************************
-* Name:        verify
-*
-* Description: Compare two arrays for equality in constant time.
-*
-* Arguments:   const uint8_t *a: pointer to first byte array
-*              const uint8_t *b: pointer to second byte array
-*              size_t len:       length of the byte arrays
-*
-* Returns 0 if the byte arrays are equal, 1 otherwise
-**************************************************/
-int verify(const uint8_t *a, const uint8_t *b, size_t len)
-{
-    size_t i;
-    uint8_t r = 0;
+ * Name:        verify
+ *
+ * Description: Compare two arrays for equality in constant time.
+ *
+ * Arguments:   const uint8_t *a: pointer to first byte array
+ *              const uint8_t *b: pointer to second byte array
+ *              size_t len:       length of the byte arrays
+ *
+ * Returns 0 if the byte arrays are equal, 1 otherwise
+ **************************************************/
+int verify(const uint8_t *a, const uint8_t *b, size_t len) {
+  size_t i;
+  uint8_t r = 0;
 
-    for (i = 0; i < len; i++)
-    {
-        r |= a[i] ^ b[i];
-    }
+  for (i = 0; i < len; i++) {
+    r |= a[i] ^ b[i];
+  }
 
-    return (-(uint64_t)r) >> 63;
+  return (-(uint64_t)r) >> 63;
 }
 
 /*************************************************
-* Name:        cmov
-*
-* Description: Copy len bytes from x to r if b is 1;
-*              don't modify x if b is 0. Requires b to be in {0,1};
-*              assumes two's complement representation of negative integers.
-*              Runs in constant time.
-*
-* Arguments:   uint8_t *r:       pointer to output byte array
-*              const uint8_t *x: pointer to input byte array
-*              size_t len:       Amount of bytes to be copied
-*              uint8_t b:        Condition bit; has to be in {0,1}
-**************************************************/
-void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b)
-{
-    size_t i;
+ * Name:        cmov
+ *
+ * Description: Copy len bytes from x to r if b is 1;
+ *              don't modify x if b is 0. Requires b to be in {0,1};
+ *              assumes two's complement representation of negative integers.
+ *              Runs in constant time.
+ *
+ * Arguments:   uint8_t *r:       pointer to output byte array
+ *              const uint8_t *x: pointer to input byte array
+ *              size_t len:       Amount of bytes to be copied
+ *              uint8_t b:        Condition bit; has to be in {0,1}
+ **************************************************/
+void cmov(uint8_t *r, const uint8_t *x, size_t len, uint8_t b) {
+  size_t i;
 
-    b = -b;
-    for (i = 0; i < len; i++)
-    {
-        r[i] ^= b & (r[i] ^ x[i]);
-    }
+  b = -b;
+  for (i = 0; i < len; i++) {
+    r[i] ^= b & (r[i] ^ x[i]);
+  }
 }
 
 /*************************************************
-* Name:        cmov_int16
-*
-* Description: Copy input v to *r if b is 1, don't modify *r if b is 0.
-*              Requires b to be in {0,1};
-*              Runs in constant time.
-*
-* Arguments:   int16_t *r:       pointer to output int16_t
-*              int16_t v:        input int16_t
-*              uint8_t b:        Condition bit; has to be in {0,1}
-**************************************************/
-void cmov_int16(int16_t *r, int16_t v, uint16_t b)
-{
-
+ * Name:        cmov_int16
+ *
+ * Description: Copy input v to *r if b is 1, don't modify *r if b is 0.
+ *              Requires b to be in {0,1};
+ *              Runs in constant time.
+ *
+ * Arguments:   int16_t *r:       pointer to output int16_t
+ *              int16_t v:        input int16_t
+ *              uint8_t b:        Condition bit; has to be in {0,1}
+ **************************************************/
+void cmov_int16(int16_t *r, int16_t v, uint16_t b) {
 // CBMC issues false alarms here for the implicit conversions between
 // uint16_t and int, so disable "conversion-check" here for now.
 // Revisit this when proof of this unit with contracts is attempted.
 #pragma CPROVER check push
 #pragma CPROVER check disable "conversion"
-    b = -b;
-    *r ^= b & ((*r) ^ v);
+  b = -b;
+  *r ^= b & ((*r) ^ v);
 #pragma CPROVER check pop
 }

--- a/randombytes/randombytes.c
+++ b/randombytes/randombytes.c
@@ -1,106 +1,88 @@
 // SPDX-License-Identifier: Apache-2.0
+#include "randombytes.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include "randombytes.h"
 
 #ifdef _WIN32
-#include <windows.h>
 #include <wincrypt.h>
+#include <windows.h>
 #else
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
 #ifdef __linux__
 #define _GNU_SOURCE
-#include <unistd.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 #else
 #include <unistd.h>
 #endif
 #endif
 
 #ifdef _WIN32
-void randombytes(uint8_t *out, size_t outlen)
-{
-    HCRYPTPROV ctx;
-    size_t len;
+void randombytes(uint8_t *out, size_t outlen) {
+  HCRYPTPROV ctx;
+  size_t len;
 
-    if (!CryptAcquireContext(&ctx, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
-    {
-        abort();
+  if (!CryptAcquireContext(&ctx, NULL, NULL, PROV_RSA_FULL,
+                           CRYPT_VERIFYCONTEXT)) {
+    abort();
+  }
+
+  while (outlen > 0) {
+    len = (outlen > 1048576) ? 1048576 : outlen;
+    if (!CryptGenRandom(ctx, len, (BYTE *)out)) {
+      abort();
     }
 
-    while (outlen > 0)
-    {
-        len = (outlen > 1048576) ? 1048576 : outlen;
-        if (!CryptGenRandom(ctx, len, (BYTE *)out))
-        {
-            abort();
-        }
+    out += len;
+    outlen -= len;
+  }
 
-        out += len;
-        outlen -= len;
-    }
-
-    if (!CryptReleaseContext(ctx, 0))
-    {
-        abort();
-    }
+  if (!CryptReleaseContext(ctx, 0)) {
+    abort();
+  }
 }
 #elif defined(__linux__) && defined(SYS_getrandom)
-void randombytes(uint8_t *out, size_t outlen)
-{
-    ssize_t ret;
+void randombytes(uint8_t *out, size_t outlen) {
+  ssize_t ret;
 
-    while (outlen > 0)
-    {
-        ret = syscall(SYS_getrandom, out, outlen, 0);
-        if (ret == -1 && errno == EINTR)
-        {
-            continue;
-        }
-        else if (ret == -1)
-        {
-            abort();
-        }
-
-        out += ret;
-        outlen -= ret;
+  while (outlen > 0) {
+    ret = syscall(SYS_getrandom, out, outlen, 0);
+    if (ret == -1 && errno == EINTR) {
+      continue;
+    } else if (ret == -1) {
+      abort();
     }
+
+    out += ret;
+    outlen -= ret;
+  }
 }
 #else
-void randombytes(uint8_t *out, size_t outlen)
-{
-    static int fd = -1;
-    ssize_t ret;
+void randombytes(uint8_t *out, size_t outlen) {
+  static int fd = -1;
+  ssize_t ret;
 
-    while (fd == -1)
-    {
-        fd = open("/dev/urandom", O_RDONLY);
-        if (fd == -1 && errno == EINTR)
-        {
-            continue;
-        }
-        else if (fd == -1)
-        {
-            abort();
-        }
+  while (fd == -1) {
+    fd = open("/dev/urandom", O_RDONLY);
+    if (fd == -1 && errno == EINTR) {
+      continue;
+    } else if (fd == -1) {
+      abort();
+    }
+  }
+
+  while (outlen > 0) {
+    ret = read(fd, out, outlen);
+    if (ret == -1 && errno == EINTR) {
+      continue;
+    } else if (ret == -1) {
+      abort();
     }
 
-    while (outlen > 0)
-    {
-        ret = read(fd, out, outlen);
-        if (ret == -1 && errno == EINTR)
-        {
-            continue;
-        }
-        else if (ret == -1)
-        {
-            abort();
-        }
-
-        out += ret;
-        outlen -= ret;
-    }
+    out += ret;
+    outlen -= ret;
+  }
 }
 #endif

--- a/scripts/ci/lint
+++ b/scripts/ci/lint
@@ -56,8 +56,8 @@ else
 fi
 echo "::endgroup::"
 
-echo "::group::Linting c files with astyle"
-checkerr "Lint C" "$(astyle $(git ls-files ":/*.c" ":/*.h") --options="$ROOT/.astylerc" --dry-run --formatted | awk '{print $2}')"
+echo "::group::Linting c files with clang-format"
+checkerr "Lint C" "$(clang-format $(git ls-files ":/*.c" ":/*.h") --dry-run)"
 echo "::endgroup::"
 
 check-eol-dry-run()

--- a/scripts/format
+++ b/scripts/format
@@ -28,7 +28,7 @@ info "Formatting python scripts"
 black --include scripts/tests "$ROOT"
 
 info "Formatting c files"
-astyle $(git ls-files ":/*.c" ":/*.h") --options="$ROOT/.astylerc" --formatted | awk '{print $2}'
+clang-format -i $(git ls-files ":/*.c" ":/*.h")
 
 info "Checking for eol"
 check-eol()

--- a/test/bench_components_kyber.c
+++ b/test/bench_components_kyber.c
@@ -1,100 +1,92 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
-#include "kem.h"
 #include "hal.h"
+#include "kem.h"
 #include "randombytes.h"
 
-#include "keccakf1600.h"
 #include "../mlkem/asm/asm.h"
+#include "keccakf1600.h"
 
 #define NWARMUP 50
 #define NITERERATIONS 300
 #define NTESTS 200
 
-static int cmp_uint64_t(const void *a, const void *b)
-{
-    return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));
+static int cmp_uint64_t(const void *a, const void *b) {
+  return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));
 }
 
-#define BENCH(txt,code)                                   \
-    for (i = 0; i < NTESTS; i++)                          \
-    {                                                     \
-        randombytes((uint8_t*)data0, sizeof(data0));      \
-        randombytes((uint8_t*)data1, sizeof(data1));      \
-        randombytes((uint8_t*)data2, sizeof(data2));      \
-        randombytes((uint8_t*)data3, sizeof(data3));      \
-        for (j = 0; j < NWARMUP; j++)                     \
-        {                                                 \
-            code;                                         \
-        }                                                 \
-        \
-        t0 = get_cyclecounter();                          \
-        for (j = 0; j < NITERERATIONS; j++)               \
-        {                                                 \
-            code;                                         \
-        }                                                 \
-        t1 = get_cyclecounter();                          \
-        (cyc)[i] = t1 - t0;                               \
-    }                                                     \
-    qsort((cyc), NTESTS, sizeof(uint64_t), cmp_uint64_t); \
-    printf(txt " cycles=%"PRIu64"\n",                  \
-           (cyc)[NTESTS >> 1]/NITERERATIONS);
+#define BENCH(txt, code)                                \
+  for (i = 0; i < NTESTS; i++) {                        \
+    randombytes((uint8_t *)data0, sizeof(data0));       \
+    randombytes((uint8_t *)data1, sizeof(data1));       \
+    randombytes((uint8_t *)data2, sizeof(data2));       \
+    randombytes((uint8_t *)data3, sizeof(data3));       \
+    for (j = 0; j < NWARMUP; j++) {                     \
+      code;                                             \
+    }                                                   \
+                                                        \
+    t0 = get_cyclecounter();                            \
+    for (j = 0; j < NITERERATIONS; j++) {               \
+      code;                                             \
+    }                                                   \
+    t1 = get_cyclecounter();                            \
+    (cyc)[i] = t1 - t0;                                 \
+  }                                                     \
+  qsort((cyc), NTESTS, sizeof(uint64_t), cmp_uint64_t); \
+  printf(txt " cycles=%" PRIu64 "\n", (cyc)[NTESTS >> 1] / NITERERATIONS);
 
-static int bench(void)
-{
-    uint64_t data0[1024] ALIGN(16);
-    uint64_t data1[1024] ALIGN(16);
-    uint64_t data2[1024] ALIGN(16);
-    uint64_t data3[1024] ALIGN(16);
-    uint64_t cyc[NTESTS];
+static int bench(void) {
+  uint64_t data0[1024] ALIGN(16);
+  uint64_t data1[1024] ALIGN(16);
+  uint64_t data2[1024] ALIGN(16);
+  uint64_t data3[1024] ALIGN(16);
+  uint64_t cyc[NTESTS];
 
-    unsigned int i, j;
-    uint64_t t0, t1;
+  unsigned int i, j;
+  uint64_t t0, t1;
 
-    BENCH("keccak-f1600-x1", KeccakF1600_StatePermute(data0));
-    BENCH("keccak-f1600-x4", KeccakF1600x4_StatePermute(data0));
+  BENCH("keccak-f1600-x1", KeccakF1600_StatePermute(data0));
+  BENCH("keccak-f1600-x4", KeccakF1600x4_StatePermute(data0));
 
-    #if defined(MLKEM_USE_AARCH64_ASM)
-    BENCH("ntt-clean", ntt_asm_clean((int16_t *)data0));
-    BENCH("intt-clean", intt_asm_clean((int16_t *)data0));
-    BENCH("poly-reduce-clean", poly_reduce_asm_clean((int16_t *)data0));
-    BENCH("poly-tomont-clean", poly_tomont_asm_clean((int16_t *)data0));
-    BENCH("poly-tobytes-clean", poly_tobytes_asm_clean((uint8_t *) data0, (int16_t *)data1));
-    BENCH("poly-mulcache-compute-clean",                                  \
-          poly_mulcache_compute_asm_clean(                                \
-                  (int16_t *) data0, (int16_t *) data1,                           \
-                  (int16_t *) data2, (int16_t *) data3));
-    BENCH("poly-basemul-acc-montgomery-clean",                            \
-          polyvec_basemul_acc_montgomery_cached_asm_clean_name(KYBER_K) ( \
-                  (int16_t *) data0, (int16_t *) data1,                           \
-                  (int16_t *) data2, (int16_t *) data3));
+#if defined(MLKEM_USE_AARCH64_ASM)
+  BENCH("ntt-clean", ntt_asm_clean((int16_t *)data0));
+  BENCH("intt-clean", intt_asm_clean((int16_t *)data0));
+  BENCH("poly-reduce-clean", poly_reduce_asm_clean((int16_t *)data0));
+  BENCH("poly-tomont-clean", poly_tomont_asm_clean((int16_t *)data0));
+  BENCH("poly-tobytes-clean",
+        poly_tobytes_asm_clean((uint8_t *)data0, (int16_t *)data1));
+  BENCH("poly-mulcache-compute-clean",
+        poly_mulcache_compute_asm_clean((int16_t *)data0, (int16_t *)data1,
+                                        (int16_t *)data2, (int16_t *)data3));
+  BENCH("poly-basemul-acc-montgomery-clean",
+        polyvec_basemul_acc_montgomery_cached_asm_clean_name(KYBER_K)(
+            (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
+            (int16_t *)data3));
 
-    BENCH("ntt-opt", ntt_asm_opt((int16_t *)data0));
-    BENCH("intt-opt", intt_asm_opt((int16_t *)data0));
-    BENCH("poly-reduce-opt", poly_reduce_asm_opt((int16_t *)data0));
-    BENCH("poly-tomont-opt", poly_tomont_asm_opt((int16_t *)data0));
-    BENCH("poly-mulcache-compute-opt",                                    \
-          poly_mulcache_compute_asm_opt(                                  \
-                  (int16_t *) data0, (int16_t *) data1,                           \
-                  (int16_t *) data2, (int16_t *) data3));
-    BENCH("poly-basemul-acc-montgomery-opt",                              \
-          polyvec_basemul_acc_montgomery_cached_asm_opt_name(KYBER_K) (   \
-                  (int16_t *) data0, (int16_t *) data1,                           \
-                  (int16_t *) data2, (int16_t *) data3));
-    #endif
+  BENCH("ntt-opt", ntt_asm_opt((int16_t *)data0));
+  BENCH("intt-opt", intt_asm_opt((int16_t *)data0));
+  BENCH("poly-reduce-opt", poly_reduce_asm_opt((int16_t *)data0));
+  BENCH("poly-tomont-opt", poly_tomont_asm_opt((int16_t *)data0));
+  BENCH("poly-mulcache-compute-opt",
+        poly_mulcache_compute_asm_opt((int16_t *)data0, (int16_t *)data1,
+                                      (int16_t *)data2, (int16_t *)data3));
+  BENCH("poly-basemul-acc-montgomery-opt",
+        polyvec_basemul_acc_montgomery_cached_asm_opt_name(KYBER_K)(
+            (int16_t *)data0, (int16_t *)data1, (int16_t *)data2,
+            (int16_t *)data3));
+#endif
 
-    return 0;
+  return 0;
 }
 
-int main(void)
-{
-    enable_cyclecounter();
-    bench();
-    disable_cyclecounter();
+int main(void) {
+  enable_cyclecounter();
+  bench();
+  disable_cyclecounter();
 
-    return 0;
+  return 0;
 }

--- a/test/bench_kyber.c
+++ b/test/bench_kyber.c
@@ -1,111 +1,102 @@
 // SPDX-License-Identifier: Apache-2.0
+#include <inttypes.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
-#include "kem.h"
 #include "hal.h"
+#include "kem.h"
 #include "randombytes.h"
 
 #define NWARMUP 50
 #define NITERERATIONS 300
 #define NTESTS 200
 
-static int cmp_uint64_t(const void *a, const void *b)
-{
-    return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));
+static int cmp_uint64_t(const void *a, const void *b) {
+  return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));
 }
 
-static int bench(void)
-{
-    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-    uint8_t sk[CRYPTO_SECRETKEYBYTES];
-    uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-    uint8_t key_a[CRYPTO_BYTES];
-    uint8_t key_b[CRYPTO_BYTES];
-    unsigned char kg_rand[2 * CRYPTO_BYTES], enc_rand[CRYPTO_BYTES];
-    uint64_t cycles_kg[NTESTS], cycles_enc[NTESTS], cycles_dec[NTESTS];
+static int bench(void) {
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  uint8_t key_a[CRYPTO_BYTES];
+  uint8_t key_b[CRYPTO_BYTES];
+  unsigned char kg_rand[2 * CRYPTO_BYTES], enc_rand[CRYPTO_BYTES];
+  uint64_t cycles_kg[NTESTS], cycles_enc[NTESTS], cycles_dec[NTESTS];
 
-    unsigned int i, j;
-    uint64_t t0, t1;
-
-
-    for (i = 0; i < NTESTS; i++)
-    {
-
-        randombytes(kg_rand, 2 * CRYPTO_BYTES);
-        randombytes(enc_rand, CRYPTO_BYTES);
-
-        // Key-pair generation
-        for (j = 0; j < NWARMUP; j++)
-        {
-            crypto_kem_keypair_derand(pk, sk, kg_rand);
-        }
-
-        t0 = get_cyclecounter();
-        for (j = 0; j < NITERERATIONS; j++)
-        {
-            crypto_kem_keypair_derand(pk, sk, kg_rand);
-        }
-        t1 = get_cyclecounter();
-        cycles_kg[i] = t1 - t0;
+  unsigned int i, j;
+  uint64_t t0, t1;
 
 
-        // Encapsulation
-        for (j = 0; j < NWARMUP; j++)
-        {
-            crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
-        }
-        t0 = get_cyclecounter();
-        for (j = 0; j < NITERERATIONS; j++)
-        {
-            crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
-        }
-        t1 = get_cyclecounter();
-        cycles_enc[i] = t1 - t0;
+  for (i = 0; i < NTESTS; i++) {
+    randombytes(kg_rand, 2 * CRYPTO_BYTES);
+    randombytes(enc_rand, CRYPTO_BYTES);
 
-        // Decapsulation
-        for (j = 0; j < NWARMUP; j++)
-        {
-            crypto_kem_dec(key_b, ct, sk);
-        }
-        t0 = get_cyclecounter();
-        for (j = 0; j < NITERERATIONS; j++)
-        {
-            crypto_kem_dec(key_b, ct, sk);
-        }
-        t1 = get_cyclecounter();
-        cycles_dec[i] = t1 - t0;
-
-
-        if (memcmp(key_a, key_b, CRYPTO_BYTES))
-        {
-            printf("ERROR keys\n");
-            return 1;
-        }
+    // Key-pair generation
+    for (j = 0; j < NWARMUP; j++) {
+      crypto_kem_keypair_derand(pk, sk, kg_rand);
     }
 
-    qsort(cycles_kg, NTESTS, sizeof(uint64_t), cmp_uint64_t);
-    qsort(cycles_enc, NTESTS, sizeof(uint64_t), cmp_uint64_t);
-    qsort(cycles_dec, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+    t0 = get_cyclecounter();
+    for (j = 0; j < NITERERATIONS; j++) {
+      crypto_kem_keypair_derand(pk, sk, kg_rand);
+    }
+    t1 = get_cyclecounter();
+    cycles_kg[i] = t1 - t0;
 
-    printf("keypair cycles=%"PRIu64"\n", cycles_kg[NTESTS >> 1]/NITERERATIONS);
-    printf("encaps cycles=%"PRIu64"\n", cycles_enc[NTESTS >> 1]/NITERERATIONS);
-    printf("decaps cycles=%"PRIu64"\n", cycles_dec[NTESTS >> 1]/NITERERATIONS);
 
-    return 0;
+    // Encapsulation
+    for (j = 0; j < NWARMUP; j++) {
+      crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
+    }
+    t0 = get_cyclecounter();
+    for (j = 0; j < NITERERATIONS; j++) {
+      crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
+    }
+    t1 = get_cyclecounter();
+    cycles_enc[i] = t1 - t0;
+
+    // Decapsulation
+    for (j = 0; j < NWARMUP; j++) {
+      crypto_kem_dec(key_b, ct, sk);
+    }
+    t0 = get_cyclecounter();
+    for (j = 0; j < NITERERATIONS; j++) {
+      crypto_kem_dec(key_b, ct, sk);
+    }
+    t1 = get_cyclecounter();
+    cycles_dec[i] = t1 - t0;
+
+
+    if (memcmp(key_a, key_b, CRYPTO_BYTES)) {
+      printf("ERROR keys\n");
+      return 1;
+    }
+  }
+
+  qsort(cycles_kg, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+  qsort(cycles_enc, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+  qsort(cycles_dec, NTESTS, sizeof(uint64_t), cmp_uint64_t);
+
+  printf("keypair cycles=%" PRIu64 "\n",
+         cycles_kg[NTESTS >> 1] / NITERERATIONS);
+  printf("encaps cycles=%" PRIu64 "\n",
+         cycles_enc[NTESTS >> 1] / NITERERATIONS);
+  printf("decaps cycles=%" PRIu64 "\n",
+         cycles_dec[NTESTS >> 1] / NITERERATIONS);
+
+  return 0;
 }
 
-int main(void)
-{
-    enable_cyclecounter();
-    bench();
-    disable_cyclecounter();
+int main(void) {
+  enable_cyclecounter();
+  bench();
+  disable_cyclecounter();
 
-    printf("CRYPTO_SECRETKEYBYTES:  %d\n", CRYPTO_SECRETKEYBYTES);
-    printf("CRYPTO_PUBLICKEYBYTES:  %d\n", CRYPTO_PUBLICKEYBYTES);
-    printf("CRYPTO_CIPHERTEXTBYTES: %d\n", CRYPTO_CIPHERTEXTBYTES);
+  printf("CRYPTO_SECRETKEYBYTES:  %d\n", CRYPTO_SECRETKEYBYTES);
+  printf("CRYPTO_PUBLICKEYBYTES:  %d\n", CRYPTO_PUBLICKEYBYTES);
+  printf("CRYPTO_CIPHERTEXTBYTES: %d\n", CRYPTO_CIPHERTEXTBYTES);
 
-    return 0;
+  return 0;
 }

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -8,63 +8,58 @@
 
 #define NTESTS 10000
 
-static void print_hex(const char *label, const uint8_t *data, size_t size)
-{
-    printf("%s = ", label);
-    for (size_t i = 0; i < size; i++)
-    {
-        printf("%02x", data[i]);
-    }
-    printf("\n");
+static void print_hex(const char *label, const uint8_t *data, size_t size) {
+  printf("%s = ", label);
+  for (size_t i = 0; i < size; i++) {
+    printf("%02x", data[i]);
+  }
+  printf("\n");
 }
 
-static void shake256_absorb(shake256incctx *state, const uint8_t *input, size_t inlen)
-{
-    shake256_inc_init(state);
-    shake256_inc_absorb(state, input, inlen);
-    shake256_inc_finalize(state);
+static void shake256_absorb(shake256incctx *state, const uint8_t *input,
+                            size_t inlen) {
+  shake256_inc_init(state);
+  shake256_inc_absorb(state, input, inlen);
+  shake256_inc_finalize(state);
 }
 
-int main(void)
-{
-    uint8_t coins[3 * KYBER_SYMBYTES] ALIGN(16);
-    uint8_t pk[CRYPTO_PUBLICKEYBYTES] ALIGN(16);
-    uint8_t sk[CRYPTO_SECRETKEYBYTES] ALIGN(16);
-    uint8_t ct[CRYPTO_CIPHERTEXTBYTES] ALIGN(16);
-    uint8_t ss1[CRYPTO_BYTES] ALIGN(16);
-    uint8_t ss2[CRYPTO_BYTES] ALIGN(16);
+int main(void) {
+  uint8_t coins[3 * KYBER_SYMBYTES] ALIGN(16);
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES] ALIGN(16);
+  uint8_t sk[CRYPTO_SECRETKEYBYTES] ALIGN(16);
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES] ALIGN(16);
+  uint8_t ss1[CRYPTO_BYTES] ALIGN(16);
+  uint8_t ss2[CRYPTO_BYTES] ALIGN(16);
 
-    const uint8_t seed[64] = {32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
-                              48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
-                              64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-                              80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
-                             };
+  const uint8_t seed[64] = {
+      32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+      48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+      64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+      80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95,
+  };
 
-    shake256incctx state;
-    shake256_absorb(&state, seed, sizeof(seed));
+  shake256incctx state;
+  shake256_absorb(&state, seed, sizeof(seed));
 
-    for (unsigned int i = 0; i < NTESTS; i++)
-    {
+  for (unsigned int i = 0; i < NTESTS; i++) {
+    shake256_inc_squeeze(coins, sizeof(coins), &state);
 
-        shake256_inc_squeeze(coins, sizeof(coins), &state);
+    crypto_kem_keypair_derand(pk, sk, coins);
+    print_hex("pk", pk, sizeof(pk));
+    print_hex("sk", sk, sizeof(sk));
 
-        crypto_kem_keypair_derand(pk, sk, coins);
-        print_hex("pk", pk, sizeof(pk));
-        print_hex("sk", sk, sizeof(sk));
+    crypto_kem_enc_derand(ct, ss1, pk, coins + 2 * KYBER_SYMBYTES);
+    print_hex("ct", ct, sizeof(ct));
 
-        crypto_kem_enc_derand(ct, ss1, pk, coins + 2 * KYBER_SYMBYTES);
-        print_hex("ct", ct, sizeof(ct));
+    crypto_kem_dec(ss2, ct, sk);
 
-        crypto_kem_dec(ss2, ct, sk);
-
-        if (memcmp(ss1, ss2, sizeof(ss1)))
-        {
-            fprintf(stderr, "ERROR\n");
-            return -1;
-        }
-
-        print_hex("ss", ss1, sizeof(ss1));
+    if (memcmp(ss1, ss2, sizeof(ss1))) {
+      fprintf(stderr, "ERROR\n");
+      return -1;
     }
 
-    return 0;
+    print_hex("ss", ss1, sizeof(ss1));
+  }
+
+  return 0;
 }

--- a/test/gen_NISTKAT.c
+++ b/test/gen_NISTKAT.c
@@ -6,96 +6,85 @@
 #include "kem.h"
 #include "randombytes.h"
 
-static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L)
-{
-    size_t i;
-    fprintf(fp, "%s", S);
-    for (i = 0; i < L; i++)
-    {
-        fprintf(fp, "%02X", A[i]);
-    }
-    if (L == 0)
-    {
-        fprintf(fp, "00");
-    }
-    fprintf(fp, "\n");
+static void fprintBstr(FILE *fp, const char *S, const uint8_t *A, size_t L) {
+  size_t i;
+  fprintf(fp, "%s", S);
+  for (i = 0; i < L; i++) {
+    fprintf(fp, "%02X", A[i]);
+  }
+  if (L == 0) {
+    fprintf(fp, "00");
+  }
+  fprintf(fp, "\n");
 }
 
-static void randombytes_nth(uint8_t *seed, size_t nth, size_t len)
-{
-    uint8_t entropy_input[48] = {0, 1, 2, 3, 4, 5, 6, 7,
-                                 8, 9, 10, 11, 12, 13, 14, 15,
-                                 16, 17, 18, 19, 20, 21, 22, 23,
-                                 24, 25, 26, 27, 28, 29, 30, 31,
-                                 32, 33, 34, 35, 36, 37, 38, 39,
-                                 40, 41, 42, 43, 44, 45, 46, 47
-                                };
-    nist_kat_init(entropy_input, NULL, 256);
+static void randombytes_nth(uint8_t *seed, size_t nth, size_t len) {
+  uint8_t entropy_input[48] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                               12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                               24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+                               36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47};
+  nist_kat_init(entropy_input, NULL, 256);
 
-    for (size_t i = 0; i < nth + 1; i++)
-    {
-        randombytes(seed, len);
-    }
+  for (size_t i = 0; i < nth + 1; i++) {
+    randombytes(seed, len);
+  }
 }
 
-int main(void)
-{
-    uint8_t seed[48] ALIGN(16);
-    FILE *fh = stdout;
-    uint8_t public_key[CRYPTO_PUBLICKEYBYTES] ALIGN(16);
-    uint8_t secret_key[CRYPTO_SECRETKEYBYTES] ALIGN(16);
-    uint8_t ciphertext[CRYPTO_CIPHERTEXTBYTES] ALIGN(16);
-    uint8_t shared_secret_e[CRYPTO_BYTES] ALIGN(16);
-    uint8_t shared_secret_d[CRYPTO_BYTES] ALIGN(16);
-    int rc;
+int main(void) {
+  uint8_t seed[48] ALIGN(16);
+  FILE *fh = stdout;
+  uint8_t public_key[CRYPTO_PUBLICKEYBYTES] ALIGN(16);
+  uint8_t secret_key[CRYPTO_SECRETKEYBYTES] ALIGN(16);
+  uint8_t ciphertext[CRYPTO_CIPHERTEXTBYTES] ALIGN(16);
+  uint8_t shared_secret_e[CRYPTO_BYTES] ALIGN(16);
+  uint8_t shared_secret_d[CRYPTO_BYTES] ALIGN(16);
+  int rc;
 
-    int count = 0;
+  int count = 0;
 
-    fprintf(fh, "# %s\n\n", CRYPTO_ALGNAME);
+  fprintf(fh, "# %s\n\n", CRYPTO_ALGNAME);
 
-    do
-    {
-        fprintf(fh, "count = %d\n", count);
-        randombytes_nth(seed, count, 48);
-        fprintBstr(fh, "seed = ", seed, 48);
+  do {
+    fprintf(fh, "count = %d\n", count);
+    randombytes_nth(seed, count, 48);
+    fprintBstr(fh, "seed = ", seed, 48);
 
-        nist_kat_init(seed, NULL, 256);
+    nist_kat_init(seed, NULL, 256);
 
-        rc = crypto_kem_keypair(public_key, secret_key);
-        if (rc != 0)
-        {
-            fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_keypair failed!\n", CRYPTO_ALGNAME);
-            return -1;
-        }
-        fprintBstr(fh, "pk = ", public_key, CRYPTO_PUBLICKEYBYTES);
-        fprintBstr(fh, "sk = ", secret_key, CRYPTO_SECRETKEYBYTES);
-
-        rc = crypto_kem_enc(ciphertext, shared_secret_e, public_key);
-        if (rc != 0)
-        {
-            fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_enc failed!\n", CRYPTO_ALGNAME);
-            return -2;
-        }
-        fprintBstr(fh, "ct = ", ciphertext, CRYPTO_CIPHERTEXTBYTES);
-        fprintBstr(fh, "ss = ", shared_secret_e, CRYPTO_BYTES);
-        fprintf(fh, "\n");
-
-        rc = crypto_kem_dec(shared_secret_d, ciphertext, secret_key);
-        if (rc != 0)
-        {
-            fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_dec failed!\n", CRYPTO_ALGNAME);
-            return -3;
-        }
-
-        rc = memcmp(shared_secret_e, shared_secret_d, CRYPTO_BYTES);
-        if (rc != 0)
-        {
-            fprintf(stderr, "[kat_kem] %s ERROR: shared secrets are not equal\n", CRYPTO_ALGNAME);
-            return -4;
-        }
-        count++;
+    rc = crypto_kem_keypair(public_key, secret_key);
+    if (rc != 0) {
+      fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_keypair failed!\n",
+              CRYPTO_ALGNAME);
+      return -1;
     }
-    while (count < 100);
+    fprintBstr(fh, "pk = ", public_key, CRYPTO_PUBLICKEYBYTES);
+    fprintBstr(fh, "sk = ", secret_key, CRYPTO_SECRETKEYBYTES);
 
-    return 0;
+    rc = crypto_kem_enc(ciphertext, shared_secret_e, public_key);
+    if (rc != 0) {
+      fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_enc failed!\n",
+              CRYPTO_ALGNAME);
+      return -2;
+    }
+    fprintBstr(fh, "ct = ", ciphertext, CRYPTO_CIPHERTEXTBYTES);
+    fprintBstr(fh, "ss = ", shared_secret_e, CRYPTO_BYTES);
+    fprintf(fh, "\n");
+
+    rc = crypto_kem_dec(shared_secret_d, ciphertext, secret_key);
+    if (rc != 0) {
+      fprintf(stderr, "[kat_kem] %s ERROR: crypto_kem_dec failed!\n",
+              CRYPTO_ALGNAME);
+      return -3;
+    }
+
+    rc = memcmp(shared_secret_e, shared_secret_d, CRYPTO_BYTES);
+    if (rc != 0) {
+      fprintf(stderr, "[kat_kem] %s ERROR: shared secrets are not equal\n",
+              CRYPTO_ALGNAME);
+      return -4;
+    }
+    count++;
+  } while (count < 100);
+
+  return 0;
 }

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -10,8 +10,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -25,120 +25,108 @@
 #include "hal.h"
 
 #if defined(PMU_CYCLES)
-void enable_cyclecounter(void)
-{
-    uint64_t tmp;
-    __asm __volatile (
-        "mrs    %[tmp], pmcr_el0\n"
-        "orr    %[tmp], %[tmp], #1\n"
-        "msr    pmcr_el0, %[tmp]\n"
-        "mrs    %[tmp], pmcntenset_el0\n"
-        "orr    %[tmp], %[tmp], #1<<31\n"
-        "msr    pmcntenset_el0, %[tmp]\n"
-        : [tmp] "=r" (tmp)
-    );
+void enable_cyclecounter(void) {
+  uint64_t tmp;
+  __asm __volatile(
+      "mrs    %[tmp], pmcr_el0\n"
+      "orr    %[tmp], %[tmp], #1\n"
+      "msr    pmcr_el0, %[tmp]\n"
+      "mrs    %[tmp], pmcntenset_el0\n"
+      "orr    %[tmp], %[tmp], #1<<31\n"
+      "msr    pmcntenset_el0, %[tmp]\n"
+      : [tmp] "=r"(tmp));
 }
 
-void disable_cyclecounter(void)
-{
-    uint64_t tmp;
-    __asm __volatile (
-        "mov   %[tmp], #0x3f\n"
-        "orr   %[tmp], %[tmp], #1<<31\n"
-        "msr    pmcntenclr_el0, %[tmp]\n"
-        : [tmp] "=r" (tmp)
-    );
+void disable_cyclecounter(void) {
+  uint64_t tmp;
+  __asm __volatile(
+      "mov   %[tmp], #0x3f\n"
+      "orr   %[tmp], %[tmp], #1<<31\n"
+      "msr    pmcntenclr_el0, %[tmp]\n"
+      : [tmp] "=r"(tmp));
 }
 
-uint64_t get_cyclecounter(void)
-{
-    uint64_t retval;
-    __asm __volatile (
-        "mrs    %[retval], pmccntr_el0\n"
-        : [retval] "=r" (retval));
-    return retval;
+uint64_t get_cyclecounter(void) {
+  uint64_t retval;
+  __asm __volatile("mrs    %[retval], pmccntr_el0\n" : [retval] "=r"(retval));
+  return retval;
 }
 
 #elif defined(PERF_CYCLES)
 
 #include <asm/unistd.h>
 #include <linux/perf_event.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
 static int perf_fd = 0;
-void enable_cyclecounter(void)
-{
-    struct perf_event_attr pe;
-    memset(&pe, 0, sizeof(struct perf_event_attr));
-    pe.type = PERF_TYPE_HARDWARE;
-    pe.size = sizeof(struct perf_event_attr);
-    pe.config = PERF_COUNT_HW_CPU_CYCLES;
-    pe.disabled = 1;
-    pe.exclude_kernel = 1;
-    pe.exclude_hv = 1;
+void enable_cyclecounter(void) {
+  struct perf_event_attr pe;
+  memset(&pe, 0, sizeof(struct perf_event_attr));
+  pe.type = PERF_TYPE_HARDWARE;
+  pe.size = sizeof(struct perf_event_attr);
+  pe.config = PERF_COUNT_HW_CPU_CYCLES;
+  pe.disabled = 1;
+  pe.exclude_kernel = 1;
+  pe.exclude_hv = 1;
 
-    perf_fd = syscall(__NR_perf_event_open, &pe, 0, -1, -1, 0);
+  perf_fd = syscall(__NR_perf_event_open, &pe, 0, -1, -1, 0);
 
-    ioctl(perf_fd, PERF_EVENT_IOC_RESET, 0);
-    ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
+  ioctl(perf_fd, PERF_EVENT_IOC_RESET, 0);
+  ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
 }
 
-void disable_cyclecounter(void)
-{
-    ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
-    close(perf_fd);
+void disable_cyclecounter(void) {
+  ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
+  close(perf_fd);
 }
 
-uint64_t get_cyclecounter(void)
-{
-    long long cpu_cycles;
-    ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
-    ssize_t read_count = read(perf_fd, &cpu_cycles, sizeof(cpu_cycles));
-    if (read_count < 0)
-    {
-        perror("read");
-        exit(EXIT_FAILURE);
-    }
-    else if (read_count == 0)
-    {
-        /* Should not happen */
-        printf("perf counter empty\n");
-        exit(EXIT_FAILURE);
-    }
-    ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
-    return cpu_cycles;
+uint64_t get_cyclecounter(void) {
+  long long cpu_cycles;
+  ioctl(perf_fd, PERF_EVENT_IOC_DISABLE, 0);
+  ssize_t read_count = read(perf_fd, &cpu_cycles, sizeof(cpu_cycles));
+  if (read_count < 0) {
+    perror("read");
+    exit(EXIT_FAILURE);
+  } else if (read_count == 0) {
+    /* Should not happen */
+    printf("perf counter empty\n");
+    exit(EXIT_FAILURE);
+  }
+  ioctl(perf_fd, PERF_EVENT_IOC_ENABLE, 0);
+  return cpu_cycles;
 }
 #elif defined(M1_CYCLES)
-// based on https://gist.github.com/dougallj/5bafb113492047c865c0c8cfbc930155#file-m1_robsize-c-L390
+// based on
+// https://gist.github.com/dougallj/5bafb113492047c865c0c8cfbc930155#file-m1_robsize-c-L390
 
 #include <dlfcn.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#define KPERF_LIST                               \
-    /*  ret, name, params */                     \
-    F(int, kpc_get_counting, void)               \
-    F(int, kpc_force_all_ctrs_set, int)          \
-    F(int, kpc_set_counting, uint32_t)           \
-    F(int, kpc_set_thread_counting, uint32_t)    \
-    F(int, kpc_set_config, uint32_t, void *)     \
-    F(int, kpc_get_config, uint32_t, void *)     \
-    F(int, kpc_set_period, uint32_t, void *)     \
-    F(int, kpc_get_period, uint32_t, void *)     \
-    F(uint32_t, kpc_get_counter_count, uint32_t) \
-    F(uint32_t, kpc_get_config_count, uint32_t)  \
-    F(int, kperf_sample_get, int *)              \
-    F(int, kpc_get_thread_counters, int, unsigned int, void *)
+#define KPERF_LIST                             \
+  /*  ret, name, params */                     \
+  F(int, kpc_get_counting, void)               \
+  F(int, kpc_force_all_ctrs_set, int)          \
+  F(int, kpc_set_counting, uint32_t)           \
+  F(int, kpc_set_thread_counting, uint32_t)    \
+  F(int, kpc_set_config, uint32_t, void *)     \
+  F(int, kpc_get_config, uint32_t, void *)     \
+  F(int, kpc_set_period, uint32_t, void *)     \
+  F(int, kpc_get_period, uint32_t, void *)     \
+  F(uint32_t, kpc_get_counter_count, uint32_t) \
+  F(uint32_t, kpc_get_config_count, uint32_t)  \
+  F(int, kperf_sample_get, int *)              \
+  F(int, kpc_get_thread_counters, int, unsigned int, void *)
 
-#define F(ret, name, ...)                \
-    typedef ret name##proc(__VA_ARGS__); \
-    static name##proc *name;
+#define F(ret, name, ...)              \
+  typedef ret name##proc(__VA_ARGS__); \
+  static name##proc *name;
 KPERF_LIST
 #undef F
 
@@ -176,100 +164,74 @@ uint64_t g_counters[COUNTERS_COUNT];
 uint64_t g_config[COUNTERS_COUNT];
 
 
-static void configure_rdtsc(void)
-{
-    if (kpc_force_all_ctrs_set(1))
-    {
-        printf("kpc_force_all_ctrs_set failed\n");
-        return;
-    }
+static void configure_rdtsc(void) {
+  if (kpc_force_all_ctrs_set(1)) {
+    printf("kpc_force_all_ctrs_set failed\n");
+    return;
+  }
 
-    if (kpc_set_counting(KPC_MASK))
-    {
-        printf("kpc_set_counting failed\n");
-        return;
-    }
+  if (kpc_set_counting(KPC_MASK)) {
+    printf("kpc_set_counting failed\n");
+    return;
+  }
 
-    if (kpc_set_thread_counting(KPC_MASK))
-    {
-        printf("kpc_set_thread_counting failed\n");
-        return;
-    }
+  if (kpc_set_thread_counting(KPC_MASK)) {
+    printf("kpc_set_thread_counting failed\n");
+    return;
+  }
 
-    if (kpc_set_config(KPC_MASK, g_config))
-    {
-        printf("kpc_set_config failed\n");
-        return;
-    }
+  if (kpc_set_config(KPC_MASK, g_config)) {
+    printf("kpc_set_config failed\n");
+    return;
+  }
 }
 
-static void init_rdtsc(void)
-{
-    void *kperf = dlopen(
-                      "/System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf",
-                      RTLD_LAZY);
-    if (!kperf)
-    {
-        printf("kperf = %p\n", kperf);
-        return;
-    }
-#define F(ret, name, ...)                         \
-    name = (name##proc *)(dlsym(kperf, #name));   \
-    if (!name)                                    \
-    {                                             \
-        printf("%s = %p\n", #name, (void *)name); \
-        return;                                   \
-    }
-    KPERF_LIST
+static void init_rdtsc(void) {
+  void *kperf = dlopen(
+      "/System/Library/PrivateFrameworks/kperf.framework/Versions/A/kperf",
+      RTLD_LAZY);
+  if (!kperf) {
+    printf("kperf = %p\n", kperf);
+    return;
+  }
+#define F(ret, name, ...)                     \
+  name = (name##proc *)(dlsym(kperf, #name)); \
+  if (!name) {                                \
+    printf("%s = %p\n", #name, (void *)name); \
+    return;                                   \
+  }
+  KPERF_LIST
 #undef F
 
-    g_config[0] = CPMU_CORE_CYCLE | CFGWORD_EL0A64EN_MASK;
+  g_config[0] = CPMU_CORE_CYCLE | CFGWORD_EL0A64EN_MASK;
 }
 
-void enable_cyclecounter(void)
-{
-    int test_high_perf_cores = 1;
+void enable_cyclecounter(void) {
+  int test_high_perf_cores = 1;
 
-    if (test_high_perf_cores)
-    {
-        pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
-    }
-    else
-    {
-        pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
-    }
-    init_rdtsc();
-    configure_rdtsc();
+  if (test_high_perf_cores) {
+    pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0);
+  } else {
+    pthread_set_qos_class_self_np(QOS_CLASS_BACKGROUND, 0);
+  }
+  init_rdtsc();
+  configure_rdtsc();
 }
 
-void disable_cyclecounter(void)
-{
-    return;
-}
+void disable_cyclecounter(void) { return; }
 
-uint64_t get_cyclecounter(void)
-{
-    if (kpc_get_thread_counters(0, COUNTERS_COUNT, g_counters))
-    {
-        printf("kpc_get_thread_counters failed\n");
-        return 1;
-    }
-    return g_counters[2];
+uint64_t get_cyclecounter(void) {
+  if (kpc_get_thread_counters(0, COUNTERS_COUNT, g_counters)) {
+    printf("kpc_get_thread_counters failed\n");
+    return 1;
+  }
+  return g_counters[2];
 }
 
 #else
 
-void enable_cyclecounter(void)
-{
-    return;
-}
-void disable_cyclecounter(void)
-{
-    return;
-}
-uint64_t get_cyclecounter(void)
-{
-    return (0);
-}
+void enable_cyclecounter(void) { return; }
+void disable_cyclecounter(void) { return; }
+uint64_t get_cyclecounter(void) { return (0); }
 
 #endif

--- a/test/hal/hal.h
+++ b/test/hal/hal.h
@@ -9,8 +9,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/test/nistrng/aes.c
+++ b/test/nistrng/aes.c
@@ -33,653 +33,611 @@
 
 #include "aes.h"
 
-static inline uint32_t br_dec32le(const unsigned char *src)
-{
-    return (uint32_t)src[0] | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) | ((uint32_t)src[3] << 24);
+static inline uint32_t br_dec32le(const unsigned char *src) {
+  return (uint32_t)src[0] | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) |
+         ((uint32_t)src[3] << 24);
 }
 
-static void br_range_dec32le(uint32_t *v, size_t num, const unsigned char *src)
-{
-    while (num-- > 0)
-    {
-        *v++ = br_dec32le(src);
-        src += 4;
-    }
+static void br_range_dec32le(uint32_t *v, size_t num,
+                             const unsigned char *src) {
+  while (num-- > 0) {
+    *v++ = br_dec32le(src);
+    src += 4;
+  }
 }
 
-static inline uint32_t br_swap32(uint32_t x)
-{
-    x = ((x & (uint32_t)0x00FF00FF) << 8) | ((x >> 8) & (uint32_t)0x00FF00FF);
-    return (x << 16) | (x >> 16);
+static inline uint32_t br_swap32(uint32_t x) {
+  x = ((x & (uint32_t)0x00FF00FF) << 8) | ((x >> 8) & (uint32_t)0x00FF00FF);
+  return (x << 16) | (x >> 16);
 }
 
-static inline void br_enc32le(unsigned char *dst, uint32_t x)
-{
-    dst[0] = (unsigned char)x;
-    dst[1] = (unsigned char)(x >> 8);
-    dst[2] = (unsigned char)(x >> 16);
-    dst[3] = (unsigned char)(x >> 24);
+static inline void br_enc32le(unsigned char *dst, uint32_t x) {
+  dst[0] = (unsigned char)x;
+  dst[1] = (unsigned char)(x >> 8);
+  dst[2] = (unsigned char)(x >> 16);
+  dst[3] = (unsigned char)(x >> 24);
 }
 
-static void br_range_enc32le(unsigned char *dst, const uint32_t *v, size_t num)
-{
-    while (num-- > 0)
-    {
-        br_enc32le(dst, *v++);
-        dst += 4;
-    }
+static void br_range_enc32le(unsigned char *dst, const uint32_t *v,
+                             size_t num) {
+  while (num-- > 0) {
+    br_enc32le(dst, *v++);
+    dst += 4;
+  }
 }
 
-static void br_aes_ct64_bitslice_Sbox(uint64_t *q)
-{
-    /*
-     * This S-box implementation is a straightforward translation of
-     * the circuit described by Boyar and Peralta in "A new
-     * combinational logic minimization technique with applications
-     * to cryptology" (https://eprint.iacr.org/2009/191.pdf).
-     *
-     * Note that variables x* (input) and s* (output) are numbered
-     * in "reverse" order (x0 is the high bit, x7 is the low bit).
-     */
+static void br_aes_ct64_bitslice_Sbox(uint64_t *q) {
+  /*
+   * This S-box implementation is a straightforward translation of
+   * the circuit described by Boyar and Peralta in "A new
+   * combinational logic minimization technique with applications
+   * to cryptology" (https://eprint.iacr.org/2009/191.pdf).
+   *
+   * Note that variables x* (input) and s* (output) are numbered
+   * in "reverse" order (x0 is the high bit, x7 is the low bit).
+   */
 
-    uint64_t x0, x1, x2, x3, x4, x5, x6, x7;
-    uint64_t y1, y2, y3, y4, y5, y6, y7, y8, y9;
-    uint64_t y10, y11, y12, y13, y14, y15, y16, y17, y18, y19;
-    uint64_t y20, y21;
-    uint64_t z0, z1, z2, z3, z4, z5, z6, z7, z8, z9;
-    uint64_t z10, z11, z12, z13, z14, z15, z16, z17;
-    uint64_t t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;
-    uint64_t t10, t11, t12, t13, t14, t15, t16, t17, t18, t19;
-    uint64_t t20, t21, t22, t23, t24, t25, t26, t27, t28, t29;
-    uint64_t t30, t31, t32, t33, t34, t35, t36, t37, t38, t39;
-    uint64_t t40, t41, t42, t43, t44, t45, t46, t47, t48, t49;
-    uint64_t t50, t51, t52, t53, t54, t55, t56, t57, t58, t59;
-    uint64_t t60, t61, t62, t63, t64, t65, t66, t67;
-    uint64_t s0, s1, s2, s3, s4, s5, s6, s7;
+  uint64_t x0, x1, x2, x3, x4, x5, x6, x7;
+  uint64_t y1, y2, y3, y4, y5, y6, y7, y8, y9;
+  uint64_t y10, y11, y12, y13, y14, y15, y16, y17, y18, y19;
+  uint64_t y20, y21;
+  uint64_t z0, z1, z2, z3, z4, z5, z6, z7, z8, z9;
+  uint64_t z10, z11, z12, z13, z14, z15, z16, z17;
+  uint64_t t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;
+  uint64_t t10, t11, t12, t13, t14, t15, t16, t17, t18, t19;
+  uint64_t t20, t21, t22, t23, t24, t25, t26, t27, t28, t29;
+  uint64_t t30, t31, t32, t33, t34, t35, t36, t37, t38, t39;
+  uint64_t t40, t41, t42, t43, t44, t45, t46, t47, t48, t49;
+  uint64_t t50, t51, t52, t53, t54, t55, t56, t57, t58, t59;
+  uint64_t t60, t61, t62, t63, t64, t65, t66, t67;
+  uint64_t s0, s1, s2, s3, s4, s5, s6, s7;
 
-    x0 = q[7];
-    x1 = q[6];
-    x2 = q[5];
-    x3 = q[4];
-    x4 = q[3];
-    x5 = q[2];
-    x6 = q[1];
-    x7 = q[0];
+  x0 = q[7];
+  x1 = q[6];
+  x2 = q[5];
+  x3 = q[4];
+  x4 = q[3];
+  x5 = q[2];
+  x6 = q[1];
+  x7 = q[0];
 
-    /*
-     * Top linear transformation.
-     */
-    y14 = x3 ^ x5;
-    y13 = x0 ^ x6;
-    y9 = x0 ^ x3;
-    y8 = x0 ^ x5;
-    t0 = x1 ^ x2;
-    y1 = t0 ^ x7;
-    y4 = y1 ^ x3;
-    y12 = y13 ^ y14;
-    y2 = y1 ^ x0;
-    y5 = y1 ^ x6;
-    y3 = y5 ^ y8;
-    t1 = x4 ^ y12;
-    y15 = t1 ^ x5;
-    y20 = t1 ^ x1;
-    y6 = y15 ^ x7;
-    y10 = y15 ^ t0;
-    y11 = y20 ^ y9;
-    y7 = x7 ^ y11;
-    y17 = y10 ^ y11;
-    y19 = y10 ^ y8;
-    y16 = t0 ^ y11;
-    y21 = y13 ^ y16;
-    y18 = x0 ^ y16;
+  /*
+   * Top linear transformation.
+   */
+  y14 = x3 ^ x5;
+  y13 = x0 ^ x6;
+  y9 = x0 ^ x3;
+  y8 = x0 ^ x5;
+  t0 = x1 ^ x2;
+  y1 = t0 ^ x7;
+  y4 = y1 ^ x3;
+  y12 = y13 ^ y14;
+  y2 = y1 ^ x0;
+  y5 = y1 ^ x6;
+  y3 = y5 ^ y8;
+  t1 = x4 ^ y12;
+  y15 = t1 ^ x5;
+  y20 = t1 ^ x1;
+  y6 = y15 ^ x7;
+  y10 = y15 ^ t0;
+  y11 = y20 ^ y9;
+  y7 = x7 ^ y11;
+  y17 = y10 ^ y11;
+  y19 = y10 ^ y8;
+  y16 = t0 ^ y11;
+  y21 = y13 ^ y16;
+  y18 = x0 ^ y16;
 
-    /*
-     * Non-linear section.
-     */
-    t2 = y12 & y15;
-    t3 = y3 & y6;
-    t4 = t3 ^ t2;
-    t5 = y4 & x7;
-    t6 = t5 ^ t2;
-    t7 = y13 & y16;
-    t8 = y5 & y1;
-    t9 = t8 ^ t7;
-    t10 = y2 & y7;
-    t11 = t10 ^ t7;
-    t12 = y9 & y11;
-    t13 = y14 & y17;
-    t14 = t13 ^ t12;
-    t15 = y8 & y10;
-    t16 = t15 ^ t12;
-    t17 = t4 ^ t14;
-    t18 = t6 ^ t16;
-    t19 = t9 ^ t14;
-    t20 = t11 ^ t16;
-    t21 = t17 ^ y20;
-    t22 = t18 ^ y19;
-    t23 = t19 ^ y21;
-    t24 = t20 ^ y18;
+  /*
+   * Non-linear section.
+   */
+  t2 = y12 & y15;
+  t3 = y3 & y6;
+  t4 = t3 ^ t2;
+  t5 = y4 & x7;
+  t6 = t5 ^ t2;
+  t7 = y13 & y16;
+  t8 = y5 & y1;
+  t9 = t8 ^ t7;
+  t10 = y2 & y7;
+  t11 = t10 ^ t7;
+  t12 = y9 & y11;
+  t13 = y14 & y17;
+  t14 = t13 ^ t12;
+  t15 = y8 & y10;
+  t16 = t15 ^ t12;
+  t17 = t4 ^ t14;
+  t18 = t6 ^ t16;
+  t19 = t9 ^ t14;
+  t20 = t11 ^ t16;
+  t21 = t17 ^ y20;
+  t22 = t18 ^ y19;
+  t23 = t19 ^ y21;
+  t24 = t20 ^ y18;
 
-    t25 = t21 ^ t22;
-    t26 = t21 & t23;
-    t27 = t24 ^ t26;
-    t28 = t25 & t27;
-    t29 = t28 ^ t22;
-    t30 = t23 ^ t24;
-    t31 = t22 ^ t26;
-    t32 = t31 & t30;
-    t33 = t32 ^ t24;
-    t34 = t23 ^ t33;
-    t35 = t27 ^ t33;
-    t36 = t24 & t35;
-    t37 = t36 ^ t34;
-    t38 = t27 ^ t36;
-    t39 = t29 & t38;
-    t40 = t25 ^ t39;
+  t25 = t21 ^ t22;
+  t26 = t21 & t23;
+  t27 = t24 ^ t26;
+  t28 = t25 & t27;
+  t29 = t28 ^ t22;
+  t30 = t23 ^ t24;
+  t31 = t22 ^ t26;
+  t32 = t31 & t30;
+  t33 = t32 ^ t24;
+  t34 = t23 ^ t33;
+  t35 = t27 ^ t33;
+  t36 = t24 & t35;
+  t37 = t36 ^ t34;
+  t38 = t27 ^ t36;
+  t39 = t29 & t38;
+  t40 = t25 ^ t39;
 
-    t41 = t40 ^ t37;
-    t42 = t29 ^ t33;
-    t43 = t29 ^ t40;
-    t44 = t33 ^ t37;
-    t45 = t42 ^ t41;
-    z0 = t44 & y15;
-    z1 = t37 & y6;
-    z2 = t33 & x7;
-    z3 = t43 & y16;
-    z4 = t40 & y1;
-    z5 = t29 & y7;
-    z6 = t42 & y11;
-    z7 = t45 & y17;
-    z8 = t41 & y10;
-    z9 = t44 & y12;
-    z10 = t37 & y3;
-    z11 = t33 & y4;
-    z12 = t43 & y13;
-    z13 = t40 & y5;
-    z14 = t29 & y2;
-    z15 = t42 & y9;
-    z16 = t45 & y14;
-    z17 = t41 & y8;
+  t41 = t40 ^ t37;
+  t42 = t29 ^ t33;
+  t43 = t29 ^ t40;
+  t44 = t33 ^ t37;
+  t45 = t42 ^ t41;
+  z0 = t44 & y15;
+  z1 = t37 & y6;
+  z2 = t33 & x7;
+  z3 = t43 & y16;
+  z4 = t40 & y1;
+  z5 = t29 & y7;
+  z6 = t42 & y11;
+  z7 = t45 & y17;
+  z8 = t41 & y10;
+  z9 = t44 & y12;
+  z10 = t37 & y3;
+  z11 = t33 & y4;
+  z12 = t43 & y13;
+  z13 = t40 & y5;
+  z14 = t29 & y2;
+  z15 = t42 & y9;
+  z16 = t45 & y14;
+  z17 = t41 & y8;
 
-    /*
-     * Bottom linear transformation.
-     */
-    t46 = z15 ^ z16;
-    t47 = z10 ^ z11;
-    t48 = z5 ^ z13;
-    t49 = z9 ^ z10;
-    t50 = z2 ^ z12;
-    t51 = z2 ^ z5;
-    t52 = z7 ^ z8;
-    t53 = z0 ^ z3;
-    t54 = z6 ^ z7;
-    t55 = z16 ^ z17;
-    t56 = z12 ^ t48;
-    t57 = t50 ^ t53;
-    t58 = z4 ^ t46;
-    t59 = z3 ^ t54;
-    t60 = t46 ^ t57;
-    t61 = z14 ^ t57;
-    t62 = t52 ^ t58;
-    t63 = t49 ^ t58;
-    t64 = z4 ^ t59;
-    t65 = t61 ^ t62;
-    t66 = z1 ^ t63;
-    s0 = t59 ^ t63;
-    s6 = t56 ^ ~t62;
-    s7 = t48 ^ ~t60;
-    t67 = t64 ^ t65;
-    s3 = t53 ^ t66;
-    s4 = t51 ^ t66;
-    s5 = t47 ^ t65;
-    s1 = t64 ^ ~s3;
-    s2 = t55 ^ ~t67;
+  /*
+   * Bottom linear transformation.
+   */
+  t46 = z15 ^ z16;
+  t47 = z10 ^ z11;
+  t48 = z5 ^ z13;
+  t49 = z9 ^ z10;
+  t50 = z2 ^ z12;
+  t51 = z2 ^ z5;
+  t52 = z7 ^ z8;
+  t53 = z0 ^ z3;
+  t54 = z6 ^ z7;
+  t55 = z16 ^ z17;
+  t56 = z12 ^ t48;
+  t57 = t50 ^ t53;
+  t58 = z4 ^ t46;
+  t59 = z3 ^ t54;
+  t60 = t46 ^ t57;
+  t61 = z14 ^ t57;
+  t62 = t52 ^ t58;
+  t63 = t49 ^ t58;
+  t64 = z4 ^ t59;
+  t65 = t61 ^ t62;
+  t66 = z1 ^ t63;
+  s0 = t59 ^ t63;
+  s6 = t56 ^ ~t62;
+  s7 = t48 ^ ~t60;
+  t67 = t64 ^ t65;
+  s3 = t53 ^ t66;
+  s4 = t51 ^ t66;
+  s5 = t47 ^ t65;
+  s1 = t64 ^ ~s3;
+  s2 = t55 ^ ~t67;
 
-    q[7] = s0;
-    q[6] = s1;
-    q[5] = s2;
-    q[4] = s3;
-    q[3] = s4;
-    q[2] = s5;
-    q[1] = s6;
-    q[0] = s7;
+  q[7] = s0;
+  q[6] = s1;
+  q[5] = s2;
+  q[4] = s3;
+  q[3] = s4;
+  q[2] = s5;
+  q[1] = s6;
+  q[0] = s7;
 }
 
-static void br_aes_ct64_ortho(uint64_t *q)
-{
-#define SWAPN(cl, ch, s, x, y)                                      \
-    do                                                              \
-    {                                                               \
-        uint64_t a, b;                                              \
-        a = (x);                                                    \
-        b = (y);                                                    \
-        (x) = (a & (uint64_t)(cl)) | ((b & (uint64_t)(cl)) << (s)); \
-        (y) = ((a & (uint64_t)(ch)) >> (s)) | (b & (uint64_t)(ch)); \
-    } while (0)
+static void br_aes_ct64_ortho(uint64_t *q) {
+#define SWAPN(cl, ch, s, x, y)                                  \
+  do {                                                          \
+    uint64_t a, b;                                              \
+    a = (x);                                                    \
+    b = (y);                                                    \
+    (x) = (a & (uint64_t)(cl)) | ((b & (uint64_t)(cl)) << (s)); \
+    (y) = ((a & (uint64_t)(ch)) >> (s)) | (b & (uint64_t)(ch)); \
+  } while (0)
 
 #define SWAP2(x, y) SWAPN(0x5555555555555555, 0xAAAAAAAAAAAAAAAA, 1, x, y)
 #define SWAP4(x, y) SWAPN(0x3333333333333333, 0xCCCCCCCCCCCCCCCC, 2, x, y)
 #define SWAP8(x, y) SWAPN(0x0F0F0F0F0F0F0F0F, 0xF0F0F0F0F0F0F0F0, 4, x, y)
 
-    SWAP2(q[0], q[1]);
-    SWAP2(q[2], q[3]);
-    SWAP2(q[4], q[5]);
-    SWAP2(q[6], q[7]);
+  SWAP2(q[0], q[1]);
+  SWAP2(q[2], q[3]);
+  SWAP2(q[4], q[5]);
+  SWAP2(q[6], q[7]);
 
-    SWAP4(q[0], q[2]);
-    SWAP4(q[1], q[3]);
-    SWAP4(q[4], q[6]);
-    SWAP4(q[5], q[7]);
+  SWAP4(q[0], q[2]);
+  SWAP4(q[1], q[3]);
+  SWAP4(q[4], q[6]);
+  SWAP4(q[5], q[7]);
 
-    SWAP8(q[0], q[4]);
-    SWAP8(q[1], q[5]);
-    SWAP8(q[2], q[6]);
-    SWAP8(q[3], q[7]);
+  SWAP8(q[0], q[4]);
+  SWAP8(q[1], q[5]);
+  SWAP8(q[2], q[6]);
+  SWAP8(q[3], q[7]);
 }
 
-static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1, const uint32_t *w)
-{
-    uint64_t x0, x1, x2, x3;
+static void br_aes_ct64_interleave_in(uint64_t *q0, uint64_t *q1,
+                                      const uint32_t *w) {
+  uint64_t x0, x1, x2, x3;
 
-    x0 = w[0];
-    x1 = w[1];
-    x2 = w[2];
-    x3 = w[3];
-    x0 |= (x0 << 16);
-    x1 |= (x1 << 16);
-    x2 |= (x2 << 16);
-    x3 |= (x3 << 16);
-    x0 &= (uint64_t)0x0000FFFF0000FFFF;
-    x1 &= (uint64_t)0x0000FFFF0000FFFF;
-    x2 &= (uint64_t)0x0000FFFF0000FFFF;
-    x3 &= (uint64_t)0x0000FFFF0000FFFF;
-    x0 |= (x0 << 8);
-    x1 |= (x1 << 8);
-    x2 |= (x2 << 8);
-    x3 |= (x3 << 8);
-    x0 &= (uint64_t)0x00FF00FF00FF00FF;
-    x1 &= (uint64_t)0x00FF00FF00FF00FF;
-    x2 &= (uint64_t)0x00FF00FF00FF00FF;
-    x3 &= (uint64_t)0x00FF00FF00FF00FF;
-    *q0 = x0 | (x2 << 8);
-    *q1 = x1 | (x3 << 8);
+  x0 = w[0];
+  x1 = w[1];
+  x2 = w[2];
+  x3 = w[3];
+  x0 |= (x0 << 16);
+  x1 |= (x1 << 16);
+  x2 |= (x2 << 16);
+  x3 |= (x3 << 16);
+  x0 &= (uint64_t)0x0000FFFF0000FFFF;
+  x1 &= (uint64_t)0x0000FFFF0000FFFF;
+  x2 &= (uint64_t)0x0000FFFF0000FFFF;
+  x3 &= (uint64_t)0x0000FFFF0000FFFF;
+  x0 |= (x0 << 8);
+  x1 |= (x1 << 8);
+  x2 |= (x2 << 8);
+  x3 |= (x3 << 8);
+  x0 &= (uint64_t)0x00FF00FF00FF00FF;
+  x1 &= (uint64_t)0x00FF00FF00FF00FF;
+  x2 &= (uint64_t)0x00FF00FF00FF00FF;
+  x3 &= (uint64_t)0x00FF00FF00FF00FF;
+  *q0 = x0 | (x2 << 8);
+  *q1 = x1 | (x3 << 8);
 }
 
-static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1)
-{
-    uint64_t x0, x1, x2, x3;
+static void br_aes_ct64_interleave_out(uint32_t *w, uint64_t q0, uint64_t q1) {
+  uint64_t x0, x1, x2, x3;
 
-    x0 = q0 & (uint64_t)0x00FF00FF00FF00FF;
-    x1 = q1 & (uint64_t)0x00FF00FF00FF00FF;
-    x2 = (q0 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
-    x3 = (q1 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
-    x0 |= (x0 >> 8);
-    x1 |= (x1 >> 8);
-    x2 |= (x2 >> 8);
-    x3 |= (x3 >> 8);
-    x0 &= (uint64_t)0x0000FFFF0000FFFF;
-    x1 &= (uint64_t)0x0000FFFF0000FFFF;
-    x2 &= (uint64_t)0x0000FFFF0000FFFF;
-    x3 &= (uint64_t)0x0000FFFF0000FFFF;
-    w[0] = (uint32_t)x0 | (uint32_t)(x0 >> 16);
-    w[1] = (uint32_t)x1 | (uint32_t)(x1 >> 16);
-    w[2] = (uint32_t)x2 | (uint32_t)(x2 >> 16);
-    w[3] = (uint32_t)x3 | (uint32_t)(x3 >> 16);
+  x0 = q0 & (uint64_t)0x00FF00FF00FF00FF;
+  x1 = q1 & (uint64_t)0x00FF00FF00FF00FF;
+  x2 = (q0 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
+  x3 = (q1 >> 8) & (uint64_t)0x00FF00FF00FF00FF;
+  x0 |= (x0 >> 8);
+  x1 |= (x1 >> 8);
+  x2 |= (x2 >> 8);
+  x3 |= (x3 >> 8);
+  x0 &= (uint64_t)0x0000FFFF0000FFFF;
+  x1 &= (uint64_t)0x0000FFFF0000FFFF;
+  x2 &= (uint64_t)0x0000FFFF0000FFFF;
+  x3 &= (uint64_t)0x0000FFFF0000FFFF;
+  w[0] = (uint32_t)x0 | (uint32_t)(x0 >> 16);
+  w[1] = (uint32_t)x1 | (uint32_t)(x1 >> 16);
+  w[2] = (uint32_t)x2 | (uint32_t)(x2 >> 16);
+  w[3] = (uint32_t)x3 | (uint32_t)(x3 >> 16);
 }
 
-static const unsigned char Rcon[] =
-{
-    0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1B, 0x36
-};
+static const unsigned char Rcon[] = {0x01, 0x02, 0x04, 0x08, 0x10,
+                                     0x20, 0x40, 0x80, 0x1B, 0x36};
 
-static uint32_t sub_word(uint32_t x)
-{
+static uint32_t sub_word(uint32_t x) {
+  uint64_t q[8];
+
+  memset(q, 0, sizeof q);
+  q[0] = x;
+  br_aes_ct64_ortho(q);
+  br_aes_ct64_bitslice_Sbox(q);
+  br_aes_ct64_ortho(q);
+  return (uint32_t)q[0];
+}
+
+static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key,
+                                 unsigned int key_len) {
+  unsigned int i, j, k, nk, nkf;
+  uint32_t tmp;
+  uint32_t skey[60];
+  unsigned nrounds = 10 + ((key_len - 16) >> 2);
+
+  nk = (key_len >> 2);
+  nkf = ((nrounds + 1) << 2);
+  br_range_dec32le(skey, (key_len >> 2), key);
+  tmp = skey[(key_len >> 2) - 1];
+  for (i = nk, j = 0, k = 0; i < nkf; i++) {
+    if (j == 0) {
+      tmp = (tmp << 24) | (tmp >> 8);
+      tmp = sub_word(tmp) ^ Rcon[k];
+    } else if (nk > 6 && j == 4) {
+      tmp = sub_word(tmp);
+    }
+    tmp ^= skey[i - nk];
+    skey[i] = tmp;
+    if (++j == nk) {
+      j = 0;
+      k++;
+    }
+  }
+
+  for (i = 0, j = 0; i < nkf; i += 4, j += 2) {
     uint64_t q[8];
 
-    memset(q, 0, sizeof q);
-    q[0] = x;
+    br_aes_ct64_interleave_in(&q[0], &q[4], skey + i);
+    q[1] = q[0];
+    q[2] = q[0];
+    q[3] = q[0];
+    q[5] = q[4];
+    q[6] = q[4];
+    q[7] = q[4];
     br_aes_ct64_ortho(q);
-    br_aes_ct64_bitslice_Sbox(q);
-    br_aes_ct64_ortho(q);
-    return (uint32_t)q[0];
+    comp_skey[j + 0] = (q[0] & (uint64_t)0x1111111111111111) |
+                       (q[1] & (uint64_t)0x2222222222222222) |
+                       (q[2] & (uint64_t)0x4444444444444444) |
+                       (q[3] & (uint64_t)0x8888888888888888);
+    comp_skey[j + 1] = (q[4] & (uint64_t)0x1111111111111111) |
+                       (q[5] & (uint64_t)0x2222222222222222) |
+                       (q[6] & (uint64_t)0x4444444444444444) |
+                       (q[7] & (uint64_t)0x8888888888888888);
+  }
 }
 
-static void br_aes_ct64_keysched(uint64_t *comp_skey, const unsigned char *key, unsigned int key_len)
-{
-    unsigned int i, j, k, nk, nkf;
-    uint32_t tmp;
-    uint32_t skey[60];
-    unsigned nrounds = 10 + ((key_len - 16) >> 2);
+static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey,
+                                    unsigned int nrounds) {
+  unsigned u, v, n;
 
-    nk = (key_len >> 2);
-    nkf = ((nrounds + 1) << 2);
-    br_range_dec32le(skey, (key_len >> 2), key);
-    tmp = skey[(key_len >> 2) - 1];
-    for (i = nk, j = 0, k = 0; i < nkf; i++)
-    {
-        if (j == 0)
-        {
-            tmp = (tmp << 24) | (tmp >> 8);
-            tmp = sub_word(tmp) ^ Rcon[k];
-        }
-        else if (nk > 6 && j == 4)
-        {
-            tmp = sub_word(tmp);
-        }
-        tmp ^= skey[i - nk];
-        skey[i] = tmp;
-        if (++j == nk)
-        {
-            j = 0;
-            k++;
-        }
-    }
+  n = (nrounds + 1) << 1;
+  for (u = 0, v = 0; u < n; u++, v += 4) {
+    uint64_t x0, x1, x2, x3;
 
-    for (i = 0, j = 0; i < nkf; i += 4, j += 2)
-    {
-        uint64_t q[8];
-
-        br_aes_ct64_interleave_in(&q[0], &q[4], skey + i);
-        q[1] = q[0];
-        q[2] = q[0];
-        q[3] = q[0];
-        q[5] = q[4];
-        q[6] = q[4];
-        q[7] = q[4];
-        br_aes_ct64_ortho(q);
-        comp_skey[j + 0] =
-            (q[0] & (uint64_t)0x1111111111111111) | (q[1] & (uint64_t)0x2222222222222222) | (q[2] & (uint64_t)0x4444444444444444) | (q[3] & (uint64_t)0x8888888888888888);
-        comp_skey[j + 1] =
-            (q[4] & (uint64_t)0x1111111111111111) | (q[5] & (uint64_t)0x2222222222222222) | (q[6] & (uint64_t)0x4444444444444444) | (q[7] & (uint64_t)0x8888888888888888);
-    }
+    x0 = x1 = x2 = x3 = comp_skey[u];
+    x0 &= (uint64_t)0x1111111111111111;
+    x1 &= (uint64_t)0x2222222222222222;
+    x2 &= (uint64_t)0x4444444444444444;
+    x3 &= (uint64_t)0x8888888888888888;
+    x1 >>= 1;
+    x2 >>= 2;
+    x3 >>= 3;
+    skey[v + 0] = (x0 << 4) - x0;
+    skey[v + 1] = (x1 << 4) - x1;
+    skey[v + 2] = (x2 << 4) - x2;
+    skey[v + 3] = (x3 << 4) - x3;
+  }
 }
 
-static void br_aes_ct64_skey_expand(uint64_t *skey, const uint64_t *comp_skey, unsigned int nrounds)
-{
-    unsigned u, v, n;
-
-    n = (nrounds + 1) << 1;
-    for (u = 0, v = 0; u < n; u++, v += 4)
-    {
-        uint64_t x0, x1, x2, x3;
-
-        x0 = x1 = x2 = x3 = comp_skey[u];
-        x0 &= (uint64_t)0x1111111111111111;
-        x1 &= (uint64_t)0x2222222222222222;
-        x2 &= (uint64_t)0x4444444444444444;
-        x3 &= (uint64_t)0x8888888888888888;
-        x1 >>= 1;
-        x2 >>= 2;
-        x3 >>= 3;
-        skey[v + 0] = (x0 << 4) - x0;
-        skey[v + 1] = (x1 << 4) - x1;
-        skey[v + 2] = (x2 << 4) - x2;
-        skey[v + 3] = (x3 << 4) - x3;
-    }
+static inline void add_round_key(uint64_t *q, const uint64_t *sk) {
+  q[0] ^= sk[0];
+  q[1] ^= sk[1];
+  q[2] ^= sk[2];
+  q[3] ^= sk[3];
+  q[4] ^= sk[4];
+  q[5] ^= sk[5];
+  q[6] ^= sk[6];
+  q[7] ^= sk[7];
 }
 
-static inline void add_round_key(uint64_t *q, const uint64_t *sk)
-{
-    q[0] ^= sk[0];
-    q[1] ^= sk[1];
-    q[2] ^= sk[2];
-    q[3] ^= sk[3];
-    q[4] ^= sk[4];
-    q[5] ^= sk[5];
-    q[6] ^= sk[6];
-    q[7] ^= sk[7];
+static inline void shift_rows(uint64_t *q) {
+  int i;
+
+  for (i = 0; i < 8; i++) {
+    uint64_t x;
+
+    x = q[i];
+    q[i] = (x & (uint64_t)0x000000000000FFFF) |
+           ((x & (uint64_t)0x00000000FFF00000) >> 4) |
+           ((x & (uint64_t)0x00000000000F0000) << 12) |
+           ((x & (uint64_t)0x0000FF0000000000) >> 8) |
+           ((x & (uint64_t)0x000000FF00000000) << 8) |
+           ((x & (uint64_t)0xF000000000000000) >> 12) |
+           ((x & (uint64_t)0x0FFF000000000000) << 4);
+  }
 }
 
-static inline void shift_rows(uint64_t *q)
-{
-    int i;
+static inline uint64_t rotr32(uint64_t x) { return (x << 32) | (x >> 32); }
 
-    for (i = 0; i < 8; i++)
-    {
-        uint64_t x;
+static inline void mix_columns(uint64_t *q) {
+  uint64_t q0, q1, q2, q3, q4, q5, q6, q7;
+  uint64_t r0, r1, r2, r3, r4, r5, r6, r7;
 
-        x = q[i];
-        q[i] = (x & (uint64_t)0x000000000000FFFF) | ((x & (uint64_t)0x00000000FFF00000) >> 4) | ((x & (uint64_t)0x00000000000F0000) << 12) | ((x & (uint64_t)0x0000FF0000000000) >> 8) | ((x & (uint64_t)0x000000FF00000000) << 8) | ((x & (uint64_t)0xF000000000000000) >> 12) | ((x & (uint64_t)0x0FFF000000000000) << 4);
-    }
+  q0 = q[0];
+  q1 = q[1];
+  q2 = q[2];
+  q3 = q[3];
+  q4 = q[4];
+  q5 = q[5];
+  q6 = q[6];
+  q7 = q[7];
+  r0 = (q0 >> 16) | (q0 << 48);
+  r1 = (q1 >> 16) | (q1 << 48);
+  r2 = (q2 >> 16) | (q2 << 48);
+  r3 = (q3 >> 16) | (q3 << 48);
+  r4 = (q4 >> 16) | (q4 << 48);
+  r5 = (q5 >> 16) | (q5 << 48);
+  r6 = (q6 >> 16) | (q6 << 48);
+  r7 = (q7 >> 16) | (q7 << 48);
+
+  q[0] = q7 ^ r7 ^ r0 ^ rotr32(q0 ^ r0);
+  q[1] = q0 ^ r0 ^ q7 ^ r7 ^ r1 ^ rotr32(q1 ^ r1);
+  q[2] = q1 ^ r1 ^ r2 ^ rotr32(q2 ^ r2);
+  q[3] = q2 ^ r2 ^ q7 ^ r7 ^ r3 ^ rotr32(q3 ^ r3);
+  q[4] = q3 ^ r3 ^ q7 ^ r7 ^ r4 ^ rotr32(q4 ^ r4);
+  q[5] = q4 ^ r4 ^ r5 ^ rotr32(q5 ^ r5);
+  q[6] = q5 ^ r5 ^ r6 ^ rotr32(q6 ^ r6);
+  q[7] = q6 ^ r6 ^ r7 ^ rotr32(q7 ^ r7);
 }
 
-static inline uint64_t rotr32(uint64_t x)
-{
-    return (x << 32) | (x >> 32);
+static void inc4_be(uint32_t *x) {
+  uint32_t t = br_swap32(*x) + 4;
+  *x = br_swap32(t);
 }
 
-static inline void mix_columns(uint64_t *q)
-{
-    uint64_t q0, q1, q2, q3, q4, q5, q6, q7;
-    uint64_t r0, r1, r2, r3, r4, r5, r6, r7;
+static void aes_ecb4x(unsigned char out[64], const uint32_t ivw[16],
+                      const uint64_t *sk_exp, unsigned int nrounds) {
+  uint32_t w[16];
+  uint64_t q[8];
+  unsigned int i;
 
-    q0 = q[0];
-    q1 = q[1];
-    q2 = q[2];
-    q3 = q[3];
-    q4 = q[4];
-    q5 = q[5];
-    q6 = q[6];
-    q7 = q[7];
-    r0 = (q0 >> 16) | (q0 << 48);
-    r1 = (q1 >> 16) | (q1 << 48);
-    r2 = (q2 >> 16) | (q2 << 48);
-    r3 = (q3 >> 16) | (q3 << 48);
-    r4 = (q4 >> 16) | (q4 << 48);
-    r5 = (q5 >> 16) | (q5 << 48);
-    r6 = (q6 >> 16) | (q6 << 48);
-    r7 = (q7 >> 16) | (q7 << 48);
+  memcpy(w, ivw, sizeof(w));
+  for (i = 0; i < 4; i++) {
+    br_aes_ct64_interleave_in(&q[i], &q[i + 4], w + (i << 2));
+  }
+  br_aes_ct64_ortho(q);
 
-    q[0] = q7 ^ r7 ^ r0 ^ rotr32(q0 ^ r0);
-    q[1] = q0 ^ r0 ^ q7 ^ r7 ^ r1 ^ rotr32(q1 ^ r1);
-    q[2] = q1 ^ r1 ^ r2 ^ rotr32(q2 ^ r2);
-    q[3] = q2 ^ r2 ^ q7 ^ r7 ^ r3 ^ rotr32(q3 ^ r3);
-    q[4] = q3 ^ r3 ^ q7 ^ r7 ^ r4 ^ rotr32(q4 ^ r4);
-    q[5] = q4 ^ r4 ^ r5 ^ rotr32(q5 ^ r5);
-    q[6] = q5 ^ r5 ^ r6 ^ rotr32(q6 ^ r6);
-    q[7] = q6 ^ r6 ^ r7 ^ rotr32(q7 ^ r7);
-}
-
-static void inc4_be(uint32_t *x)
-{
-    uint32_t t = br_swap32(*x) + 4;
-    *x = br_swap32(t);
-}
-
-static void aes_ecb4x(unsigned char out[64], const uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds)
-{
-    uint32_t w[16];
-    uint64_t q[8];
-    unsigned int i;
-
-    memcpy(w, ivw, sizeof(w));
-    for (i = 0; i < 4; i++)
-    {
-        br_aes_ct64_interleave_in(&q[i], &q[i + 4], w + (i << 2));
-    }
-    br_aes_ct64_ortho(q);
-
-    add_round_key(q, sk_exp);
-    for (i = 1; i < nrounds; i++)
-    {
-        br_aes_ct64_bitslice_Sbox(q);
-        shift_rows(q);
-        mix_columns(q);
-        add_round_key(q, sk_exp + (i << 3));
-    }
+  add_round_key(q, sk_exp);
+  for (i = 1; i < nrounds; i++) {
     br_aes_ct64_bitslice_Sbox(q);
     shift_rows(q);
-    add_round_key(q, sk_exp + 8 * nrounds);
+    mix_columns(q);
+    add_round_key(q, sk_exp + (i << 3));
+  }
+  br_aes_ct64_bitslice_Sbox(q);
+  shift_rows(q);
+  add_round_key(q, sk_exp + 8 * nrounds);
 
-    br_aes_ct64_ortho(q);
-    for (i = 0; i < 4; i++)
-    {
-        br_aes_ct64_interleave_out(w + (i << 2), q[i], q[i + 4]);
+  br_aes_ct64_ortho(q);
+  for (i = 0; i < 4; i++) {
+    br_aes_ct64_interleave_out(w + (i << 2), q[i], q[i + 4]);
+  }
+  br_range_enc32le(out, w, 16);
+}
+
+static void aes_ctr4x(unsigned char out[64], uint32_t ivw[16],
+                      const uint64_t *sk_exp, unsigned int nrounds) {
+  aes_ecb4x(out, ivw, sk_exp, nrounds);
+
+  /* Increase counter for next 4 blocks */
+  inc4_be(ivw + 3);
+  inc4_be(ivw + 7);
+  inc4_be(ivw + 11);
+  inc4_be(ivw + 15);
+}
+
+static void aes_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
+                    const uint64_t *rkeys, unsigned int nrounds) {
+  uint32_t blocks[16];
+  unsigned char t[64];
+
+  while (nblocks >= 4) {
+    br_range_dec32le(blocks, 16, in);
+    aes_ecb4x(out, blocks, rkeys, nrounds);
+    nblocks -= 4;
+    in += 64;
+    out += 64;
+  }
+
+  if (nblocks) {
+    br_range_dec32le(blocks, nblocks * 4, in);
+    aes_ecb4x(t, blocks, rkeys, nrounds);
+    memcpy(out, t, nblocks * 16);
+  }
+}
+
+static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv,
+                    const uint64_t *rkeys, unsigned int nrounds) {
+  uint32_t ivw[16];
+  size_t i;
+  uint32_t cc = 0;
+
+  br_range_dec32le(ivw, 3, iv);
+  memcpy(ivw + 4, ivw, 3 * sizeof(uint32_t));
+  memcpy(ivw + 8, ivw, 3 * sizeof(uint32_t));
+  memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
+  ivw[3] = br_swap32(cc);
+  ivw[7] = br_swap32(cc + 1);
+  ivw[11] = br_swap32(cc + 2);
+  ivw[15] = br_swap32(cc + 3);
+
+  while (outlen > 64) {
+    aes_ctr4x(out, ivw, rkeys, nrounds);
+    out += 64;
+    outlen -= 64;
+  }
+  if (outlen > 0) {
+    unsigned char tmp[64];
+    aes_ctr4x(tmp, ivw, rkeys, nrounds);
+    for (i = 0; i < outlen; i++) {
+      out[i] = tmp[i];
     }
-    br_range_enc32le(out, w, 16);
+  }
 }
 
-static void aes_ctr4x(unsigned char out[64], uint32_t ivw[16], const uint64_t *sk_exp, unsigned int nrounds)
-{
-    aes_ecb4x(out, ivw, sk_exp, nrounds);
+void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key) {
+  uint64_t skey[22];
 
-    /* Increase counter for next 4 blocks */
-    inc4_be(ivw + 3);
-    inc4_be(ivw + 7);
-    inc4_be(ivw + 11);
-    inc4_be(ivw + 15);
+  r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES128_STATESIZE);
+  if (r->sk_exp == NULL) {
+    exit(111);
+  }
+
+  br_aes_ct64_keysched(skey, key, 16);
+  br_aes_ct64_skey_expand(r->sk_exp, skey, 10);
 }
 
-static void aes_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const uint64_t *rkeys, unsigned int nrounds)
-{
-    uint32_t blocks[16];
-    unsigned char t[64];
-
-    while (nblocks >= 4)
-    {
-        br_range_dec32le(blocks, 16, in);
-        aes_ecb4x(out, blocks, rkeys, nrounds);
-        nblocks -= 4;
-        in += 64;
-        out += 64;
-    }
-
-    if (nblocks)
-    {
-        br_range_dec32le(blocks, nblocks * 4, in);
-        aes_ecb4x(t, blocks, rkeys, nrounds);
-        memcpy(out, t, nblocks * 16);
-    }
+void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key) {
+  aes128_ecb_keyexp(r, key);
 }
 
-static void aes_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const uint64_t *rkeys, unsigned int nrounds)
-{
-    uint32_t ivw[16];
-    size_t i;
-    uint32_t cc = 0;
+void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key) {
+  uint64_t skey[26];
+  r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES192_STATESIZE);
+  if (r->sk_exp == NULL) {
+    exit(111);
+  }
 
-    br_range_dec32le(ivw, 3, iv);
-    memcpy(ivw + 4, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw + 8, ivw, 3 * sizeof(uint32_t));
-    memcpy(ivw + 12, ivw, 3 * sizeof(uint32_t));
-    ivw[3] = br_swap32(cc);
-    ivw[7] = br_swap32(cc + 1);
-    ivw[11] = br_swap32(cc + 2);
-    ivw[15] = br_swap32(cc + 3);
-
-    while (outlen > 64)
-    {
-        aes_ctr4x(out, ivw, rkeys, nrounds);
-        out += 64;
-        outlen -= 64;
-    }
-    if (outlen > 0)
-    {
-        unsigned char tmp[64];
-        aes_ctr4x(tmp, ivw, rkeys, nrounds);
-        for (i = 0; i < outlen; i++)
-        {
-            out[i] = tmp[i];
-        }
-    }
+  br_aes_ct64_keysched(skey, key, 24);
+  br_aes_ct64_skey_expand(r->sk_exp, skey, 12);
 }
 
-void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key)
-{
-    uint64_t skey[22];
-
-    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES128_STATESIZE);
-    if (r->sk_exp == NULL)
-    {
-        exit(111);
-    }
-
-    br_aes_ct64_keysched(skey, key, 16);
-    br_aes_ct64_skey_expand(r->sk_exp, skey, 10);
+void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key) {
+  aes192_ecb_keyexp(r, key);
 }
 
-void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key)
-{
-    aes128_ecb_keyexp(r, key);
+void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key) {
+  uint64_t skey[30];
+  r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES256_STATESIZE);
+  if (r->sk_exp == NULL) {
+    exit(111);
+  }
+
+  br_aes_ct64_keysched(skey, key, 32);
+  br_aes_ct64_skey_expand(r->sk_exp, skey, 14);
 }
 
-void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key)
-{
-    uint64_t skey[26];
-    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES192_STATESIZE);
-    if (r->sk_exp == NULL)
-    {
-        exit(111);
-    }
-
-    br_aes_ct64_keysched(skey, key, 24);
-    br_aes_ct64_skey_expand(r->sk_exp, skey, 12);
+void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key) {
+  aes256_ecb_keyexp(r, key);
 }
 
-void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key)
-{
-    aes192_ecb_keyexp(r, key);
+void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
+                const aes128ctx *ctx) {
+  aes_ecb(out, in, nblocks, ctx->sk_exp, 10);
 }
 
-void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key)
-{
-    uint64_t skey[30];
-    r->sk_exp = malloc(sizeof(uint64_t) * PQC_AES256_STATESIZE);
-    if (r->sk_exp == NULL)
-    {
-        exit(111);
-    }
-
-    br_aes_ct64_keysched(skey, key, 32);
-    br_aes_ct64_skey_expand(r->sk_exp, skey, 14);
+void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv,
+                const aes128ctx *ctx) {
+  aes_ctr(out, outlen, iv, ctx->sk_exp, 10);
 }
 
-void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key)
-{
-    aes256_ecb_keyexp(r, key);
+void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
+                const aes192ctx *ctx) {
+  aes_ecb(out, in, nblocks, ctx->sk_exp, 12);
 }
 
-void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx)
-{
-    aes_ecb(out, in, nblocks, ctx->sk_exp, 10);
+void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv,
+                const aes192ctx *ctx) {
+  aes_ctr(out, outlen, iv, ctx->sk_exp, 12);
 }
 
-void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes128ctx *ctx)
-{
-    aes_ctr(out, outlen, iv, ctx->sk_exp, 10);
+void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
+                const aes256ctx *ctx) {
+  aes_ecb(out, in, nblocks, ctx->sk_exp, 14);
 }
 
-void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx)
-{
-    aes_ecb(out, in, nblocks, ctx->sk_exp, 12);
+void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv,
+                const aes256ctx *ctx) {
+  aes_ctr(out, outlen, iv, ctx->sk_exp, 14);
 }
 
-void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes192ctx *ctx)
-{
-    aes_ctr(out, outlen, iv, ctx->sk_exp, 12);
-}
+void aes128_ctx_release(aes128ctx *r) { free(r->sk_exp); }
 
-void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx)
-{
-    aes_ecb(out, in, nblocks, ctx->sk_exp, 14);
-}
+void aes192_ctx_release(aes192ctx *r) { free(r->sk_exp); }
 
-void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes256ctx *ctx)
-{
-    aes_ctr(out, outlen, iv, ctx->sk_exp, 14);
-}
-
-void aes128_ctx_release(aes128ctx *r)
-{
-    free(r->sk_exp);
-}
-
-void aes192_ctx_release(aes192ctx *r)
-{
-    free(r->sk_exp);
-}
-
-void aes256_ctx_release(aes256ctx *r)
-{
-    free(r->sk_exp);
-}
+void aes256_ctx_release(aes256ctx *r) { free(r->sk_exp); }

--- a/test/nistrng/aes.h
+++ b/test/nistrng/aes.h
@@ -14,21 +14,18 @@
 
 // We've put these states on the heap to make sure ctx_release is used.
 #define PQC_AES128_STATESIZE 88
-typedef struct
-{
-    uint64_t *sk_exp;
+typedef struct {
+  uint64_t *sk_exp;
 } aes128ctx;
 
 #define PQC_AES192_STATESIZE 104
-typedef struct
-{
-    uint64_t  *sk_exp;
+typedef struct {
+  uint64_t *sk_exp;
 } aes192ctx;
 
 #define PQC_AES256_STATESIZE 120
-typedef struct
-{
-    uint64_t *sk_exp;
+typedef struct {
+  uint64_t *sk_exp;
 } aes256ctx;
 
 /** Initializes the context **/
@@ -36,9 +33,11 @@ void aes128_ecb_keyexp(aes128ctx *r, const unsigned char *key);
 
 void aes128_ctr_keyexp(aes128ctx *r, const unsigned char *key);
 
-void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes128ctx *ctx);
+void aes128_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
+                const aes128ctx *ctx);
 
-void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes128ctx *ctx);
+void aes128_ctr(unsigned char *out, size_t outlen, const unsigned char *iv,
+                const aes128ctx *ctx);
 
 /** Frees the context **/
 void aes128_ctx_release(aes128ctx *r);
@@ -48,9 +47,11 @@ void aes192_ecb_keyexp(aes192ctx *r, const unsigned char *key);
 
 void aes192_ctr_keyexp(aes192ctx *r, const unsigned char *key);
 
-void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes192ctx *ctx);
+void aes192_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
+                const aes192ctx *ctx);
 
-void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes192ctx *ctx);
+void aes192_ctr(unsigned char *out, size_t outlen, const unsigned char *iv,
+                const aes192ctx *ctx);
 
 void aes192_ctx_release(aes192ctx *r);
 
@@ -59,9 +60,11 @@ void aes256_ecb_keyexp(aes256ctx *r, const unsigned char *key);
 
 void aes256_ctr_keyexp(aes256ctx *r, const unsigned char *key);
 
-void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks, const aes256ctx *ctx);
+void aes256_ecb(unsigned char *out, const unsigned char *in, size_t nblocks,
+                const aes256ctx *ctx);
 
-void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv, const aes256ctx *ctx);
+void aes256_ctr(unsigned char *out, size_t outlen, const unsigned char *iv,
+                const aes256ctx *ctx);
 
 /** Frees the context **/
 void aes256_ctx_release(aes256ctx *r);

--- a/test/nistrng/randombytes.h
+++ b/test/nistrng/randombytes.h
@@ -8,6 +8,10 @@
 
 void randombytes(uint8_t *buf, size_t n);
 
-void nist_kat_init(unsigned char entropy_input[AES256_KEYBYTES + AES_BLOCKBYTES], const unsigned char personalization_string[AES256_KEYBYTES + AES_BLOCKBYTES], int security_strength);
+void nist_kat_init(
+    unsigned char entropy_input[AES256_KEYBYTES + AES_BLOCKBYTES],
+    const unsigned char
+        personalization_string[AES256_KEYBYTES + AES_BLOCKBYTES],
+    int security_strength);
 
 #endif

--- a/test/nistrng/rng.c
+++ b/test/nistrng/rng.c
@@ -1,102 +1,94 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <assert.h>
-#include <string.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "aes.h"
 #include "randombytes.h"
 
-typedef struct
-{
-    unsigned char key[AES256_KEYBYTES];
-    unsigned char ctr[AES_BLOCKBYTES];
+typedef struct {
+  unsigned char key[AES256_KEYBYTES];
+  unsigned char ctr[AES_BLOCKBYTES];
 } nistkatctx;
 
 static nistkatctx ctx;
 
-static void _aes256_ecb(unsigned char key[AES256_KEYBYTES], unsigned char ctr[AES_BLOCKBYTES], unsigned char buffer[AES_BLOCKBYTES])
-{
-    aes256ctx aesctx;
-    aes256_ecb_keyexp(&aesctx, key);
-    aes256_ecb(buffer, ctr, 1, &aesctx);
-    aes256_ctx_release(&aesctx);
+static void _aes256_ecb(unsigned char key[AES256_KEYBYTES],
+                        unsigned char ctr[AES_BLOCKBYTES],
+                        unsigned char buffer[AES_BLOCKBYTES]) {
+  aes256ctx aesctx;
+  aes256_ecb_keyexp(&aesctx, key);
+  aes256_ecb(buffer, ctr, 1, &aesctx);
+  aes256_ctx_release(&aesctx);
 }
 
-static void aes256_block_update(uint8_t block[AES_BLOCKBYTES])
-{
-    for (int j = AES_BLOCKBYTES - 1; j >= 0; j--)
-    {
-        ctx.ctr[j]++;
+static void aes256_block_update(uint8_t block[AES_BLOCKBYTES]) {
+  for (int j = AES_BLOCKBYTES - 1; j >= 0; j--) {
+    ctx.ctr[j]++;
 
-        if (ctx.ctr[j] != 0x00)
-        {
-            break;
-        }
+    if (ctx.ctr[j] != 0x00) {
+      break;
     }
+  }
 
-    _aes256_ecb(ctx.key, ctx.ctr, block);
+  _aes256_ecb(ctx.key, ctx.ctr, block);
 }
 
-static void nistkat_update(const unsigned char *provided_data, unsigned char *key, unsigned char *ctr)
-{
-    int len = AES256_KEYBYTES + AES_BLOCKBYTES;
-    uint8_t tmp[len];
+static void nistkat_update(const unsigned char *provided_data,
+                           unsigned char *key, unsigned char *ctr) {
+  int len = AES256_KEYBYTES + AES_BLOCKBYTES;
+  uint8_t tmp[len];
 
-    for (int i = 0; i < len / AES_BLOCKBYTES; i++)
-    {
-        aes256_block_update(tmp + AES_BLOCKBYTES * i);
+  for (int i = 0; i < len / AES_BLOCKBYTES; i++) {
+    aes256_block_update(tmp + AES_BLOCKBYTES * i);
+  }
+
+  if (provided_data) {
+    for (int i = 0; i < len; i++) {
+      tmp[i] ^= provided_data[i];
     }
+  }
 
-    if (provided_data)
-    {
-        for (int i = 0; i < len; i++)
-        {
-            tmp[i] ^= provided_data[i];
-        }
-    }
-
-    memcpy(key, tmp, AES256_KEYBYTES);
-    memcpy(ctr, tmp + AES256_KEYBYTES, AES_BLOCKBYTES);
+  memcpy(key, tmp, AES256_KEYBYTES);
+  memcpy(ctr, tmp + AES256_KEYBYTES, AES_BLOCKBYTES);
 }
 
-void nist_kat_init(unsigned char entropy_input[AES256_KEYBYTES + AES_BLOCKBYTES], const unsigned char personalization_string[AES256_KEYBYTES + AES_BLOCKBYTES], int security_strength)
-{
-    int len = AES256_KEYBYTES + AES_BLOCKBYTES;
-    uint8_t seed_material[len];
-    (void) security_strength;
+void nist_kat_init(
+    unsigned char entropy_input[AES256_KEYBYTES + AES_BLOCKBYTES],
+    const unsigned char
+        personalization_string[AES256_KEYBYTES + AES_BLOCKBYTES],
+    int security_strength) {
+  int len = AES256_KEYBYTES + AES_BLOCKBYTES;
+  uint8_t seed_material[len];
+  (void)security_strength;
 
-    memcpy(seed_material, entropy_input, len);
-    if (personalization_string)
-    {
-        for (int i = 0; i < len; i++)
-        {
-            seed_material[i] ^= personalization_string[i];
-        }
+  memcpy(seed_material, entropy_input, len);
+  if (personalization_string) {
+    for (int i = 0; i < len; i++) {
+      seed_material[i] ^= personalization_string[i];
     }
-    memset(ctx.key, 0x00, AES256_KEYBYTES);
-    memset(ctx.ctr, 0x00, AES_BLOCKBYTES);
-    nistkat_update(seed_material, ctx.key, ctx.ctr);
+  }
+  memset(ctx.key, 0x00, AES256_KEYBYTES);
+  memset(ctx.ctr, 0x00, AES_BLOCKBYTES);
+  nistkat_update(seed_material, ctx.key, ctx.ctr);
 }
 
-void randombytes(uint8_t *buf, size_t n)
-{
-    uint8_t block[AES_BLOCKBYTES];
+void randombytes(uint8_t *buf, size_t n) {
+  uint8_t block[AES_BLOCKBYTES];
 
-    size_t nb = n / AES_BLOCKBYTES;
-    size_t tail = n % AES_BLOCKBYTES;
+  size_t nb = n / AES_BLOCKBYTES;
+  size_t tail = n % AES_BLOCKBYTES;
 
-    for (size_t i = 0; i < nb; i++)
-    {
-        aes256_block_update(block);
-        memcpy(buf + i * AES_BLOCKBYTES, block, AES_BLOCKBYTES);
-    }
+  for (size_t i = 0; i < nb; i++) {
+    aes256_block_update(block);
+    memcpy(buf + i * AES_BLOCKBYTES, block, AES_BLOCKBYTES);
+  }
 
-    if (tail > 0)
-    {
-        aes256_block_update(block);
-        memcpy(buf + nb * AES_BLOCKBYTES, block, tail);
-    }
+  if (tail > 0) {
+    aes256_block_update(block);
+    memcpy(buf + nb * AES_BLOCKBYTES, block, tail);
+  }
 
-    nistkat_update(NULL, ctx.key, ctx.ctr);
+  nistkat_update(NULL, ctx.key, ctx.ctr);
 }

--- a/test/test_kyber.c
+++ b/test/test_kyber.c
@@ -7,118 +7,107 @@
 
 #define NTESTS 1000
 
-static int test_keys(void)
-{
-    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-    uint8_t sk[CRYPTO_SECRETKEYBYTES];
-    uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-    uint8_t key_a[CRYPTO_BYTES];
-    uint8_t key_b[CRYPTO_BYTES];
+static int test_keys(void) {
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  uint8_t key_a[CRYPTO_BYTES];
+  uint8_t key_b[CRYPTO_BYTES];
 
-    //Alice generates a public key
-    crypto_kem_keypair(pk, sk);
+  // Alice generates a public key
+  crypto_kem_keypair(pk, sk);
 
-    //Bob derives a secret key and creates a response
-    crypto_kem_enc(ct, key_b, pk);
+  // Bob derives a secret key and creates a response
+  crypto_kem_enc(ct, key_b, pk);
 
-    //Alice uses Bobs response to get her shared key
-    crypto_kem_dec(key_a, ct, sk);
+  // Alice uses Bobs response to get her shared key
+  crypto_kem_dec(key_a, ct, sk);
 
-    if (memcmp(key_a, key_b, CRYPTO_BYTES))
-    {
-        printf("ERROR keys\n");
-        return 1;
-    }
+  if (memcmp(key_a, key_b, CRYPTO_BYTES)) {
+    printf("ERROR keys\n");
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
-static int test_invalid_sk_a(void)
-{
-    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-    uint8_t sk[CRYPTO_SECRETKEYBYTES];
-    uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-    uint8_t key_a[CRYPTO_BYTES];
-    uint8_t key_b[CRYPTO_BYTES];
+static int test_invalid_sk_a(void) {
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  uint8_t key_a[CRYPTO_BYTES];
+  uint8_t key_b[CRYPTO_BYTES];
 
-    //Alice generates a public key
-    crypto_kem_keypair(pk, sk);
+  // Alice generates a public key
+  crypto_kem_keypair(pk, sk);
 
-    //Bob derives a secret key and creates a response
-    crypto_kem_enc(ct, key_b, pk);
+  // Bob derives a secret key and creates a response
+  crypto_kem_enc(ct, key_b, pk);
 
-    //Replace secret key with random values
-    randombytes(sk, CRYPTO_SECRETKEYBYTES);
+  // Replace secret key with random values
+  randombytes(sk, CRYPTO_SECRETKEYBYTES);
 
-    //Alice uses Bobs response to get her shared key
-    crypto_kem_dec(key_a, ct, sk);
+  // Alice uses Bobs response to get her shared key
+  crypto_kem_dec(key_a, ct, sk);
 
-    if (!memcmp(key_a, key_b, CRYPTO_BYTES))
-    {
-        printf("ERROR invalid sk\n");
-        return 1;
-    }
+  if (!memcmp(key_a, key_b, CRYPTO_BYTES)) {
+    printf("ERROR invalid sk\n");
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
-static int test_invalid_ciphertext(void)
-{
-    uint8_t pk[CRYPTO_PUBLICKEYBYTES];
-    uint8_t sk[CRYPTO_SECRETKEYBYTES];
-    uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
-    uint8_t key_a[CRYPTO_BYTES];
-    uint8_t key_b[CRYPTO_BYTES];
-    uint8_t b;
-    size_t pos;
+static int test_invalid_ciphertext(void) {
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES];
+  uint8_t sk[CRYPTO_SECRETKEYBYTES];
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES];
+  uint8_t key_a[CRYPTO_BYTES];
+  uint8_t key_b[CRYPTO_BYTES];
+  uint8_t b;
+  size_t pos;
 
-    do
-    {
-        randombytes(&b, sizeof(uint8_t));
-    }
-    while (!b);
-    randombytes((uint8_t *)&pos, sizeof(size_t));
+  do {
+    randombytes(&b, sizeof(uint8_t));
+  } while (!b);
+  randombytes((uint8_t *)&pos, sizeof(size_t));
 
-    //Alice generates a public key
-    crypto_kem_keypair(pk, sk);
+  // Alice generates a public key
+  crypto_kem_keypair(pk, sk);
 
-    //Bob derives a secret key and creates a response
-    crypto_kem_enc(ct, key_b, pk);
+  // Bob derives a secret key and creates a response
+  crypto_kem_enc(ct, key_b, pk);
 
-    //Change some byte in the ciphertext (i.e., encapsulated key)
-    ct[pos % CRYPTO_CIPHERTEXTBYTES] ^= b;
+  // Change some byte in the ciphertext (i.e., encapsulated key)
+  ct[pos % CRYPTO_CIPHERTEXTBYTES] ^= b;
 
-    //Alice uses Bobs response to get her shared key
-    crypto_kem_dec(key_a, ct, sk);
+  // Alice uses Bobs response to get her shared key
+  crypto_kem_dec(key_a, ct, sk);
 
-    if (!memcmp(key_a, key_b, CRYPTO_BYTES))
-    {
-        printf("ERROR invalid ciphertext\n");
-        return 1;
-    }
+  if (!memcmp(key_a, key_b, CRYPTO_BYTES)) {
+    printf("ERROR invalid ciphertext\n");
+    return 1;
+  }
 
-    return 0;
+  return 0;
 }
 
-int main(void)
-{
-    unsigned int i;
-    int r;
+int main(void) {
+  unsigned int i;
+  int r;
 
-    for (i = 0; i < NTESTS; i++)
-    {
-        r  = test_keys();
-        r |= test_invalid_sk_a();
-        r |= test_invalid_ciphertext();
-        if (r)
-        {
-            return 1;
-        }
+  for (i = 0; i < NTESTS; i++) {
+    r = test_keys();
+    r |= test_invalid_sk_a();
+    r |= test_invalid_ciphertext();
+    if (r) {
+      return 1;
     }
+  }
 
-    printf("CRYPTO_SECRETKEYBYTES:  %d\n", CRYPTO_SECRETKEYBYTES);
-    printf("CRYPTO_PUBLICKEYBYTES:  %d\n", CRYPTO_PUBLICKEYBYTES);
-    printf("CRYPTO_CIPHERTEXTBYTES: %d\n", CRYPTO_CIPHERTEXTBYTES);
+  printf("CRYPTO_SECRETKEYBYTES:  %d\n", CRYPTO_SECRETKEYBYTES);
+  printf("CRYPTO_PUBLICKEYBYTES:  %d\n", CRYPTO_PUBLICKEYBYTES);
+  printf("CRYPTO_CIPHERTEXTBYTES: %d\n", CRYPTO_CIPHERTEXTBYTES);
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
Fixes Issue #180 

Adoption will be a gradual series of two-way doors.

Phase 1: add clang-tools to our nix environment, and add a proposed .clang-format file.

Phase 2: Update scripts and CI actions to use clang-format instead of astyle

Phase 3: Reformat and commit all code with clang-format

Phase 4: Switch scripts and CI to use clang-format by defauly.

Phase 5: Update developers' editors and IDEs to use clang-format and our chosen style.

Phase 6: Retire astyle.

Verification: all KATs and proofs must succeed. CBMC contracts must remain readable.


