### PR TITLE
Fix gen_matrix()

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -214,8 +214,7 @@ void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES],
 
     while (ctr[0] < KYBER_N || ctr[1] < KYBER_N || ctr[2] < KYBER_N ||
            ctr[3] < KYBER_N) {
-      shake128x4_squeezeblocks(bufx[0], bufx[1], bufx[2], bufx[3],
-                               GEN_MATRIX_NBLOCKS, &statex);
+      shake128x4_squeezeblocks(bufx[0], bufx[1], bufx[2], bufx[3], 1, &statex);
       buflen = SHAKE128_RATE;
 
       for (unsigned j = 0; j < KECCAK_WAY; j++) {


### PR DESCRIPTION
When building the public matrix, we first squeeze GEN_MATRIX_NBLOCKS out of the Keccak state and rejection sample them into the matrix entries. We then run a 'fill up' stage, squeezing and sampling one block a time, until the entry buffers are full.

The previous code got the fill-up stage wrong: Instead of squeezing one block a time, we squeezed GEN_MATRIX_NBLOCKS, _but_ sampled as if we had only squeezed one. This would lead to incorrect results if the fill-up stage needs more than one iteration. Thanks to the large default value of GEN_MATRIX_NBLOCKS, this would not happen in any of the KAT tests, but it may still fail in rare cases. It also fails when setting GEN_MATRIX_NBLOCKS=2.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
