### PR TITLE
Fix linter for clang-format

### DIFF
--- a/mlkem/native/aarch64/profiles/clean.h
+++ b/mlkem/native/aarch64/profiles/clean.h
@@ -42,7 +42,8 @@ static inline void polyvec_basemul_acc_montgomery_cached_native(
       r->coeffs, a->vec[0].coeffs, b->vec[0].coeffs, b_cache->vec[0].coeffs);
 }
 
-static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES], const poly *a) {
+static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
+                                       const poly *a) {
   poly_tobytes_asm_clean(r, a->coeffs);
 }
 

--- a/mlkem/native/aarch64/profiles/opt.h
+++ b/mlkem/native/aarch64/profiles/opt.h
@@ -42,7 +42,8 @@ static inline void polyvec_basemul_acc_montgomery_cached_native(
       r->coeffs, a->vec[0].coeffs, b->vec[0].coeffs, b_cache->vec[0].coeffs);
 }
 
-static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES], const poly *a) {
+static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
+                                       const poly *a) {
   poly_tobytes_asm_clean(r, a->coeffs);
 }
 

--- a/scripts/ci/lint
+++ b/scripts/ci/lint
@@ -57,7 +57,7 @@ fi
 echo "::endgroup::"
 
 echo "::group::Linting c files with clang-format"
-checkerr "Lint C" "$(clang-format $(git ls-files ":/*.c" ":/*.h") --dry-run)"
+checkerr "Lint C" "$(clang-format $(git ls-files ":/*.c" ":/*.h") --Werror --dry-run)"
 echo "::endgroup::"
 
 check-eol-dry-run()


### PR DESCRIPTION
Fixes #193 

Adds -Werror flag to run of clang-format in "lint" script so that clang-format returns
an error code if any file needs formatting.

This forces the "lint" script (and CI) to fail and report the error.
