### PR TITLE
Simplify native interface for rej_uniform

### DIFF
--- a/mlkem/native/aarch64/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/arith_native_aarch64.h
@@ -13,9 +13,8 @@ void ntt_asm_opt(int16_t *);
 void intt_asm_clean(int16_t *);
 void intt_asm_opt(int16_t *);
 
-unsigned int rej_uniform_asm_clean(int16_t *r, unsigned int len,
+unsigned int rej_uniform_asm_clean(int16_t *r,
                                    const uint8_t *buf,
-                                   unsigned int *buf_consumed,
                                    unsigned int buflen);
 
 void poly_reduce_asm_clean(int16_t *);

--- a/mlkem/native/aarch64/profiles/clean.h
+++ b/mlkem/native/aarch64/profiles/clean.h
@@ -47,11 +47,13 @@ static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
   poly_tobytes_asm_clean(r, a->coeffs);
 }
 
-static inline unsigned int rej_uniform_native(int16_t *r, unsigned int len,
-                                              const uint8_t *buf,
-                                              unsigned int *buf_consumed,
-                                              unsigned int buflen) {
-  return rej_uniform_asm_clean(r, len, buf, buf_consumed, buflen);
+static inline int rej_uniform_native(int16_t *r, unsigned int len,
+                                     const uint8_t *buf,
+                                     unsigned int buflen) {
+  if (len != KYBER_N || buflen % 24 != 0) {
+        return -1;
+  }
+  return (int) rej_uniform_asm_clean(r, buf, buflen);
 }
 
 #endif /* MLKEM_ARITH_NATIVE_PROFILE_H */

--- a/mlkem/native/aarch64/profiles/opt.h
+++ b/mlkem/native/aarch64/profiles/opt.h
@@ -47,11 +47,13 @@ static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
   poly_tobytes_asm_clean(r, a->coeffs);
 }
 
-static inline unsigned int rej_uniform_native(int16_t *r, unsigned int len,
-                                              const uint8_t *buf,
-                                              unsigned int *buf_consumed,
-                                              unsigned int buflen) {
-  return rej_uniform_asm_clean(r, len, buf, buf_consumed, buflen);
+static inline int rej_uniform_native(int16_t *r, unsigned int len,
+                                     const uint8_t *buf,
+                                     unsigned int buflen) {
+  if (len != KYBER_N || buflen % 24 != 0) {
+        return -1;
+  }
+  return (int) rej_uniform_asm_clean(r, buf, buflen);
 }
 
 #endif /* MLKEM_ARITH_NATIVE_PROFILE_H */

--- a/mlkem/native/aarch64/rej_uniform_asm_clean.S
+++ b/mlkem/native/aarch64/rej_uniform_asm_clean.S
@@ -6,18 +6,15 @@
  * Description: Run rejection sampling on uniform random bytes to generate
  *              uniform random integers mod q
  *
- * Arguments:   - int16_t *r:          pointer to output buffer
- *              - unsigned int len:    requested number of 16-bit integers
- *                                     (uniform mod q)
+ * Arguments:   - int16_t *r:          pointer to output buffer of KYBER_N
+ *                                     16-bit coefficients.
  *              - const uint8_t *buf:  pointer to input buffer
  *                                     (assumed to be uniform random bytes)
- *              - unsigned int *buf_consumed: pointer at which to store the
- *                                            number of bytes processed
- *              - unsigned int buflen: length of input buffer in bytes
+ *              - unsigned int buflen: length of input buffer in bytes.
+ *                                     Must be a multiple of 24.
  *
- * Returns number of sampled 16-bit integers (at most len)
+ * Returns number of sampled 16-bit integers (at most KYBER_N).
  **************************************************/
-
 #include "config.h"
 #include "params.h"
 #if defined(MLKEM_USE_NATIVE_AARCH64)
@@ -303,10 +300,9 @@ bit_table_data:
 
     /* Parameters */
     output                      .req x0
-    len                         .req w1
-    buf                         .req x2
-    buf_consumed_ptr            .req x3
-    buflen                      .req w4
+    buf                         .req x1
+    buflen                      .req w2
+    len                         .req w3
 
     /* Pointers to static data */
     table_idx                   .req x5
@@ -391,20 +387,15 @@ _rej_uniform_asm_clean:
     ASM_LOAD(bit_table, bit_table_data)
     ASM_LOAD(table_idx, table_data)
 
-    ldr         bits_q, [bit_table]
-    movz        tmp, #KYBER_Q
-    dup         kyber_q.8h, tmp
-
-    // We only deal with output buffer length KYBER_N.
-    mov tmp, #KYBER_N
-    cmp len, tmp
-    b.ne reject
+    ldr  bits_q, [bit_table]
+    movz tmp, #KYBER_Q
+    dup  kyber_q.8h, tmp
 
     add output_tmp_base, sp, #STACK_OFFSET_TMP_OUTPUT
     mov output_tmp, output_tmp_base
 
     mov count, #0
-    mov buf_consumed, #0
+    mov len, #KYBER_N
 
     cmp buflen, #48
     b.lo loop48_end
@@ -421,7 +412,6 @@ loop48:
         // We handle 16 such triples a time, and use ld3 for the required
         // de-interleaving of the byte stream.
         sub     buflen, buflen, #48
-        add     buf_consumed, buf_consumed, #48
         ld3     {buf0.16b, buf1.16b, buf2.16b}, [buf], #48
 
         // Unpack 16 triples of bytes into 16 pairs of 16-bit integers,
@@ -534,7 +524,6 @@ loop48_end:
     b.lo memory_copy
 
         sub     buflen, buflen, #24
-        add     buf_consumed, buf_consumed, #24
         ld3     {buf0.8b, buf1.8b, buf2.8b}, [buf], #24
 
         zip1    tmp0.16b, buf0.16b, buf1.16b
@@ -583,8 +572,6 @@ loop48_end:
         add     count, count, ctr1
 
 memory_copy:
-    str buf_consumed, [buf_consumed_ptr]
-
     // min = min(count,len)
     cmp  count, len
     csel count, count, len, lo
@@ -610,9 +597,6 @@ final_copy:
     mov w0, count
     b return
 
-reject:
-    mov x0, #0
-    str w0, [buf_consumed_ptr]
 return:
     pop_stack
     ret

--- a/mlkem/native/arith_native.h
+++ b/mlkem/native/arith_native.h
@@ -96,10 +96,25 @@ static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
 #endif
 
 #if defined(MLKEM_USE_NATIVE_REJ_UNIFORM)
-static inline unsigned int rej_uniform_native(int16_t *r, unsigned int len,
-                                              const uint8_t *buf,
-                                              unsigned int *buf_consumed,
-                                              unsigned int buflen);
+/*************************************************
+ * Name:        rej_uniform_native
+ *
+ * Description: Run rejection sampling on uniform random bytes to generate
+ *              uniform random integers mod q
+ *
+ * Arguments:   - int16_t *r:          pointer to output buffer
+ *              - unsigned int len:    requested number of 16-bit integers
+ *                                     (uniform mod q).
+ *              - const uint8_t *buf:  pointer to input buffer
+ *                                     (assumed to be uniform random bytes)
+ *              - unsigned int buflen: length of input buffer in bytes.
+ *
+ * Return -1 if the native implementation does not support the input lengths.
+ * Otherwise, returns non-negative number of sampled 16-bit integers (at most len).
+ **************************************************/
+static inline int rej_uniform_native(int16_t *r, unsigned int len,
+                                     const uint8_t *buf,
+                                     unsigned int buflen);
 #endif
 
 #endif /* MLKEM_USE_NATIVE */

--- a/mlkem/rej_uniform.c
+++ b/mlkem/rej_uniform.c
@@ -65,16 +65,13 @@ unsigned int rej_uniform(int16_t *r, unsigned int len, const uint8_t *buf,
  **************************************************/
 unsigned int rej_uniform(int16_t *r, unsigned int len, const uint8_t *buf,
                          unsigned int buflen) {
-  unsigned int ctr, consumed = 0;
+  int ret;
 
   // Sample from large buffer with full lane as much as possible.
-  ctr = rej_uniform_native(r, len, buf, &consumed, buflen);
-  if (ctr < len) {
-    // This function will utilize every last byte of the buffer.
-    ctr += rej_uniform_scalar(r + ctr, len - ctr, buf + consumed,
-                              buflen - consumed);
-  }
+  ret = rej_uniform_native(r, len, buf, buflen);
+  if (ret != -1)
+      return (unsigned) ret;
 
-  return ctr;
+  return rej_uniform_scalar(r, len, buf, buflen);
 }
 #endif /* MLKEM_USE_NATIVE_AARCH64 */


### PR DESCRIPTION
Previously, the native interface for rejection sampling was

```
static inline unsigned int rej_uniform_native
    (int16_t *r, unsigned int len,
     const uint8_t *buf,
     unsigned int *buf_consumed,
     unsigned int buflen)
```

Here, `*buf_consumed` would contain the number of bytes processed from the input buffer, and the return value would be the number of valid coefficients sampled.

This generality is not needed -- iInstead, there are only two cases to consider: First, the native call does not support the input arguments, in which case no data is being processed, and one should fallback to the generic C implementation. Second, the call satisfies the same semantics as the C call, that is, it returns the number of sampled coefficients, and guarantees that the entire input buffer was processed if that number is smaller than `len`.

This restricted interface can be more succinctly captured via

```
static inline int rej_uniform_native
    (int16_t *r, unsigned int len,
     const uint8_t *buf, unsigned int buflen)
```

where a return value of -1 captures that the parameters were unsupported.

This commit modifies the native interface accordingly, and adjusts the AArch64 implementation: Specifically, the AArch64 ASM implementation only supports input buffers of length KYBER_N, which can be quickly detected in the recently introduced wrapper round the ASM routine, rather than in assembly (that wrapper didn't exist when the ASM routine was introduced).

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
