### PR TITLE
Add some x86_64 based benchmarks to CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -75,6 +75,22 @@ jobs:
             ec2_ami: ubuntu-latest (aarch64)
             archflags: -march=armv9-a+sha3
             cflags: -DFORCE_AARCH64
+          - name: AMD EPYC 4th gen (c7a)
+            ec2_instance_type: c7a.medium
+            ec2_ami: ubuntu-latest (x86_64)
+            cflags: -DFORCE_X86_64
+          - name: Intel Xeon 4th gen (c7i)
+            ec2_instance_type: c7i.large
+            ec2_ami: ubuntu-latest (x86_64)
+            cflags: -DFORCE_X86_64
+          - name: AMD EPYC 3rd gen (c6a)
+            ec2_instance_type: c7a.medium
+            ec2_ami: ubuntu-latest (x86_64)
+            cflags: -DFORCE_X86_64
+          - name: Intel Xeon 3rd gen (c6i)
+            ec2_instance_type: c7i.large
+            ec2_ami: ubuntu-latest (x86_64)
+            cflags: -DFORCE_X86_64
     uses: ./.github/workflows/bench_ec2_reusable.yml
     if: github.repository_owner == 'pq-code-package' && (github.event.label.name == 'benchmark' || github.ref == 'refs/heads/main')
     with:


### PR DESCRIPTION
As we start integrating AVX2 assembly, this will help us gauge its performance impact.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
