### PR TITLE
Reduce number of vCPUs in CBMC CI task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,8 @@ jobs:
             ec2_ami: ubuntu-latest (custom AMI)
             ec2_ami_id: ami-0d47e137a1108e078 # x86_64 ubuntu-latest, 32g
             cbmc: 'false'
-          - name: Graviton3, CBMC (c7g.4xlarge)
-            ec2_instance_type: c7g.4xlarge
+          - name: Graviton3, CBMC (c7g.xlarge)
+            ec2_instance_type: c7g.xlarge
             ec2_ami: ubuntu-latest (custom AMI)
             ec2_ami_id: ami-08ddb0acd99dc3d33 # aarch64, ubuntu-latest, 64g
             cbmc: 'true'


### PR DESCRIPTION
The current use of 4xlarge instances leads to spurious CI failures due to exceeded vCPU quota.

This commit switches to a lower number of vCPUs, which will lead to a slower, but more reliable CI.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
