### PR TITLE
Fix `lint` script

### DIFF
--- a/mlkem/native/aarch64/profiles/clean.h
+++ b/mlkem/native/aarch64/profiles/clean.h
@@ -48,10 +48,9 @@ static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
 }
 
 static inline int rej_uniform_native(int16_t *r, unsigned int len,
-                                     const uint8_t *buf,
-                                     unsigned int buflen) {
+                                     const uint8_t *buf, unsigned int buflen) {
   if (len != KYBER_N || buflen % 24 != 0) {
-        return -1;
+    return -1;
   }
   return (int)rej_uniform_asm_clean(r, buf, buflen);
 }

--- a/mlkem/native/aarch64/profiles/opt.h
+++ b/mlkem/native/aarch64/profiles/opt.h
@@ -48,10 +48,9 @@ static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
 }
 
 static inline int rej_uniform_native(int16_t *r, unsigned int len,
-                                     const uint8_t *buf,
-                                     unsigned int buflen) {
+                                     const uint8_t *buf, unsigned int buflen) {
   if (len != KYBER_N || buflen % 24 != 0) {
-        return -1;
+    return -1;
   }
   return (int)rej_uniform_asm_clean(r, buf, buflen);
 }

--- a/scripts/ci/lint
+++ b/scripts/ci/lint
@@ -57,7 +57,7 @@ fi
 echo "::endgroup::"
 
 echo "::group::Linting c files with clang-format"
-checkerr "Lint C" "$(clang-format $(git ls-files ":/*.c" ":/*.h") --Werror --dry-run)"
+checkerr "Lint C" "$(clang-format $(git ls-files ":/*.c" ":/*.h") --Werror --dry-run 2>&1 | grep "error:" | cut -d ':' -f 1,2 | tr ':' ' ')"
 echo "::endgroup::"
 
 check-eol-dry-run()


### PR DESCRIPTION
The `clang-format` step in the `lint` script would correctly fail
upon badly formatting source files, but (a) the error would not be
displayed correctly, (b) fail to propagate to the result of  `lint`.

This commit fixes this by adjusting the output of the format checker
to match the expectation of `lint`'s internals:
- The output must be to stdout
- The output must consist of lines of the form "file:line:..."
  showing every ill-formatted line/file combination once

The output of `clang-format` does not match this format,
and thus needs a bit of massaging.
