### PR TITLE
Add AVX2 [inv]NTT from official Kyber repository

### DIFF
--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -5,7 +5,7 @@ ifeq ($(OPT),1)
 	CPPFLAGS += -DMLKEM_USE_NATIVE
 endif
 
-CPPFLAGS += -Imlkem -Imlkem/sys -Imlkem/native
+CPPFLAGS += -Imlkem -Imlkem/sys -Imlkem/native -Imlkem/native/aarch64 -Imlkem/native/x86_64
 TESTS = test_kyber bench_kyber bench_components_kyber gen_NISTKAT gen_KAT
 
 MLKEM512_DIR = $(BUILD_DIR)/mlkem512

--- a/mlkem/common.h
+++ b/mlkem/common.h
@@ -2,6 +2,7 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#define ALIGN(x) __attribute__((aligned(x)))
+#define DEFAULT_ALIGN 32
+#define ALIGN __attribute__((aligned(DEFAULT_ALIGN)))
 
 #endif

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -249,7 +249,7 @@ void indcpa_keypair_derand(uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[KYBER_INDCPA_SECRETKEYBYTES],
                            const uint8_t coins[KYBER_SYMBYTES]) {
   unsigned int i;
-  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
+  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN;
   const uint8_t *publicseed = buf;
   const uint8_t *noiseseed = buf + KYBER_SYMBYTES;
   polyvec a[KYBER_K], e, pkpv, skpv;
@@ -316,7 +316,7 @@ void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
                 const uint8_t pk[KYBER_INDCPA_PUBLICKEYBYTES],
                 const uint8_t coins[KYBER_SYMBYTES]) {
   unsigned int i;
-  uint8_t seed[KYBER_SYMBYTES] ALIGN(16);
+  uint8_t seed[KYBER_SYMBYTES] ALIGN;
   polyvec sp, pkpv, ep, at[KYBER_K], b;
   polyvec_mulcache sp_cache;
   poly v, k, epp;

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -49,7 +49,7 @@ int crypto_kem_keypair_derand(uint8_t *pk, uint8_t *sk, const uint8_t *coins) {
  * Returns 0 (success)
  **************************************************/
 int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
-  uint8_t coins[2 * KYBER_SYMBYTES] ALIGN(16);
+  uint8_t coins[2 * KYBER_SYMBYTES] ALIGN;
   randombytes(coins, 2 * KYBER_SYMBYTES);
   crypto_kem_keypair_derand(pk, sk, coins);
   return 0;
@@ -75,9 +75,9 @@ int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
  **************************************************/
 int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
                           const uint8_t *coins) {
-  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
+  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN;
   /* Will contain key, coins */
-  uint8_t kr[2 * KYBER_SYMBYTES] ALIGN(16);
+  uint8_t kr[2 * KYBER_SYMBYTES] ALIGN;
 
   memcpy(buf, coins, KYBER_SYMBYTES);
 
@@ -108,7 +108,7 @@ int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
  * Returns 0 (success)
  **************************************************/
 int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
-  uint8_t coins[KYBER_SYMBYTES] ALIGN(16);
+  uint8_t coins[KYBER_SYMBYTES] ALIGN;
   randombytes(coins, KYBER_SYMBYTES);
   crypto_kem_enc_derand(ct, ss, pk, coins);
   return 0;
@@ -133,10 +133,10 @@ int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
  **************************************************/
 int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
   int fail;
-  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN(16);
+  uint8_t buf[2 * KYBER_SYMBYTES] ALIGN;
   /* Will contain key, coins */
-  uint8_t kr[2 * KYBER_SYMBYTES] ALIGN(16);
-  uint8_t cmp[KYBER_CIPHERTEXTBYTES + KYBER_SYMBYTES] ALIGN(16);
+  uint8_t kr[2 * KYBER_SYMBYTES] ALIGN;
+  uint8_t cmp[KYBER_CIPHERTEXTBYTES + KYBER_SYMBYTES] ALIGN;
   const uint8_t *pk = sk + KYBER_INDCPA_SECRETKEYBYTES;
 
   indcpa_dec(buf, ct, sk);

--- a/mlkem/native/x86_64/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/arith_native_x86_64.h
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-#ifndef MLKEM_AARCH64_NATIVE_H
-#define MLKEM_AARCH64_NATIVE_H
+#ifndef MLKEM_X86_64_NATIVE_H
+#define MLKEM_X86_64_NATIVE_H
 
 #include <stdint.h>
 #include "config.h"
 #include "fips202.h"
 #include "params.h"
 
-#ifdef MLKEM_USE_NATIVE_X86_64
+#if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
+
+#include <immintrin.h>
+#include <stdint.h>
 
 #define REJ_UNIFORM_AVX_NBLOCKS \
   ((12 * KYBER_N / 8 * (1 << 12) / KYBER_Q + SHAKE128_RATE) / SHAKE128_RATE)
@@ -15,6 +18,9 @@
 
 // TODO: Document buffer constraints
 unsigned int rej_uniform_avx2(int16_t *r, const uint8_t *buf);
+void ntt_avx2(__m256i *r, const __m256i *qdata);
+void nttpack_avx2(__m256i *r, const __m256i *qdata);
 
-#endif /* MLKEM_USE_NATIVE_X86_64 */
-#endif /* MLKEM_AARCH64_NATIVE_H */
+#endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
+
+#endif /* MLKEM_X86_64_NATIVE_H */

--- a/mlkem/native/x86_64/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/arith_native_x86_64.h
@@ -19,7 +19,9 @@
 // TODO: Document buffer constraints
 unsigned int rej_uniform_avx2(int16_t *r, const uint8_t *buf);
 void ntt_avx2(__m256i *r, const __m256i *qdata);
+void invntt_avx2(__m256i *r, const __m256i *qdata);
 void nttpack_avx2(__m256i *r, const __m256i *qdata);
+void nttunpack_avx2(__m256i *r, const __m256i *qdata);
 
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
 

--- a/mlkem/native/x86_64/consts.h
+++ b/mlkem/native/x86_64/consts.h
@@ -28,15 +28,6 @@
  *
  * This define helps us get around this
  */
-#ifdef __ASSEMBLER__
-#if defined(__WIN32__) || defined(__APPLE__)
-#define decorate(s) _##s
-#define cdecl2(s) decorate(s)
-#define cdecl(s) cdecl2(KYBER_NAMESPACE(##s))
-#else
-#define cdecl(s) KYBER_NAMESPACE(##s)
-#endif
-#endif
 
 #ifndef __ASSEMBLER__
 #include "align.h"

--- a/mlkem/native/x86_64/fq.inc
+++ b/mlkem/native/x86_64/fq.inc
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Implementation from Kyber reference repository
+// https://github.com/pq-crystals/kyber/blob/main/avx2
+
+.macro red16 r,rs=0,x=12
+vpmulhw         %ymm1,%ymm\r,%ymm\x
+.if \rs
+vpmulhrsw	%ymm\rs,%ymm\x,%ymm\x
+.else
+vpsraw          $10,%ymm\x,%ymm\x
+.endif
+vpmullw         %ymm0,%ymm\x,%ymm\x
+vpsubw          %ymm\x,%ymm\r,%ymm\r
+.endm
+
+.macro csubq r,x=12
+vpsubw		%ymm0,%ymm\r,%ymm\r
+vpsraw		$15,%ymm\r,%ymm\x
+vpand		%ymm0,%ymm\x,%ymm\x
+vpaddw		%ymm\x,%ymm\r,%ymm\r
+.endm
+
+.macro caddq r,x=12
+vpsraw		$15,%ymm\r,%ymm\x
+vpand		%ymm0,%ymm\x,%ymm\x
+vpaddw		%ymm\x,%ymm\r,%ymm\r
+.endm
+
+.macro fqmulprecomp al,ah,b,x=12
+vpmullw		%ymm\al,%ymm\b,%ymm\x
+vpmulhw		%ymm\ah,%ymm\b,%ymm\b
+vpmulhw		%ymm0,%ymm\x,%ymm\x
+vpsubw		%ymm\x,%ymm\b,%ymm\b
+.endm

--- a/mlkem/native/x86_64/intt.S
+++ b/mlkem/native/x86_64/intt.S
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Implementation from Kyber reference repository
+// https://github.com/pq-crystals/kyber/blob/main/avx2
+
+#include "config.h"
+
+#if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
+
+#include "consts.h"
+.include "shuffle.inc"
+.include "fq.inc"
+
+.macro butterfly rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3,zl0=2,zl1=2,zh0=3,zh1=3
+vpsubw		%ymm\rl0,%ymm\rh0,%ymm12
+vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rl0
+vpsubw		%ymm\rl1,%ymm\rh1,%ymm13
+
+vpmullw		%ymm\zl0,%ymm12,%ymm\rh0
+vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl1
+vpsubw		%ymm\rl2,%ymm\rh2,%ymm14
+
+vpmullw		%ymm\zl0,%ymm13,%ymm\rh1
+vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl2
+vpsubw		%ymm\rl3,%ymm\rh3,%ymm15
+
+vpmullw		%ymm\zl1,%ymm14,%ymm\rh2
+vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl3
+vpmullw		%ymm\zl1,%ymm15,%ymm\rh3
+
+vpmulhw		%ymm\zh0,%ymm12,%ymm12
+vpmulhw		%ymm\zh0,%ymm13,%ymm13
+
+vpmulhw		%ymm\zh1,%ymm14,%ymm14
+vpmulhw		%ymm\zh1,%ymm15,%ymm15
+
+vpmulhw		%ymm0,%ymm\rh0,%ymm\rh0
+
+vpmulhw		%ymm0,%ymm\rh1,%ymm\rh1
+
+vpmulhw		%ymm0,%ymm\rh2,%ymm\rh2
+vpmulhw		%ymm0,%ymm\rh3,%ymm\rh3
+
+#
+
+#
+
+vpsubw		%ymm\rh0,%ymm12,%ymm\rh0
+
+vpsubw		%ymm\rh1,%ymm13,%ymm\rh1
+
+vpsubw		%ymm\rh2,%ymm14,%ymm\rh2
+vpsubw		%ymm\rh3,%ymm15,%ymm\rh3
+.endm
+
+.macro intt_levels0t5 off
+/* level 0 */
+vmovdqa		_16XFLO*2(%rsi),%ymm2
+vmovdqa		_16XFHI*2(%rsi),%ymm3
+
+vmovdqa         (128*\off+  0)*2(%rdi),%ymm4
+vmovdqa         (128*\off+ 32)*2(%rdi),%ymm6
+vmovdqa         (128*\off+ 16)*2(%rdi),%ymm5
+vmovdqa         (128*\off+ 48)*2(%rdi),%ymm7
+
+fqmulprecomp	2,3,4
+fqmulprecomp	2,3,6
+fqmulprecomp	2,3,5
+fqmulprecomp	2,3,7
+
+vmovdqa         (128*\off+ 64)*2(%rdi),%ymm8
+vmovdqa         (128*\off+ 96)*2(%rdi),%ymm10
+vmovdqa         (128*\off+ 80)*2(%rdi),%ymm9
+vmovdqa         (128*\off+112)*2(%rdi),%ymm11
+
+fqmulprecomp	2,3,8
+fqmulprecomp	2,3,10
+fqmulprecomp	2,3,9
+fqmulprecomp	2,3,11
+
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+208)*2(%rsi),%ymm15
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+176)*2(%rsi),%ymm1
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+224)*2(%rsi),%ymm2
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+192)*2(%rsi),%ymm3
+vmovdqa		_REVIDXB*2(%rsi),%ymm12
+vpshufb		%ymm12,%ymm15,%ymm15
+vpshufb		%ymm12,%ymm1,%ymm1
+vpshufb		%ymm12,%ymm2,%ymm2
+vpshufb		%ymm12,%ymm3,%ymm3
+
+butterfly	4,5,8,9,6,7,10,11,15,1,2,3
+
+/* level 1 */
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+144)*2(%rsi),%ymm2
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+160)*2(%rsi),%ymm3
+vmovdqa		_REVIDXB*2(%rsi),%ymm1
+vpshufb		%ymm1,%ymm2,%ymm2
+vpshufb		%ymm1,%ymm3,%ymm3
+
+butterfly	4,5,6,7,8,9,10,11,2,2,3,3
+
+shuffle1	4,5,3,5
+shuffle1	6,7,4,7
+shuffle1	8,9,6,9
+shuffle1	10,11,8,11
+
+/* level 2 */
+vmovdqa		_REVIDXD*2(%rsi),%ymm12
+vpermd		(_ZETAS_EXP+(1-\off)*224+112)*2(%rsi),%ymm12,%ymm2
+vpermd		(_ZETAS_EXP+(1-\off)*224+128)*2(%rsi),%ymm12,%ymm10
+
+butterfly	3,4,6,8,5,7,9,11,2,2,10,10
+
+vmovdqa		_16XV*2(%rsi),%ymm1
+red16		3
+
+shuffle2	3,4,10,4
+shuffle2	6,8,3,8
+shuffle2	5,7,6,7
+shuffle2	9,11,5,11
+
+/* level 3 */
+vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+80)*2(%rsi),%ymm2
+vpermq		$0x1B,(_ZETAS_EXP+(1-\off)*224+96)*2(%rsi),%ymm9
+
+butterfly	10,3,6,5,4,8,7,11,2,2,9,9
+
+shuffle4	10,3,9,3
+shuffle4	6,5,10,5
+shuffle4	4,8,6,8
+shuffle4	7,11,4,11
+
+/* level 4 */
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+48)*2(%rsi),%ymm2
+vpermq		$0x4E,(_ZETAS_EXP+(1-\off)*224+64)*2(%rsi),%ymm7
+
+butterfly	9,10,6,4,3,5,8,11,2,2,7,7
+
+red16		9
+
+shuffle8	9,10,7,10
+shuffle8	6,4,9,4
+shuffle8	3,5,6,5
+shuffle8	8,11,3,11
+
+/* level 5 */
+vmovdqa		(_ZETAS_EXP+(1-\off)*224+16)*2(%rsi),%ymm2
+vmovdqa		(_ZETAS_EXP+(1-\off)*224+32)*2(%rsi),%ymm8
+
+butterfly	7,9,6,3,10,4,5,11,2,2,8,8
+
+vmovdqa         %ymm7,(128*\off+  0)*2(%rdi)
+vmovdqa         %ymm9,(128*\off+ 16)*2(%rdi)
+vmovdqa         %ymm6,(128*\off+ 32)*2(%rdi)
+vmovdqa         %ymm3,(128*\off+ 48)*2(%rdi)
+vmovdqa         %ymm10,(128*\off+ 64)*2(%rdi)
+vmovdqa         %ymm4,(128*\off+ 80)*2(%rdi)
+vmovdqa         %ymm5,(128*\off+ 96)*2(%rdi)
+vmovdqa         %ymm11,(128*\off+112)*2(%rdi)
+.endm
+
+.macro intt_level6 off
+/* level 6 */
+vmovdqa         (64*\off+  0)*2(%rdi),%ymm4
+vmovdqa         (64*\off+128)*2(%rdi),%ymm8
+vmovdqa         (64*\off+ 16)*2(%rdi),%ymm5
+vmovdqa         (64*\off+144)*2(%rdi),%ymm9
+vpbroadcastq	(_ZETAS_EXP+0)*2(%rsi),%ymm2
+
+vmovdqa         (64*\off+ 32)*2(%rdi),%ymm6
+vmovdqa         (64*\off+160)*2(%rdi),%ymm10
+vmovdqa         (64*\off+ 48)*2(%rdi),%ymm7
+vmovdqa         (64*\off+176)*2(%rdi),%ymm11
+vpbroadcastq	(_ZETAS_EXP+4)*2(%rsi),%ymm3
+
+butterfly	4,5,6,7,8,9,10,11
+
+.if \off == 0
+red16		4
+.endif
+
+vmovdqa		%ymm4,(64*\off+  0)*2(%rdi)
+vmovdqa		%ymm5,(64*\off+ 16)*2(%rdi)
+vmovdqa		%ymm6,(64*\off+ 32)*2(%rdi)
+vmovdqa		%ymm7,(64*\off+ 48)*2(%rdi)
+vmovdqa		%ymm8,(64*\off+128)*2(%rdi)
+vmovdqa		%ymm9,(64*\off+144)*2(%rdi)
+vmovdqa		%ymm10,(64*\off+160)*2(%rdi)
+vmovdqa		%ymm11,(64*\off+176)*2(%rdi)
+.endm
+
+.text
+.global invntt_avx2
+.global _invntt_avx2
+invntt_avx2:
+_invntt_avx2:
+vmovdqa         _16XQ*2(%rsi),%ymm0
+
+intt_levels0t5	0
+intt_levels0t5	1
+
+intt_level6	0
+intt_level6	1
+ret
+
+#endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/ntt.S
+++ b/mlkem/native/x86_64/ntt.S
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Implementation from Kyber reference repository
+// https://github.com/pq-crystals/kyber/blob/main/avx2
+
+#include "config.h"
+
+#if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
+
+#include "consts.h"
+.include "shuffle.inc"
+
+.macro mul rh0,rh1,rh2,rh3,zl0=15,zl1=15,zh0=2,zh1=2
+vpmullw		%ymm\zl0,%ymm\rh0,%ymm12
+vpmullw		%ymm\zl0,%ymm\rh1,%ymm13
+
+vpmullw		%ymm\zl1,%ymm\rh2,%ymm14
+vpmullw		%ymm\zl1,%ymm\rh3,%ymm15
+
+vpmulhw		%ymm\zh0,%ymm\rh0,%ymm\rh0
+vpmulhw		%ymm\zh0,%ymm\rh1,%ymm\rh1
+
+vpmulhw		%ymm\zh1,%ymm\rh2,%ymm\rh2
+vpmulhw		%ymm\zh1,%ymm\rh3,%ymm\rh3
+.endm
+
+.macro reduce
+vpmulhw		%ymm0,%ymm12,%ymm12
+vpmulhw		%ymm0,%ymm13,%ymm13
+
+vpmulhw		%ymm0,%ymm14,%ymm14
+vpmulhw		%ymm0,%ymm15,%ymm15
+.endm
+
+.macro update rln,rl0,rl1,rl2,rl3,rh0,rh1,rh2,rh3
+vpaddw		%ymm\rh0,%ymm\rl0,%ymm\rln
+vpsubw		%ymm\rh0,%ymm\rl0,%ymm\rh0
+vpaddw		%ymm\rh1,%ymm\rl1,%ymm\rl0
+
+vpsubw		%ymm\rh1,%ymm\rl1,%ymm\rh1
+vpaddw		%ymm\rh2,%ymm\rl2,%ymm\rl1
+vpsubw		%ymm\rh2,%ymm\rl2,%ymm\rh2
+
+vpaddw		%ymm\rh3,%ymm\rl3,%ymm\rl2
+vpsubw		%ymm\rh3,%ymm\rl3,%ymm\rh3
+
+vpsubw		%ymm12,%ymm\rln,%ymm\rln
+vpaddw		%ymm12,%ymm\rh0,%ymm\rh0
+vpsubw		%ymm13,%ymm\rl0,%ymm\rl0
+
+vpaddw		%ymm13,%ymm\rh1,%ymm\rh1
+vpsubw		%ymm14,%ymm\rl1,%ymm\rl1
+vpaddw		%ymm14,%ymm\rh2,%ymm\rh2
+
+vpsubw		%ymm15,%ymm\rl2,%ymm\rl2
+vpaddw		%ymm15,%ymm\rh3,%ymm\rh3
+.endm
+
+.macro level0 off
+vpbroadcastq	(_ZETAS_EXP+0)*2(%rsi),%ymm15
+vmovdqa		(64*\off+128)*2(%rdi),%ymm8
+vmovdqa		(64*\off+144)*2(%rdi),%ymm9
+vmovdqa		(64*\off+160)*2(%rdi),%ymm10
+vmovdqa		(64*\off+176)*2(%rdi),%ymm11
+vpbroadcastq	(_ZETAS_EXP+4)*2(%rsi),%ymm2
+
+mul		8,9,10,11
+
+vmovdqa		(64*\off+  0)*2(%rdi),%ymm4
+vmovdqa		(64*\off+ 16)*2(%rdi),%ymm5
+vmovdqa		(64*\off+ 32)*2(%rdi),%ymm6
+vmovdqa		(64*\off+ 48)*2(%rdi),%ymm7
+
+reduce
+update		3,4,5,6,7,8,9,10,11
+
+vmovdqa		%ymm3,(64*\off+  0)*2(%rdi)
+vmovdqa		%ymm4,(64*\off+ 16)*2(%rdi)
+vmovdqa		%ymm5,(64*\off+ 32)*2(%rdi)
+vmovdqa		%ymm6,(64*\off+ 48)*2(%rdi)
+vmovdqa		%ymm8,(64*\off+128)*2(%rdi)
+vmovdqa		%ymm9,(64*\off+144)*2(%rdi)
+vmovdqa		%ymm10,(64*\off+160)*2(%rdi)
+vmovdqa		%ymm11,(64*\off+176)*2(%rdi)
+.endm
+
+.macro levels1t6 off
+/* level 1 */
+vmovdqa		(_ZETAS_EXP+224*\off+16)*2(%rsi),%ymm15
+vmovdqa		(128*\off+ 64)*2(%rdi),%ymm8
+vmovdqa		(128*\off+ 80)*2(%rdi),%ymm9
+vmovdqa		(128*\off+ 96)*2(%rdi),%ymm10
+vmovdqa		(128*\off+112)*2(%rdi),%ymm11
+vmovdqa		(_ZETAS_EXP+224*\off+32)*2(%rsi),%ymm2
+
+mul		8,9,10,11
+
+vmovdqa		(128*\off+  0)*2(%rdi),%ymm4
+vmovdqa	 	(128*\off+ 16)*2(%rdi),%ymm5
+vmovdqa		(128*\off+ 32)*2(%rdi),%ymm6
+vmovdqa		(128*\off+ 48)*2(%rdi),%ymm7
+
+reduce
+update		3,4,5,6,7,8,9,10,11
+
+/* level 2 */
+shuffle8	5,10,7,10
+shuffle8	6,11,5,11
+
+vmovdqa		(_ZETAS_EXP+224*\off+48)*2(%rsi),%ymm15
+vmovdqa		(_ZETAS_EXP+224*\off+64)*2(%rsi),%ymm2
+
+mul		7,10,5,11
+
+shuffle8	3,8,6,8
+shuffle8	4,9,3,9
+
+reduce
+update		4,6,8,3,9,7,10,5,11
+
+/* level 3 */
+shuffle4	8,5,9,5
+shuffle4	3,11,8,11
+
+vmovdqa		(_ZETAS_EXP+224*\off+80)*2(%rsi),%ymm15
+vmovdqa		(_ZETAS_EXP+224*\off+96)*2(%rsi),%ymm2
+
+mul		9,5,8,11
+
+shuffle4	4,7,3,7
+shuffle4	6,10,4,10
+
+reduce
+update		6,3,7,4,10,9,5,8,11
+
+/* level 4 */
+shuffle2	7,8,10,8
+shuffle2	4,11,7,11
+
+vmovdqa		(_ZETAS_EXP+224*\off+112)*2(%rsi),%ymm15
+vmovdqa		(_ZETAS_EXP+224*\off+128)*2(%rsi),%ymm2
+
+mul		10,8,7,11
+
+shuffle2	6,9,4,9
+shuffle2	3,5,6,5
+
+reduce
+update		3,4,9,6,5,10,8,7,11
+
+/* level 5 */
+shuffle1	9,7,5,7
+shuffle1	6,11,9,11
+
+vmovdqa		(_ZETAS_EXP+224*\off+144)*2(%rsi),%ymm15
+vmovdqa		(_ZETAS_EXP+224*\off+160)*2(%rsi),%ymm2
+
+mul		5,7,9,11
+
+shuffle1	3,10,6,10
+shuffle1	4,8,3,8
+
+reduce
+update		4,6,10,3,8,5,7,9,11
+
+/* level 6 */
+vmovdqa		(_ZETAS_EXP+224*\off+176)*2(%rsi),%ymm14
+vmovdqa		(_ZETAS_EXP+224*\off+208)*2(%rsi),%ymm15
+vmovdqa		(_ZETAS_EXP+224*\off+192)*2(%rsi),%ymm8
+vmovdqa		(_ZETAS_EXP+224*\off+224)*2(%rsi),%ymm2
+
+mul		10,3,9,11,14,15,8,2
+
+reduce
+update		8,4,6,5,7,10,3,9,11
+
+vmovdqa		%ymm8,(128*\off+  0)*2(%rdi)
+vmovdqa		%ymm4,(128*\off+ 16)*2(%rdi)
+vmovdqa		%ymm10,(128*\off+ 32)*2(%rdi)
+vmovdqa		%ymm3,(128*\off+ 48)*2(%rdi)
+vmovdqa		%ymm6,(128*\off+ 64)*2(%rdi)
+vmovdqa		%ymm5,(128*\off+ 80)*2(%rdi)
+vmovdqa		%ymm9,(128*\off+ 96)*2(%rdi)
+vmovdqa		%ymm11,(128*\off+112)*2(%rdi)
+.endm
+
+.text
+.global ntt_avx2
+.global _ntt_avx2
+ntt_avx2:
+_ntt_avx2:
+vmovdqa		_16XQ*2(%rsi),%ymm0
+
+level0		0
+level0		1
+
+levels1t6	0
+levels1t6	1
+
+ret
+
+#endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -15,6 +15,7 @@
 
 #define MLKEM_USE_NATIVE_REJ_UNIFORM
 #define MLKEM_USE_NATIVE_NTT
+#define MLKEM_USE_NATIVE_INTT
 
 static inline int rej_uniform_native(int16_t *r, unsigned int len,
                                      const uint8_t *buf, unsigned int buflen) {
@@ -30,6 +31,12 @@ static inline void ntt_native(poly *data) {
   ntt_avx2((__m256i *)data, qdata.vec);
   nttpack_avx2((__m256i *)(data->coeffs), qdata.vec);
   nttpack_avx2((__m256i *)(data->coeffs + KYBER_N / 2), qdata.vec);
+  poly_reduce(data);
+}
+
+static inline void intt_native(poly *data) {
+  nttunpack_avx2((__m256i *)(data->coeffs), qdata.vec);
+  invntt_avx2((__m256i *)data, qdata.vec);
   poly_reduce(data);
 }
 

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -9,8 +9,12 @@
 
 #include "../../arith_native.h"
 #include "../arith_native_x86_64.h"
+#include "../consts.h"
+
+#include "poly.h"
 
 #define MLKEM_USE_NATIVE_REJ_UNIFORM
+#define MLKEM_USE_NATIVE_NTT
 
 static inline int rej_uniform_native(int16_t *r, unsigned int len,
                                      const uint8_t *buf, unsigned int buflen) {
@@ -20,6 +24,13 @@ static inline int rej_uniform_native(int16_t *r, unsigned int len,
   }
 
   return (int)rej_uniform_avx2(r, buf);
+}
+
+static inline void ntt_native(poly *data) {
+  ntt_avx2((__m256i *)data, qdata.vec);
+  nttpack_avx2((__m256i *)(data->coeffs), qdata.vec);
+  nttpack_avx2((__m256i *)(data->coeffs + KYBER_N / 2), qdata.vec);
+  poly_reduce(data);
 }
 
 #endif /* MLKEM_ARITH_NATIVE_PROFILE_H */

--- a/mlkem/native/x86_64/rej_uniform_avx2.c
+++ b/mlkem/native/x86_64/rej_uniform_avx2.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Implementation from Kyber reference repository
-// https://github.com/pq-crystals/kyber/blob/main/avx2/rejsample.c
+// https://github.com/pq-crystals/kyber/blob/main/avx2
 
 #include "config.h"
 

--- a/mlkem/native/x86_64/shuffle.S
+++ b/mlkem/native/x86_64/shuffle.S
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Implementation from Kyber reference repository
+// https://github.com/pq-crystals/kyber/blob/main/avx2
+
+#include "config.h"
+
+#if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
+
+#include "consts.h"
+.include "fq.inc"
+.include "shuffle.inc"
+
+.global nttpack_avx2
+.global _nttpack_avx2
+nttpack_avx2:
+_nttpack_avx2:
+#load
+vmovdqa		(%rdi),%ymm4
+vmovdqa		32(%rdi),%ymm5
+vmovdqa		64(%rdi),%ymm6
+vmovdqa		96(%rdi),%ymm7
+vmovdqa		128(%rdi),%ymm8
+vmovdqa		160(%rdi),%ymm9
+vmovdqa		192(%rdi),%ymm10
+vmovdqa		224(%rdi),%ymm11
+
+shuffle1	4,5,3,5
+shuffle1	6,7,4,7
+shuffle1	8,9,6,9
+shuffle1	10,11,8,11
+
+shuffle2	3,4,10,4
+shuffle2	6,8,3,8
+shuffle2	5,7,6,7
+shuffle2	9,11,5,11
+
+shuffle4	10,3,9,3
+shuffle4	6,5,10,5
+shuffle4	4,8,6,8
+shuffle4	7,11,4,11
+
+shuffle8	9,10,7,10
+shuffle8	6,4,9,4
+shuffle8	3,5,6,5
+shuffle8	8,11,3,11
+
+#store
+vmovdqa		%ymm7,(%rdi)
+vmovdqa		%ymm9,32(%rdi)
+vmovdqa		%ymm6,64(%rdi)
+vmovdqa		%ymm3,96(%rdi)
+vmovdqa		%ymm10,128(%rdi)
+vmovdqa		%ymm4,160(%rdi)
+vmovdqa		%ymm5,192(%rdi)
+vmovdqa		%ymm11,224(%rdi)
+
+ret
+
+#endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/shuffle.S
+++ b/mlkem/native/x86_64/shuffle.S
@@ -57,4 +57,56 @@ vmovdqa		%ymm11,224(%rdi)
 
 ret
 
+nttunpack128_avx2:
+#load
+vmovdqa		(%rdi),%ymm4
+vmovdqa		32(%rdi),%ymm5
+vmovdqa		64(%rdi),%ymm6
+vmovdqa		96(%rdi),%ymm7
+vmovdqa		128(%rdi),%ymm8
+vmovdqa		160(%rdi),%ymm9
+vmovdqa		192(%rdi),%ymm10
+vmovdqa		224(%rdi),%ymm11
+
+shuffle8	4,8,3,8
+shuffle8	5,9,4,9
+shuffle8	6,10,5,10
+shuffle8	7,11,6,11
+
+shuffle4	3,5,7,5
+shuffle4	8,10,3,10
+shuffle4	4,6,8,6
+shuffle4	9,11,4,11
+
+shuffle2	7,8,9,8
+shuffle2	5,6,7,6
+shuffle2	3,4,5,4
+shuffle2	10,11,3,11
+
+shuffle1	9,5,10,5
+shuffle1	8,4,9,4
+shuffle1	7,3,8,3
+shuffle1	6,11,7,11
+
+#store
+vmovdqa		%ymm10,(%rdi)
+vmovdqa		%ymm5,32(%rdi)
+vmovdqa		%ymm9,64(%rdi)
+vmovdqa		%ymm4,96(%rdi)
+vmovdqa		%ymm8,128(%rdi)
+vmovdqa		%ymm3,160(%rdi)
+vmovdqa		%ymm7,192(%rdi)
+vmovdqa		%ymm11,224(%rdi)
+
+ret
+
+.global nttunpack_avx2
+.global _nttunpack_avx2
+nttunpack_avx2:
+_nttunpack_avx2:
+call		nttunpack128_avx2
+add		$256,%rdi
+call		nttunpack128_avx2
+ret
+
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/shuffle.inc
+++ b/mlkem/native/x86_64/shuffle.inc
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+.macro shuffle8 r0,r1,r2,r3
+vperm2i128	$0x20,%ymm\r1,%ymm\r0,%ymm\r2
+vperm2i128	$0x31,%ymm\r1,%ymm\r0,%ymm\r3
+.endm
+
+.macro shuffle4 r0,r1,r2,r3
+vpunpcklqdq	%ymm\r1,%ymm\r0,%ymm\r2
+vpunpckhqdq	%ymm\r1,%ymm\r0,%ymm\r3
+.endm
+
+.macro shuffle2 r0,r1,r2,r3
+#vpsllq		$32,%ymm\r1,%ymm\r2
+vmovsldup	%ymm\r1,%ymm\r2
+vpblendd	$0xAA,%ymm\r2,%ymm\r0,%ymm\r2
+vpsrlq		$32,%ymm\r0,%ymm\r0
+#vmovshdup	%ymm\r0,%ymm\r0
+vpblendd	$0xAA,%ymm\r1,%ymm\r0,%ymm\r3
+.endm
+
+.macro shuffle1 r0,r1,r2,r3
+vpslld		$16,%ymm\r1,%ymm\r2
+vpblendw	$0xAA,%ymm\r2,%ymm\r0,%ymm\r2
+vpsrld		$16,%ymm\r0,%ymm\r0
+vpblendw	$0xAA,%ymm\r1,%ymm\r0,%ymm\r3
+.endm

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -316,8 +316,8 @@ void poly_tomsg(uint8_t msg[KYBER_INDCPA_MSGBYTES], const poly *a) {
 void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                            const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce0,
                            uint8_t nonce1, uint8_t nonce2, uint8_t nonce3) {
-  uint8_t buf[KECCAK_WAY][KYBER_ETA1 * KYBER_N / 4] ALIGN(16);
-  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
+  uint8_t buf[KECCAK_WAY][KYBER_ETA1 * KYBER_N / 4] ALIGN;
+  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN;
   memcpy(extkey[0], seed, KYBER_SYMBYTES);
   memcpy(extkey[1], seed, KYBER_SYMBYTES);
   memcpy(extkey[2], seed, KYBER_SYMBYTES);
@@ -348,7 +348,7 @@ void poly_getnoise_eta1_4x(poly *r0, poly *r1, poly *r2, poly *r3,
  **************************************************/
 void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES],
                         uint8_t nonce) {
-  uint8_t buf[KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
+  uint8_t buf[KYBER_ETA2 * KYBER_N / 4] ALIGN;
   prf(buf, sizeof(buf), seed, nonce);
   poly_cbd_eta2(r, buf);
 }
@@ -368,8 +368,8 @@ void poly_getnoise_eta2(poly *r, const uint8_t seed[KYBER_SYMBYTES],
 void poly_getnoise_eta2_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                            const uint8_t seed[KYBER_SYMBYTES], uint8_t nonce0,
                            uint8_t nonce1, uint8_t nonce2, uint8_t nonce3) {
-  uint8_t buf[KECCAK_WAY][KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
-  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
+  uint8_t buf[KECCAK_WAY][KYBER_ETA2 * KYBER_N / 4] ALIGN;
+  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN;
   memcpy(extkey[0], seed, KYBER_SYMBYTES);
   memcpy(extkey[1], seed, KYBER_SYMBYTES);
   memcpy(extkey[2], seed, KYBER_SYMBYTES);
@@ -402,9 +402,9 @@ void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                               const uint8_t seed[KYBER_SYMBYTES],
                               uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
                               uint8_t nonce3) {
-  uint8_t buf1[KECCAK_WAY / 2][KYBER_ETA1 * KYBER_N / 4] ALIGN(16);
-  uint8_t buf2[KECCAK_WAY / 2][KYBER_ETA2 * KYBER_N / 4] ALIGN(16);
-  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN(16);
+  uint8_t buf1[KECCAK_WAY / 2][KYBER_ETA1 * KYBER_N / 4] ALIGN;
+  uint8_t buf2[KECCAK_WAY / 2][KYBER_ETA2 * KYBER_N / 4] ALIGN;
+  uint8_t extkey[KECCAK_WAY][KYBER_SYMBYTES + 1] ALIGN;
   memcpy(extkey[0], seed, KYBER_SYMBYTES);
   memcpy(extkey[1], seed, KYBER_SYMBYTES);
   memcpy(extkey[2], seed, KYBER_SYMBYTES);

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -14,7 +14,7 @@
  */
 typedef struct {
   int16_t coeffs[KYBER_N];
-} ALIGN(16) poly;
+} ALIGN poly;
 
 /*
  * INTERNAL presentation of precomputed data speeding up

--- a/mlkem/polyvec.h
+++ b/mlkem/polyvec.h
@@ -8,7 +8,7 @@
 
 typedef struct {
   poly vec[KYBER_K];
-} ALIGN(16) polyvec;
+} ALIGN polyvec;
 
 // REF-CHANGE: This struct does not exist in the reference implementation
 typedef struct {

--- a/test/bench_components_kyber.c
+++ b/test/bench_components_kyber.c
@@ -42,10 +42,10 @@ static int cmp_uint64_t(const void *a, const void *b) {
   printf(txt " cycles=%" PRIu64 "\n", (cyc)[NTESTS >> 1] / NITERERATIONS);
 
 static int bench(void) {
-  uint64_t data0[1024] ALIGN(16);
-  uint64_t data1[1024] ALIGN(16);
-  uint64_t data2[1024] ALIGN(16);
-  uint64_t data3[1024] ALIGN(16);
+  uint64_t data0[1024] ALIGN;
+  uint64_t data1[1024] ALIGN;
+  uint64_t data2[1024] ALIGN;
+  uint64_t data3[1024] ALIGN;
   uint64_t cyc[NTESTS];
 
   unsigned int i, j;

--- a/test/gen_KAT.c
+++ b/test/gen_KAT.c
@@ -24,12 +24,12 @@ static void shake256_absorb(shake256incctx *state, const uint8_t *input,
 }
 
 int main(void) {
-  uint8_t coins[3 * KYBER_SYMBYTES] ALIGN(16);
-  uint8_t pk[CRYPTO_PUBLICKEYBYTES] ALIGN(16);
-  uint8_t sk[CRYPTO_SECRETKEYBYTES] ALIGN(16);
-  uint8_t ct[CRYPTO_CIPHERTEXTBYTES] ALIGN(16);
-  uint8_t ss1[CRYPTO_BYTES] ALIGN(16);
-  uint8_t ss2[CRYPTO_BYTES] ALIGN(16);
+  uint8_t coins[3 * KYBER_SYMBYTES] ALIGN;
+  uint8_t pk[CRYPTO_PUBLICKEYBYTES] ALIGN;
+  uint8_t sk[CRYPTO_SECRETKEYBYTES] ALIGN;
+  uint8_t ct[CRYPTO_CIPHERTEXTBYTES] ALIGN;
+  uint8_t ss1[CRYPTO_BYTES] ALIGN;
+  uint8_t ss2[CRYPTO_BYTES] ALIGN;
 
   const uint8_t seed[64] = {
       32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,

--- a/test/gen_NISTKAT.c
+++ b/test/gen_NISTKAT.c
@@ -31,13 +31,13 @@ static void randombytes_nth(uint8_t *seed, size_t nth, size_t len) {
 }
 
 int main(void) {
-  uint8_t seed[48] ALIGN(16);
+  uint8_t seed[48] ALIGN;
   FILE *fh = stdout;
-  uint8_t public_key[CRYPTO_PUBLICKEYBYTES] ALIGN(16);
-  uint8_t secret_key[CRYPTO_SECRETKEYBYTES] ALIGN(16);
-  uint8_t ciphertext[CRYPTO_CIPHERTEXTBYTES] ALIGN(16);
-  uint8_t shared_secret_e[CRYPTO_BYTES] ALIGN(16);
-  uint8_t shared_secret_d[CRYPTO_BYTES] ALIGN(16);
+  uint8_t public_key[CRYPTO_PUBLICKEYBYTES] ALIGN;
+  uint8_t secret_key[CRYPTO_SECRETKEYBYTES] ALIGN;
+  uint8_t ciphertext[CRYPTO_CIPHERTEXTBYTES] ALIGN;
+  uint8_t shared_secret_e[CRYPTO_BYTES] ALIGN;
+  uint8_t shared_secret_d[CRYPTO_BYTES] ALIGN;
   int rc;
 
   int count = 0;


### PR DESCRIPTION
Based on #201 

The AVX2 Kyber NTT produces non-reduced outputs in non-standard order, for better performance. Neither is currently supported by the C<->Native interface.

To accommodate, we temporarily reduce and reorder the output of the AVX2 NTT to match the current C<->Native interface. This will likely need changing later.

Likewise, the inverse NTT operates on a non-standard order that is currently not supported by our C<->Native interface. To accommodate, we shuffle the data in the expected order first before calling the AVX2 iNTT. This may need revisiting later for better performance.
