### PR TITLE
Allow non-standard ordering of polynomials in NTT domain

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -14,6 +14,8 @@
 #include "rej_uniform.h"
 #include "symmetric.h"
 
+#include "arith_native.h"
+
 /*************************************************
  * Name:        pack_pk
  *
@@ -218,6 +220,16 @@ void gen_matrix(polyvec *a, const uint8_t seed[KYBER_SYMBYTES],
       ctr[0] += rej_uniform(vec[0] + ctr[0], KYBER_N - ctr[0], bufx[0], buflen);
     }
   }
+
+#if defined(MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER)
+  // The public matrix is generated in NTT domain. If the native backend
+  // uses a custom order in NTT domain, permute A accordingly.
+  for (i = 0; i < KYBER_K; i++) {
+    for (int j = 0; j < KYBER_K; j++) {
+      poly_permute_bitrev_to_custom(&a[i].vec[j]);
+    }
+  }
+#endif /* MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER */
 }
 
 /*************************************************

--- a/mlkem/native/arith_native.h
+++ b/mlkem/native/arith_native.h
@@ -170,6 +170,24 @@ static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
                                        const poly *a);
 #endif /* MLKEM_USE_NATIVE_POLY_TOBYTES */
 
+#if defined(MLKEM_USE_NATIVE_POLY_FROMBYTES)
+/*************************************************
+ * Name:        poly_frombytes_native
+ *
+ * Description: Serialization of a polynomial.
+ *              Signed coefficients are converted to
+ *              unsigned form before serialization.
+ *
+ * Arguments:   INPUT:
+ *              - r: pointer to output polynomial in NTT domain
+ *              OUTPUT
+ *              - a: const pointer to input byte aray
+ *                   (of KYBER_POLYBYTES bytes)
+ **************************************************/
+static inline void poly_frombytes_native(poly *a,
+                                         const uint8_t r[KYBER_POLYBYTES]);
+#endif /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
+
 #if defined(MLKEM_USE_NATIVE_REJ_UNIFORM)
 /*************************************************
  * Name:        rej_uniform_native

--- a/mlkem/native/profile.h
+++ b/mlkem/native/profile.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+#ifndef MLKEM_ARITH_NATIVE_PROFILE_CHOICE_H
+#define MLKEM_ARITH_NATIVE_PROFILE_CHOICE_H
+
+#include <stdint.h>
+#include "config.h"
+#include "params.h"
+
+#if defined(MLKEM_USE_NATIVE)
+#include "poly.h"
+#include "polyvec.h"
+
+/*
+ * MLKEM native arithmetic profile
+ *
+ * The profile decides which implementation(s) of the arithmetic backend to use.
+ *
+ * If you don't change anything, the default profile will be used. This profile
+ * picks implementations based on characteristics of your system visible to
+ * the compiler.
+ *
+ * If you want to pick a specific profile for your target, there are three ways
+ * to do so, in descending order of convenience to the user:
+ * 1. Pick one of the profiles shipped with this repository.
+ * 2. Provide your own profile and register it via MLKEM_ARITH_NATIVE_PROFILE
+ *    (which must be the profile's path relative to this directoru).
+ * 3. Set MLKEM_ARITH_NATIVE_MANUAL and use an adhoc profile specified via
+ * CFLAGS.
+ */
+
+// Option 2: Manually written profile
+#if defined(MLKEM_ARITH_NATIVE_PROFILE)
+
+#define STRINGIFY_(x) #x
+#define STRINGIFY(x) STRINGIFY_(x)
+#include STRINGIFY(MLKEM_ARITH_NATIVE_PROFILE)
+
+// Option 1: Choose from shipped list of profiles
+#elif !defined(MLKEM_ARITH_NATIVE_MANUAL)
+
+#ifdef SYS_AARCH64
+// For now, we only have clean and opt profiles.
+// In the future, this is likely to branch further depending
+// on the microarchitecture.
+#if defined(MLKEM_USE_NATIVE_AARCH64_CLEAN)
+#include "aarch64/profiles/clean.h"
+#else /* MLKEM_USE_NATIVE_AARCH64_CLEAN */
+#include "aarch64/profiles/opt.h"
+#endif /* !MLKEM_USE_NATIVE_AARCH64_CLEAN */
+#endif /* SYS_AARCH64 */
+
+#ifdef SYS_X86_64_AVX2
+// For now, there's only one x86_64 profile, which is essentially
+// the AVX2 code from the Kyber repository
+// https://github.com/pq-crystals/kyber
+#include "x86_64/profiles/default.h"
+#endif /* SYS_X86_64 */
+
+#else /* !MLKEM_ARITH_NATIVE_PROFILE && MLKEM_ARITH_NATIVE_MANUAL */
+
+/* Option 3: Build your own profile here, or via CFLAGS */
+
+#endif /* !MLKEM_ARITH_NATIVE_PROFILE && !MLKEM_ARITH_NATIVE_MANUAL */
+
+#endif /* MLKEM_USE_NATIVE */
+#endif /* MLKEM_ARITH_NATIVE_PROFILE_CHOICE_H */

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -218,6 +218,7 @@ void poly_tobytes(uint8_t r[KYBER_POLYBYTES], const poly *a) {
 }
 #endif /* MLKEM_USE_NATIVE_POLY_TOBYTES */
 
+#if !defined(MLKEM_USE_NATIVE_POLY_FROMBYTES)
 /*************************************************
  * Name:        poly_frombytes
  *
@@ -243,6 +244,11 @@ void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]) {
         ((a[3 * i + 1] >> 4) | ((uint16_t)a[3 * i + 2] << 4)) & 0xFFF;
   }
 }
+#else /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
+void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]) {
+    poly_frombytes_native(r, a);
+}
+#endif /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
 
 /*************************************************
  * Name:        poly_frommsg

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -244,9 +244,9 @@ void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]) {
         ((a[3 * i + 1] >> 4) | ((uint16_t)a[3 * i + 2] << 4)) & 0xFFF;
   }
 }
-#else /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
+#else  /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
 void poly_frombytes(poly *r, const uint8_t a[KYBER_POLYBYTES]) {
-    poly_frombytes_native(r, a);
+  poly_frombytes_native(r, a);
 }
 #endif /* MLKEM_USE_NATIVE_POLY_FROMBYTES */
 


### PR DESCRIPTION
The reference implementation uses the standard bitreversed
order for polynomials in NTT domain. Some optimized native
implementations, however, may want to use a different order
that's easier to work with, for NTT, invNTT, and base multiplication.

When such custom order is used, the generation of the public matrix
needs adjusting, since it is generated directly in NTT domain.

This commit extends the native arithmetic interface to include
an option MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER and an associated
function poly_permute_bitrev_to_custom(), which can be used to
indicate that the native backend uses a custom order.