### PR TITLE
Add missing use of precomputed mulcache

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -350,7 +350,7 @@ void indcpa_enc(uint8_t c[KYBER_INDCPA_BYTES],
     polyvec_basemul_acc_montgomery_cached(&b.vec[i], &at[i], &sp, &sp_cache);
   }
 
-  polyvec_basemul_acc_montgomery(&v, &pkpv, &sp);
+  polyvec_basemul_acc_montgomery_cached(&v, &pkpv, &sp, &sp_cache);
 
   polyvec_invntt_tomont(&b);
   poly_invntt_tomont(&v);

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -129,26 +129,6 @@ void poly_invntt_tomont(poly *p) { intt_native(p); }
 #endif /* MLKEM_USE_NATIVE_INTT */
 
 /*************************************************
- * Name:        basemul
- *
- * Description: Multiplication of polynomials in Zq[X]/(X^2-zeta)
- *              used for multiplication of elements in Rq in NTT domain
- *
- * Arguments:   - int16_t r[2]: pointer to the output polynomial
- *              - const int16_t a[2]: pointer to the first factor
- *              - const int16_t b[2]: pointer to the second factor
- *              - int16_t zeta: integer defining the reduction polynomial
- **************************************************/
-void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2],
-             int16_t zeta) {
-  r[0] = fqmul(a[1], b[1]);
-  r[0] = fqmul(r[0], zeta);
-  r[0] += fqmul(a[0], b[0]);
-  r[1] = fqmul(a[0], b[1]);
-  r[1] += fqmul(a[1], b[0]);
-}
-
-/*************************************************
  * Name:        basemul_cached
  *
  * Description: Multiplication of polynomials in Zq[X]/(X^2-zeta)

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -15,10 +15,6 @@ void poly_ntt(poly *r);
 #define invntt KYBER_NAMESPACE(invntt)
 void poly_invntt_tomont(poly *r);
 
-#define basemul KYBER_NAMESPACE(basemul)
-void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2],
-             int16_t zeta);
-
 #define basemul_cached KYBER_NAMESPACE(basemul_cached)
 void basemul_cached(int16_t r[2], const int16_t a[2], const int16_t b[2],
                     int16_t b_cached);

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -431,25 +431,6 @@ void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
 }
 
 /*************************************************
- * Name:        poly_basemul_montgomery
- *
- * Description: Multiplication of two polynomials in NTT domain
- *
- * Arguments:   - poly *r: pointer to output polynomial
- *              - const poly *a: pointer to first input polynomial
- *              - const poly *b: pointer to second input polynomial
- **************************************************/
-void poly_basemul_montgomery(poly *r, const poly *a, const poly *b) {
-  unsigned int i;
-  for (i = 0; i < KYBER_N / 4; i++) {
-    basemul(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i],
-            zetas[64 + i]);
-    basemul(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2],
-            -zetas[64 + i]);
-  }
-}
-
-/*************************************************
  * Name:        poly_basemul_montgomery_cached
  *
  * Description: Multiplication of two polynomials in NTT domain,

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -209,8 +209,6 @@ void poly_getnoise_eta1122_4x(poly *r0, poly *r1, poly *r2, poly *r3,
                               uint8_t nonce0, uint8_t nonce1, uint8_t nonce2,
                               uint8_t nonce3);
 
-#define poly_basemul_montgomery KYBER_NAMESPACE(poly_basemul_montgomery)
-void poly_basemul_montgomery(poly *r, const poly *a, const poly *b);
 #define poly_basemul_montgomery_cached \
   KYBER_NAMESPACE(poly_basemul_montgomery_cached)
 void poly_basemul_montgomery_cached(poly *r, const poly *a, const poly *b,

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -215,7 +215,7 @@ void polyvec_basemul_acc_montgomery_cached(poly *r, const polyvec *a,
   unsigned int i;
   poly t;
 
-  poly_basemul_montgomery(r, &a->vec[0], &b->vec[0]);
+  poly_basemul_montgomery_cached(r, &a->vec[0], &b->vec[0], &b_cache->vec[0]);
   for (i = 1; i < KYBER_K; i++) {
     poly_basemul_montgomery_cached(&t, &a->vec[i], &b->vec[i],
                                    &b_cache->vec[i]);


### PR DESCRIPTION
In `indcpa_enc()`, a single vector `sp` is subject to multiple scalar products. For efficiency, a mulcache for `sp` is used for most of them. The final scalar product with `sp`, however, is recomputing the mulcache instead of using the existing one.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
