### PR TITLE
Add AVX2 assembly for base multiplication

### DIFF
--- a/mlkem/native/x86_64/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/arith_native_x86_64.h
@@ -29,6 +29,8 @@ void basemul_avx2(__m256i *r, const __m256i *a, const __m256i *b,
 void polyvec_basemul_acc_montgomery_cached_avx2(
     poly *r, const polyvec *a, const polyvec *b,
     const polyvec_mulcache *b_cache);
+void ntttobytes_avx2(uint8_t *r, const __m256i *a, const __m256i *qdata);
+void nttfrombytes_avx2(__m256i *r, const uint8_t *a, const __m256i *qdata);
 
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
 

--- a/mlkem/native/x86_64/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/arith_native_x86_64.h
@@ -6,6 +6,7 @@
 #include "config.h"
 #include "fips202.h"
 #include "params.h"
+#include "polyvec.h"
 
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
 
@@ -23,6 +24,11 @@ void invntt_avx2(__m256i *r, const __m256i *qdata);
 void nttpack_avx2(__m256i *r, const __m256i *qdata);
 void nttunpack_avx2(__m256i *r, const __m256i *qdata);
 void reduce_avx2(__m256i *r, const __m256i *qdata);
+void basemul_avx2(__m256i *r, const __m256i *a, const __m256i *b,
+                  const __m256i *qdata);
+void polyvec_basemul_acc_montgomery_cached_avx2(
+    poly *r, const polyvec *a, const polyvec *b,
+    const polyvec_mulcache *b_cache);
 
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
 

--- a/mlkem/native/x86_64/basemul.S
+++ b/mlkem/native/x86_64/basemul.S
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Implementation from Kyber reference repository
+// https://github.com/pq-crystals/kyber/blob/main/avx2
+
+#include "config.h"
+
+#if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
+
+#include "consts.h"
+
+.macro schoolbook off
+vmovdqa		_16XQINV*2(%rcx),%ymm0
+vmovdqa		(64*\off+ 0)*2(%rsi),%ymm1		# a0
+vmovdqa		(64*\off+16)*2(%rsi),%ymm2		# b0
+vmovdqa		(64*\off+32)*2(%rsi),%ymm3		# a1
+vmovdqa		(64*\off+48)*2(%rsi),%ymm4		# b1
+
+vpmullw		%ymm0,%ymm1,%ymm9			# a0.lo
+vpmullw		%ymm0,%ymm2,%ymm10			# b0.lo
+vpmullw		%ymm0,%ymm3,%ymm11			# a1.lo
+vpmullw		%ymm0,%ymm4,%ymm12			# b1.lo
+
+vmovdqa		(64*\off+ 0)*2(%rdx),%ymm5		# c0
+vmovdqa		(64*\off+16)*2(%rdx),%ymm6		# d0
+
+vpmulhw		%ymm5,%ymm1,%ymm13			# a0c0.hi
+vpmulhw		%ymm6,%ymm1,%ymm1			# a0d0.hi
+vpmulhw		%ymm5,%ymm2,%ymm14			# b0c0.hi
+vpmulhw		%ymm6,%ymm2,%ymm2			# b0d0.hi
+
+vmovdqa		(64*\off+32)*2(%rdx),%ymm7		# c1
+vmovdqa		(64*\off+48)*2(%rdx),%ymm8		# d1
+
+vpmulhw		%ymm7,%ymm3,%ymm15			# a1c1.hi
+vpmulhw		%ymm8,%ymm3,%ymm3			# a1d1.hi
+vpmulhw		%ymm7,%ymm4,%ymm0			# b1c1.hi
+vpmulhw		%ymm8,%ymm4,%ymm4			# b1d1.hi
+
+vmovdqa		%ymm13,(%rsp)
+
+vpmullw		%ymm5,%ymm9,%ymm13			# a0c0.lo
+vpmullw		%ymm6,%ymm9,%ymm9			# a0d0.lo
+vpmullw		%ymm5,%ymm10,%ymm5			# b0c0.lo
+vpmullw		%ymm6,%ymm10,%ymm10			# b0d0.lo
+
+vpmullw		%ymm7,%ymm11,%ymm6			# a1c1.lo
+vpmullw		%ymm8,%ymm11,%ymm11			# a1d1.lo
+vpmullw		%ymm7,%ymm12,%ymm7			# b1c1.lo
+vpmullw		%ymm8,%ymm12,%ymm12			# b1d1.lo
+
+vmovdqa		_16XQ*2(%rcx),%ymm8
+vpmulhw		%ymm8,%ymm13,%ymm13
+vpmulhw		%ymm8,%ymm9,%ymm9
+vpmulhw		%ymm8,%ymm5,%ymm5
+vpmulhw		%ymm8,%ymm10,%ymm10
+vpmulhw		%ymm8,%ymm6,%ymm6
+vpmulhw		%ymm8,%ymm11,%ymm11
+vpmulhw		%ymm8,%ymm7,%ymm7
+vpmulhw		%ymm8,%ymm12,%ymm12
+
+vpsubw		(%rsp),%ymm13,%ymm13			# -a0c0
+vpsubw		%ymm9,%ymm1,%ymm9			# a0d0
+vpsubw		%ymm5,%ymm14,%ymm5			# b0c0
+vpsubw		%ymm10,%ymm2,%ymm10			# b0d0
+
+vpsubw		%ymm6,%ymm15,%ymm6			# a1c1
+vpsubw		%ymm11,%ymm3,%ymm11			# a1d1
+vpsubw		%ymm7,%ymm0,%ymm7			# b1c1
+vpsubw		%ymm12,%ymm4,%ymm12			# b1d1
+
+vmovdqa		(%r9),%ymm0
+vmovdqa		32(%r9),%ymm1
+vpmullw		%ymm0,%ymm10,%ymm2
+vpmullw		%ymm0,%ymm12,%ymm3
+vpmulhw		%ymm1,%ymm10,%ymm10
+vpmulhw		%ymm1,%ymm12,%ymm12
+vpmulhw		%ymm8,%ymm2,%ymm2
+vpmulhw		%ymm8,%ymm3,%ymm3
+vpsubw		%ymm2,%ymm10,%ymm10			# rb0d0
+vpsubw		%ymm3,%ymm12,%ymm12			# rb1d1
+
+vpaddw		%ymm5,%ymm9,%ymm9
+vpaddw		%ymm7,%ymm11,%ymm11
+vpsubw		%ymm13,%ymm10,%ymm13
+vpsubw		%ymm12,%ymm6,%ymm6
+
+vmovdqa		%ymm13,(64*\off+ 0)*2(%rdi)
+vmovdqa		%ymm9,(64*\off+16)*2(%rdi)
+vmovdqa		%ymm6,(64*\off+32)*2(%rdi)
+vmovdqa		%ymm11,(64*\off+48)*2(%rdi)
+.endm
+
+.text
+.global basemul_avx2
+.global _basemul_avx2
+basemul_avx2:
+_basemul_avx2:
+mov		%rsp,%r8
+and		$-32,%rsp
+sub		$32,%rsp
+
+lea		(_ZETAS_EXP+176)*2(%rcx),%r9
+schoolbook	0
+
+add		$32*2,%r9
+schoolbook	1
+
+add		$192*2,%r9
+schoolbook	2
+
+add		$32*2,%r9
+schoolbook	3
+
+mov		%r8,%rsp
+ret
+
+#endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/basemul.c
+++ b/mlkem/native/x86_64/basemul.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "config.h"
+
+#if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
+
+#include "arith_native_x86_64.h"
+#include "consts.h"
+#include "poly.h"
+#include "polyvec.h"
+
+static void poly_basemul_montgomery_avx2(poly *r, const poly *a,
+                                         const poly *b) {
+  poly tmp0 = *a, tmp1 = *b;
+  // TODO! This needs to be removed once all AVX2 assembly is integrated
+  // and adjusted to the custom coefficient order in NTT domain
+  nttunpack_avx2((__m256i *)tmp0.coeffs, qdata.vec);
+  nttunpack_avx2((__m256i *)tmp1.coeffs, qdata.vec);
+  basemul_avx2((__m256i *)r->coeffs, (const __m256i *)tmp0.coeffs,
+               (const __m256i *)tmp1.coeffs, qdata.vec);
+  nttpack_avx2((__m256i *)(r->coeffs), qdata.vec);
+  nttpack_avx2((__m256i *)(r->coeffs + KYBER_N / 2), qdata.vec);
+}
+
+void polyvec_basemul_acc_montgomery_cached_avx2(
+    poly *r, const polyvec *a, const polyvec *b,
+    const polyvec_mulcache *b_cache) {
+  ((void)b_cache);  // cache unused
+
+  // TODO! Think through bounds
+
+  unsigned int i;
+  poly t;
+
+  poly_basemul_montgomery_avx2(r, &a->vec[0], &b->vec[0]);
+  for (i = 1; i < KYBER_K; i++) {
+    poly_basemul_montgomery_avx2(&t, &a->vec[i], &b->vec[i]);
+    poly_add(r, r, &t);
+  }
+}
+
+#else
+
+// Dummy constant to keep compiler happy despite empty CU
+int empty_cu_avx2_basemul;
+
+#endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -63,7 +63,6 @@ static inline void poly_reduce_native(poly *data) {
 static inline void poly_mulcache_compute_native(poly_mulcache *x,
                                                 const poly *y) {
   // AVX2 backend does not use mulcache
-  ((void)x);
   ((void)y);
 
   // TODO! The mulcache is subject to the absolute bound < q

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -7,6 +7,8 @@
 #else
 #define MLKEM_ARITH_NATIVE_PROFILE_H
 
+#include <string.h>
+
 #include "../../arith_native.h"
 #include "../arith_native_x86_64.h"
 #include "../consts.h"
@@ -17,6 +19,8 @@
 #define MLKEM_USE_NATIVE_NTT
 #define MLKEM_USE_NATIVE_INTT
 #define MLKEM_USE_NATIVE_POLY_REDUCE
+#define MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED
+#define MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE
 
 #define INVNTT_BOUND_NATIVE (KYBER_Q + 1)  // poly_reduce() is in [0,..,KYBER_Q]
 #define NTT_BOUND_NATIVE (KYBER_Q + 1)     // poly_reduce() is in [0,..,KYBER_Q]
@@ -52,6 +56,24 @@ static inline void intt_native(poly *data) {
 
 static inline void poly_reduce_native(poly *data) {
   reduce_avx2((__m256i *)data->coeffs, qdata.vec);
+}
+
+static inline void poly_mulcache_compute_native(poly_mulcache *x,
+                                                const poly *y) {
+  // AVX2 backend does not use mulcache
+  ((void)x);
+  ((void)y);
+
+  // TODO! The mulcache is subject to the absolute bound < q
+  // This needs to be dropped if the mulcache is not present.
+  // Until that's done, memset to 0 to avoid failure.
+  memset(x, 0, sizeof(poly_mulcache));
+}
+
+static inline void polyvec_basemul_acc_montgomery_cached_native(
+    poly *r, const polyvec *a, const polyvec *b,
+    const polyvec_mulcache *b_cache) {
+  polyvec_basemul_acc_montgomery_cached_avx2(r, a, b, b_cache);
 }
 
 #endif /* MLKEM_ARITH_NATIVE_PROFILE_H */

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -21,6 +21,8 @@
 #define MLKEM_USE_NATIVE_POLY_REDUCE
 #define MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED
 #define MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE
+#define MLKEM_USE_NATIVE_POLY_TOBYTES
+#define MLKEM_USE_NATIVE_POLY_FROMBYTES
 
 #define INVNTT_BOUND_NATIVE (KYBER_Q + 1)  // poly_reduce() is in [0,..,KYBER_Q]
 #define NTT_BOUND_NATIVE (KYBER_Q + 1)     // poly_reduce() is in [0,..,KYBER_Q]
@@ -74,6 +76,22 @@ static inline void polyvec_basemul_acc_montgomery_cached_native(
     poly *r, const polyvec *a, const polyvec *b,
     const polyvec_mulcache *b_cache) {
   polyvec_basemul_acc_montgomery_cached_avx2(r, a, b, b_cache);
+}
+
+static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
+                                       const poly *a) {
+  poly tmp = *a;
+  // TODO! This needs to be removed once all AVX2 assembly is integrated
+  // and adjusted to the custom coefficient order in NTT domain
+  nttunpack_avx2((__m256i *)tmp.coeffs, qdata.vec);
+  ntttobytes_avx2(r, (const __m256i *)tmp.coeffs, qdata.vec);
+}
+
+static inline void poly_frombytes_native(poly *r,
+                                         const uint8_t a[KYBER_POLYBYTES]) {
+  nttfrombytes_avx2((__m256i *)r->coeffs, a, qdata.vec);
+  nttpack_avx2((__m256i *)(r->coeffs), qdata.vec);
+  nttpack_avx2((__m256i *)(r->coeffs + KYBER_N / 2), qdata.vec);
 }
 
 #endif /* MLKEM_ARITH_NATIVE_PROFILE_H */

--- a/mlkem/native/x86_64/shuffle.S
+++ b/mlkem/native/x86_64/shuffle.S
@@ -109,4 +109,164 @@ add		$256,%rdi
 call		nttunpack128_avx2
 ret
 
+ntttobytes128_avx:
+#load
+vmovdqa		(%rsi),%ymm5
+vmovdqa		32(%rsi),%ymm6
+vmovdqa		64(%rsi),%ymm7
+vmovdqa		96(%rsi),%ymm8
+vmovdqa		128(%rsi),%ymm9
+vmovdqa		160(%rsi),%ymm10
+vmovdqa		192(%rsi),%ymm11
+vmovdqa		224(%rsi),%ymm12
+
+#csubq
+csubq		5,13
+csubq		6,13
+csubq		7,13
+csubq		8,13
+csubq		9,13
+csubq		10,13
+csubq		11,13
+csubq		12,13
+
+#bitpack
+vpsllw		$12,%ymm6,%ymm4
+vpor		%ymm4,%ymm5,%ymm4
+
+vpsrlw		$4,%ymm6,%ymm5
+vpsllw		$8,%ymm7,%ymm6
+vpor		%ymm5,%ymm6,%ymm5
+
+vpsrlw		$8,%ymm7,%ymm6
+vpsllw		$4,%ymm8,%ymm7
+vpor		%ymm6,%ymm7,%ymm6
+
+vpsllw		$12,%ymm10,%ymm7
+vpor		%ymm7,%ymm9,%ymm7
+
+vpsrlw		$4,%ymm10,%ymm8
+vpsllw		$8,%ymm11,%ymm9
+vpor		%ymm8,%ymm9,%ymm8
+
+vpsrlw		$8,%ymm11,%ymm9
+vpsllw		$4,%ymm12,%ymm10
+vpor		%ymm9,%ymm10,%ymm9
+
+shuffle1	4,5,3,5
+shuffle1	6,7,4,7
+shuffle1	8,9,6,9
+
+shuffle2	3,4,8,4
+shuffle2	6,5,3,5
+shuffle2	7,9,6,9
+
+shuffle4	8,3,7,3
+shuffle4	6,4,8,4
+shuffle4	5,9,6,9
+
+shuffle8	7,8,5,8
+shuffle8	6,3,7,3
+shuffle8	4,9,6,9
+
+#store
+vmovdqu		%ymm5,(%rdi)
+vmovdqu		%ymm7,32(%rdi)
+vmovdqu		%ymm6,64(%rdi)
+vmovdqu		%ymm8,96(%rdi)
+vmovdqu		%ymm3,128(%rdi)
+vmovdqu		%ymm9,160(%rdi)
+
+ret
+
+.global _ntttobytes_avx2
+.global ntttobytes_avx2
+ntttobytes_avx2:
+_ntttobytes_avx2:
+#consts
+vmovdqa		_16XQ*2(%rdx),%ymm0
+call		ntttobytes128_avx
+add		$256,%rsi
+add		$192,%rdi
+call		ntttobytes128_avx
+ret
+
+nttfrombytes128_avx:
+#load
+vmovdqu		(%rsi),%ymm4
+vmovdqu		32(%rsi),%ymm5
+vmovdqu		64(%rsi),%ymm6
+vmovdqu		96(%rsi),%ymm7
+vmovdqu		128(%rsi),%ymm8
+vmovdqu		160(%rsi),%ymm9
+
+shuffle8	4,7,3,7
+shuffle8	5,8,4,8
+shuffle8	6,9,5,9
+
+shuffle4	3,8,6,8
+shuffle4	7,5,3,5
+shuffle4	4,9,7,9
+
+shuffle2	6,5,4,5
+shuffle2	8,7,6,7
+shuffle2	3,9,8,9
+
+shuffle1	4,7,10,7
+shuffle1	5,8,4,8
+shuffle1	6,9,5,9
+
+#bitunpack
+vpsrlw		$12,%ymm10,%ymm11
+vpsllw		$4,%ymm7,%ymm12
+vpor		%ymm11,%ymm12,%ymm11
+vpand		%ymm0,%ymm10,%ymm10
+vpand		%ymm0,%ymm11,%ymm11
+
+vpsrlw		$8,%ymm7,%ymm12
+vpsllw		$8,%ymm4,%ymm13
+vpor		%ymm12,%ymm13,%ymm12
+vpand		%ymm0,%ymm12,%ymm12
+
+vpsrlw		$4,%ymm4,%ymm13
+vpand		%ymm0,%ymm13,%ymm13
+
+vpsrlw		$12,%ymm8,%ymm14
+vpsllw		$4,%ymm5,%ymm15
+vpor		%ymm14,%ymm15,%ymm14
+vpand		%ymm0,%ymm8,%ymm8
+vpand		%ymm0,%ymm14,%ymm14
+
+vpsrlw		$8,%ymm5,%ymm15
+vpsllw		$8,%ymm9,%ymm1
+vpor		%ymm15,%ymm1,%ymm15
+vpand		%ymm0,%ymm15,%ymm15
+
+vpsrlw		$4,%ymm9,%ymm1
+vpand		%ymm0,%ymm1,%ymm1
+
+#store
+vmovdqa		%ymm10,(%rdi)
+vmovdqa		%ymm11,32(%rdi)
+vmovdqa		%ymm12,64(%rdi)
+vmovdqa		%ymm13,96(%rdi)
+vmovdqa		%ymm8,128(%rdi)
+vmovdqa		%ymm14,160(%rdi)
+vmovdqa		%ymm15,192(%rdi)
+vmovdqa		%ymm1,224(%rdi)
+
+ret
+
+.global nttfrombytes_avx2
+.global _nttfrombytes_avx2
+_nttfrombytes_avx2:
+nttfrombytes_avx2:
+#consts
+vmovdqa		_16XMASK*2(%rdx),%ymm0
+call		nttfrombytes128_avx
+add		$256,%rdi
+add		$192,%rsi
+call		nttfrombytes128_avx
+ret
+
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/scripts/tests
+++ b/scripts/tests
@@ -297,7 +297,7 @@ class State(object):
             )
 
             if actual_proc is not None and expect_proc is not None:
-                actual = actual_proc(result)
+                actual = actual_proc(result.encode())
                 expect = expect_proc(scheme)
                 f = actual != expect
                 fail = fail or f


### PR DESCRIPTION
Add AVX2 assembly for base multiplication from official Kyber repository.

Since we don't yet integrate all AVX2 assembly, we need to conjugate the basemul assembly with transformation to/from standard coefficient order and the custom order used by the AVX2 code.