### PR TITLE
fix ci event trigger for labelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action != 'labeled' }}
 
 jobs:
   build_kat:
+    name: Functional tests (${{ matrix.target.name }})
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +39,7 @@ jobs:
                runner: pqcp-x64,
                name: 'ubuntu-latest (x86_64)',
              }}
-    name: Functional tests (${{ matrix.target.name }})
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ci' }}
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -67,6 +68,7 @@ jobs:
       matrix:
         system: [ubuntu-latest]
     name: Linting
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ci' }}
     runs-on: ${{ matrix.system }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The GH action behavior isn't ideal...

Since we need to have the event trigger set as
```
  pull_request:
    branches: ["main"]
    types: [ "labeled", "synchronize" ]
```

concurrency group would need the adjustment to avoid the previous in-progress jobs being cancelled
```
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event.action != 'labeled' }}
```

While setting
```
if: ${{ github.event.action != 'labeled' || github.event.label.name == 'ci' }}
```
could avoiding the job be re-run upon labeled event,

once a label is set, the UI would show that all the newly triggered job is skipped, thus can be merged, while the previous triggered jobs might failed or still in-progress. 
Anyway we can still check all the status at the `checks` tab.

IDK if this is better than the original behavior though 😞 