### PR TITLE
Fix tests and GH cache issue

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -32,6 +32,12 @@ inputs:
   nix-shell:
     description: Run in the specified Nix environment if exists
     default: "ci"
+  nix-cache:
+    description: Determine whether to enable nix cache
+    default: 'true'
+  nix-verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
   custom_shell:
     description: The shell to use. Only relevant if no nix-shell specified
     default: "bash"
@@ -44,6 +50,8 @@ runs:
     - uses: ./.github/actions/setup-shell
       with:
         nix-shell: ${{ inputs.nix-shell }}
+        nix-cache: ${{ inputs.nix-cache }}
+        nix-verbose: ${{ inputs.nix-verbose }}
         custom_shell: ${{ inputs.custom_shell }}
         script: |
           ARCH=$(uname -m)

--- a/.github/actions/cbmc/action.yml
+++ b/.github/actions/cbmc/action.yml
@@ -7,6 +7,12 @@ inputs:
   nix-shell:
     description: Run in the specified Nix environment if exists
     default: "ci-cbmc"
+  nix-cache:
+    description: Determine whether to enable nix cache
+    default: 'true'
+  nix-verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
   custom_shell:
     description: The shell to use. Only relevant if use-nix is 'false'
     default: "bash"
@@ -17,6 +23,8 @@ runs:
       - uses: ./.github/actions/setup-shell
         with:
           nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
           custom_shell: ${{ inputs.custom_shell }}
           script: |
             cat >> $GITHUB_STEP_SUMMARY << EOF

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -7,6 +7,12 @@ inputs:
   nix-shell:
     description: Run in the specified Nix environment if exists
     default: "ci"
+  nix-cache:
+    description: Determine whether to enable nix cache
+    default: 'true'
+  nix-verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
   custom_shell:
     description: The shell to use. Only relevant if no nix-shell specified
     default: "bash"
@@ -55,6 +61,8 @@ runs:
         uses: ./.github/actions/setup-shell
         with:
           nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
           custom_shell: ${{ inputs.custom_shell }}
           script: |
             # only summary on the first time

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -10,6 +10,9 @@ inputs:
   nix-cache:
     description: Determine whether to enable nix cache
     default: "false"
+  nix-verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
   custom_shell:
     description: The shell to use. Only relevant if no nix-shell specified
     default: "bash"
@@ -24,6 +27,7 @@ runs:
           nix-shell: ${{ inputs.nix-shell }}
           custom_shell: ${{ inputs.custom_shell }}
           nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
           script: |
             cat >> $GITHUB_STEP_SUMMARY << EOF
               ## Setup

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -10,6 +10,12 @@ inputs:
   custom_shell:
     description: The shell to use. Only relevant if no nix-shell specified
     default: "bash"
+  nix-cache:
+    description: Determine whether to enable nix cache
+    default: 'true'
+  nix-verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
   cflags:
     description: CFLAGS to pass to compilation
     default: ""
@@ -36,6 +42,8 @@ runs:
         uses: ./.github/actions/functest
         with:
           nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
+          nix-verbose: ${{ inputs.nix-verbose }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           mode: native
@@ -48,6 +56,7 @@ runs:
         uses: ./.github/actions/functest
         with:
           nix-shell: ${{ inputs.nix-shell }}
+          nix-cache: ${{ inputs.nix-cache }}
           custom_shell: ${{ inputs.custom_shell }}
           cflags: ${{ inputs.cflags }}
           mode: native

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -13,6 +13,9 @@ inputs:
   cache:
     description: Determine whether to enable nix cache
     default: 'true'
+  verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
 
 runs:
   using: composite
@@ -59,7 +62,8 @@ runs:
       shell: bash -leo pipefail {0}
       run: |
         echo NIX_SHELL="${{ inputs.devShell }}" >> $GITHUB_ENV
-        echo SHELL="$(which nix) develop --quiet .#${{ inputs.devShell }} -c bash -e {0}" >> $GITHUB_ENV
+        nix_extra_flags="${{ inputs.verbose == 'false' && '--quiet' || '' }}"
+        echo SHELL="$(which nix) develop $nix_extra_flags .#${{ inputs.devShell }} -c bash -e {0}" >> $GITHUB_ENV
     - name: Prepare nix dev shell
       shell: ${{ env.SHELL }}
       run: |

--- a/.github/actions/setup-shell/action.yml
+++ b/.github/actions/setup-shell/action.yml
@@ -13,6 +13,9 @@ inputs:
   nix-cache:
     description: Determine whether to enable nix cache
     default: 'true'
+  nix-verbose:
+    description: Determine wether to suppress nix log or not
+    default: 'false'
   custom_shell:
     description: The shell to use. Only relevant if no nix-shell specified
     default: 'bash'
@@ -28,6 +31,7 @@ runs:
       if: ${{ inputs.use-nix == 'true' && (env.SHELL == '' || env.Nix_SHELL != inputs.nix-shell) }}
       with:
         devShell: ${{ inputs.nix-shell }}
+        verbose: ${{ inputs.nix-verbose }}
         cache: ${{ inputs.nix-cache }}
         script: ${{ inputs.script }}
     - name: Set custom shell

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -32,10 +32,10 @@ on:
         description: Run with optimized code if enabled
         type: boolean
         default: true
-      always_terminate:
-        description: Indicates if EC2 instance should always be terminated
+      verbose:
+        description: Determine for the log verbosity
         type: boolean
-        default: true
+        default: false
       bench_extra_args:
         description: Additional command line to be appended to `tests bench` script
         default: ''
@@ -55,7 +55,7 @@ jobs:
       opt: ${{ inputs.opt }}
       name: ${{ inputs.name }}
       store_results: false
-      always_terminate: ${{ inputs.always_terminate }}
+      verbose: ${{ inputs.verbose }}
       bench_extra_args: ${{ inputs.bench_extra_args }}
       cross_prefix: ${{ inputs.cross_prefix }}
     secrets: inherit

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -36,10 +36,10 @@ on:
         type: boolean
         description: Indicates if results should be pushed to github pages
         default: false
-      always_terminate:
+      verbose:
+        description: Determine for the log verbosity
         type: boolean
-        description: Indicates if instance should always be terminated, even on failure
-        default: true
+        default: false
       bench_extra_args:
         type: string
         description: Additional command line to be appended to `bench` script
@@ -106,7 +106,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bench
         with:
-          nix-shell: bench
+          nix-shell: ci
+          nix-cache: false
+          nix-verbose: ${{ inputs.verbose }}
           name: ${{ inputs.name }}
           cflags: ${{ inputs.cflags }}
           archflags: ${{ inputs.archflags }}
@@ -125,7 +127,7 @@ jobs:
       - start-ec2-runner
       - bench # required to wait when the main job is done
     runs-on: ubuntu-latest
-    if: ${{ (inputs.always_terminate && always()) || success() }} # required to stop the runner even if the error happened in the previous jobs
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci_ec2_any.yml
+++ b/.github/workflows/ci_ec2_any.yml
@@ -24,10 +24,10 @@ on:
       cflags:
         description: Custom CFLAGS for compilation
         default:
-      always_terminate:
-        description: Indicates if instance should always be terminated, even on failure
+      verbose:
+        description: Determine for the log verbosity
         type: boolean
-        default: true
+        default: false
       compile_mode:
         description: Indicates the desired compilation mode (native or cross compilation), or `all` to perform both types, or `none` to skip compilation and functional testing.
         type: choice
@@ -66,5 +66,5 @@ jobs:
       nistkattest: ${{ inputs.compile_mode != 'none' }}
       lint: true
       cbmc: ${{ inputs.cbmc }}
-      always_terminate: ${{ inputs.always_terminate }}
+      verbose: ${{ inputs.verbose }}
     secrets: inherit

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -24,10 +24,10 @@ on:
         type: string
         description: Custom CFLAGS for compilation
         default: ""
-      always_terminate:
+      verbose:
+        description: Determine for the log verbosity
         type: boolean
-        description: Indicates if instance should always be terminated, even on failure
-        default: true
+        default: false
       compile_mode:
         type: string
         description: either all, native, cross or none
@@ -109,6 +109,8 @@ jobs:
       - name: Functional Tests
         uses: ./.github/actions/multi-functest
         with:
+          nix-cache: false
+          nix-verbose: ${{ inputs.verbose }}
           cflags: ${{ inputs.cflags }}
           compile_mode: ${{ inputs.compile_mode }}
           opt: ${{ inputs.opt }}
@@ -120,11 +122,14 @@ jobs:
         uses: ./.github/actions/lint
         with:
           nix-shell: ci-linter
+          nix-cache: false
+          nix-verbose: ${{ inputs.verbose }}
       - name: CBMC
         if: ${{ inputs.cbmc && (success() || failure()) }}
         uses: ./.github/actions/cbmc
         with:
           nix-shell: ci-cbmc
+          nix-verbose: ${{ inputs.verbose }}
   stop-ec2-runner:
     name: Stop ${{ inputs.name }} (${{ inputs.ec2_instance_type }})
     permissions:
@@ -134,7 +139,7 @@ jobs:
       - start-ec2-runner
       - tests
     runs-on: ubuntu-latest
-    if: ${{ (inputs.always_terminate && always()) || success() }} # required to stop the runner even if the error happened in the previous jobs
+    if: ${{ always() }} # required to stop the runner even if the error happened in the previous jobs
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/cbmc/default.nix
+++ b/cbmc/default.nix
@@ -4,6 +4,7 @@
 , callPackage
 , z3_4_12
 , bitwuzla
+, ninja
 }:
 builtins.attrValues {
   cbmc = cbmc.overrideAttrs (old: rec {
@@ -22,6 +23,7 @@ builtins.attrValues {
   cbmc-viewer = callPackage ./cbmc-viewer.nix { }; # 3.9
 
   inherit
+    ninja# 1.11.1
     z3_4_12# 4.12.5
     bitwuzla; # 0.4.0
 }

--- a/flake.nix
+++ b/flake.nix
@@ -46,32 +46,18 @@
           x86_64-gcc = wrap-gcc pkgs.pkgsCross.gnu64;
           aarch64-gcc = wrap-gcc pkgs.pkgsCross.aarch64-multiplatform;
 
-          cross =
-            let
-              gcc_all =
-                if pkgs.stdenv.isDarwin
-                then [ ]
-                else [ aarch64-gcc x86_64-gcc ];
-            in
-            gcc_all;
-
           core =
             let
               gcc =
                 if pkgs.stdenv.isDarwin
                 then [ ]
-                else if pkgs.stdenv.isAarch64
-                then [ aarch64-gcc ]
-                else
-                  [ x86_64-gcc ];
+                else [ aarch64-gcc x86_64-gcc ];
             in
             gcc ++
             builtins.attrValues {
               inherit (pkgs)
                 yq
-                ninja# 1.11.1
-                qemu# 8.2.4
-                cadical;
+                qemu; # 8.2.4
 
               inherit (pkgs.python3Packages)
                 python
@@ -95,8 +81,7 @@
               };
           };
 
-          devShells.bench = wrapShell pkgs.mkShellNoCC { packages = core; };
-          devShells.ci = wrapShell pkgs.mkShellNoCC { packages = core ++ cross; };
+          devShells.ci = wrapShell pkgs.mkShellNoCC { packages = core; };
           devShells.ci-cbmc = wrapShell pkgs.mkShellNoCC { packages = core ++ cbmcpkg; };
           devShells.ci-linter = wrapShell pkgs.mkShellNoCC { packages = linters; };
         };

--- a/scripts/tests
+++ b/scripts/tests
@@ -11,7 +11,7 @@ import hashlib
 import asyncio
 from functools import reduce
 from enum import IntEnum
-from typing import Optional
+from typing import Optional, Callable, TypedDict
 
 
 def config_logger(verbose):
@@ -29,7 +29,7 @@ def config_logger(verbose):
         )
 
 
-def sha256sum(result):
+def sha256sum(result: bytes) -> str:
     m = hashlib.sha256()
     m.update(result)
     return m.hexdigest()
@@ -99,7 +99,7 @@ class SCHEME(IntEnum):
         return self.name.removeprefix("MLKEM")
 
 
-def parse_meta(scheme, field):
+def parse_meta(scheme: SCHEME, field: str) -> str:
     result = subprocess.run(
         [
             "yq",
@@ -117,7 +117,7 @@ def parse_meta(scheme, field):
     return result.stdout.strip()
 
 
-def github_summary(title: str, test: TEST_TYPES, results):
+def github_summary(title: str, test: TEST_TYPES, results: TypedDict):
     summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
 
     res = list(results.values())
@@ -203,7 +203,7 @@ class State(object):
 
     def compile_schemes(
         self,
-        test,
+        test_type: TEST_TYPES,
         extra_make_envs={},
         extra_make_args=[],
     ):
@@ -215,11 +215,11 @@ class State(object):
                 s += f"{k}={v} "
             return s
 
-        logging.debug(f"Compiling {test}...")
+        logging.debug(f"Compiling {test_type}...")
         args = [
             "make",
             f"CROSS_PREFIX={self.cross_prefix}",
-            f"{test}",
+            f"{test_type}",
         ] + extra_make_args
 
         logging.info(dict2str(extra_make_envs) + " ".join(args))
@@ -236,11 +236,15 @@ class State(object):
 
     def run_scheme(
         self,
-        bin,
+        bin: str,
         run_as_root=False,
         exec_wrapper=None,
-    ):
+    ) -> bytes:
         """Run the binary in all different ways"""
+        if not os.path.isfile(bin):
+            logging.error(f"{bin} does not exists")
+            sys.exit(1)
+
         cmd = [f"./{bin}"]
         if self.cross_prefix and platform.system() != "Darwin":
             logging.info(f"Emulating {bin} with QEMU")
@@ -277,27 +281,27 @@ class State(object):
             )
             sys.exit(1)
 
-        return result.stdout.decode()
+        return result.stdout
 
     def run_schemes(
         self,
-        test,
+        test_type: TEST_TYPES,
         run_as_root=False,
         exec_wrapper=None,
-        actual_proc=None,
-        expect_proc=None,
-    ):
+        actual_proc: Callable[[bytes], str] = None,
+        expect_proc: Callable[[SCHEME], str] = None,
+    ) -> TypedDict:
         fail = False
         results = {}
         for scheme in SCHEME:
             result = self.run_scheme(
-                test.bin_path(scheme),
+                test_type.bin_path(scheme),
                 run_as_root,
                 exec_wrapper,
             )
 
             if actual_proc is not None and expect_proc is not None:
-                actual = actual_proc(result.encode())
+                actual = actual_proc(result)
                 expect = expect_proc(scheme)
                 f = actual != expect
                 fail = fail or f
@@ -310,8 +314,8 @@ class State(object):
                 results[scheme] = f
             else:
                 logging.info(f"{scheme}")
-                logging.info(f"\n{result}")
-                results[scheme] = result
+                logging.info(f"\n{result.decode()}")
+                results[scheme] = result.decode()
 
         if fail:
             sys.exit(1)
@@ -320,17 +324,17 @@ class State(object):
 
     def test(
         self,
-        test: TEST_TYPES,
+        test_type: TEST_TYPES,
         extra_make_envs={},
         extra_make_args=[],
-        actual_proc=None,
-        expect_proc=None,
-        run_as_root=False,
-        exec_wrapper=None,
+        actual_proc: Callable[[bytes], str] = None,
+        expect_proc: Callable[[SCHEME], str] = None,
+        run_as_root: bool = False,
+        exec_wrapper: str = None,
     ):
         config_logger(self.verbose)
 
-        logging.info(f"{test.desc()}")
+        logging.info(f"{test_type.desc()}")
 
         make_envs = (
             {"CFLAGS": f"{self.cflags}"} if self.cflags is not None else {}
@@ -341,7 +345,7 @@ class State(object):
 
         if self.compile:
             self.compile_schemes(
-                test,
+                test_type,
                 make_envs,
                 extra_make_args
                 + list(
@@ -353,7 +357,7 @@ class State(object):
         results = None
         if self.run:
             results = self.run_schemes(
-                test,
+                test_type,
                 run_as_root,
                 exec_wrapper,
                 actual_proc,
@@ -367,7 +371,7 @@ class State(object):
                 + ("Opt" if self.opt else "Non-opt")
                 + " Tests"
             )
-            github_summary(title, test, results)
+            github_summary(title, test_type, results)
 
         return results
 
@@ -522,7 +526,7 @@ def cli():
 @add_options(_shared_options)
 @click.make_pass_decorator(State, ensure=True)
 def func(state: State):
-    def expect(scheme):
+    def expect(scheme: SCHEME) -> str:
         sk_bytes = parse_meta(scheme, "length-secret-key")
         pk_bytes = parse_meta(scheme, "length-public-key")
         ct_bytes = parse_meta(scheme, "length-ciphertext")
@@ -577,10 +581,10 @@ def kat(state: State):
 @click.make_pass_decorator(State, ensure=True)
 def bench(
     state: State,
-    cycles,
+    cycles: str,
     output,
-    run_as_root,
-    exec_wrapper,
+    run_as_root: bool,
+    exec_wrapper: str,
     mac_taskpolicy,
     components,
 ):
@@ -667,15 +671,15 @@ def bench(
 @click.make_pass_decorator(State, ensure=True)
 def all(
     state: State,
-    func,
-    kat,
-    nistkat,
+    func: bool,
+    kat: bool,
+    nistkat: bool,
 ):
     opt_flag = "opt" if state.opt else "no-opt"
     auto_flag = "auto" if state.auto else "no-auto"
     compile_mode = "cross" if state.cross_prefix else "native"
 
-    def _cmd(cmd, compile_flag, run_flag):
+    def _cmd(cmd: str, compile_flag: str, run_flag: str) -> [str]:
         return [
             "tests",
             f"{cmd}",
@@ -688,24 +692,24 @@ def all(
             *(["--verbose"] if state.verbose else []),
         ]
 
-    def _cmds(compile_flag, run_flag):
-        return (
-            ([_cmd("func", compile_flag, run_flag)] if func else [])
-            + ([_cmd("kat", compile_flag, run_flag)] if kat else [])
-            + ([_cmd("nistkat", compile_flag, run_flag)] if nistkat else [])
-        )
+    def _cmds(compile_flag: str, run_flag: str) -> TypedDict:
+        return {
+            **({"func": _cmd("func", compile_flag, run_flag)} if func else {}),
+            **({"kat": _cmd("kat", compile_flag, run_flag)} if kat else {}),
+            **({"nistkat": _cmd("nistkat", compile_flag, run_flag)} if nistkat else {}),
+        }
 
-    compile_cmds = [] if not state.compile else _cmds("compile", "no-run")
-    run_cmds = [] if not state.run else _cmds("no-compile", "run")
+    compile_cmds = {} if not state.compile else _cmds("compile", "no-run")
+    run_cmds = {} if not state.run else _cmds("no-compile", "run")
 
     exit_code = 0
 
     gh_env = os.environ.get("GITHUB_ENV")
 
     # sequentially compile
-    for c in compile_cmds:
+    for k, c in compile_cmds.items():
         if gh_env is not None:
-            print(f"::group::compile {compile_mode} {opt_flag} {c[1]} test")
+            print(f"::group::compile {compile_mode} {opt_flag} {k} test")
         result = subprocess.run(
             c,
             encoding="utf-8",
@@ -716,20 +720,22 @@ def all(
         print(result.stdout)
         if result.returncode != 0:
             print(f"{result.stderr}")
+            run_cmds.pop(k, None)
         if gh_env is not None:
             print(f"::endgroup::")
 
     # parallelly run
-    async def run(cmd):
+    async def run(k: str, cmd: str):
         p = await asyncio.create_subprocess_shell(
             " ".join(cmd),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        if gh_env is not None:
-            print(f"::group::run {compile_mode} {opt_flag} {cmd[1]} test")
 
         stdout, stderr = await p.communicate()
+        if gh_env is not None:
+            print(f"::group::run {compile_mode} {opt_flag} {k} test")
+
         if stdout:
             print(stdout.decode())
         if p.returncode != 0 and stderr:
@@ -742,12 +748,11 @@ def all(
     async def run_all():
         ts = []
         async with asyncio.TaskGroup() as g:
-            for cmd in run_cmds:
-
-                ts.append(g.create_task(run(cmd)))
+            for k, cmd in run_cmds.items():
+                ts.append(g.create_task(run(k, cmd)))
         return reduce(lambda acc, c: acc or c, map(lambda t: t.result(), ts), exit_code)
 
-    asyncio.run(run_all())
+    exit_code = asyncio.run(run_all())
     exit(exit_code)
 
 


### PR DESCRIPTION
Currently since we're equipping our shells with both x64_64 and aarch64 gcc and glibc, which results in quite a large cache size, if we were to upload to and fetch the GH cache, we would easily run into GH cache throttling and rate limiting issues.

Therefore, allowing the nix-setup interface to control the use of the GH cache and disabling it in certain scenarios would be better.