### PR TITLE
AVX2: Switch to custom NTT coefficient ordering 

### DIFF
--- a/mlkem/native/x86_64/basemul.c
+++ b/mlkem/native/x86_64/basemul.c
@@ -11,15 +11,8 @@
 
 static void poly_basemul_montgomery_avx2(poly *r, const poly *a,
                                          const poly *b) {
-  poly tmp0 = *a, tmp1 = *b;
-  // TODO! This needs to be removed once all AVX2 assembly is integrated
-  // and adjusted to the custom coefficient order in NTT domain
-  nttunpack_avx2((__m256i *)tmp0.coeffs, qdata.vec);
-  nttunpack_avx2((__m256i *)tmp1.coeffs, qdata.vec);
-  basemul_avx2((__m256i *)r->coeffs, (const __m256i *)tmp0.coeffs,
-               (const __m256i *)tmp1.coeffs, qdata.vec);
-  nttpack_avx2((__m256i *)(r->coeffs), qdata.vec);
-  nttpack_avx2((__m256i *)(r->coeffs + KYBER_N / 2), qdata.vec);
+  basemul_avx2((__m256i *)r->coeffs, (const __m256i *)a->coeffs,
+               (const __m256i *)b->coeffs, qdata.vec);
 }
 
 void polyvec_basemul_acc_montgomery_cached_avx2(

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -15,6 +15,8 @@
 
 #include "poly.h"
 
+#define MLKEM_USE_NATIVE_NTT_CUSTOM_ORDER
+
 #define MLKEM_USE_NATIVE_REJ_UNIFORM
 #define MLKEM_USE_NATIVE_NTT
 #define MLKEM_USE_NATIVE_INTT
@@ -26,6 +28,10 @@
 
 #define INVNTT_BOUND_NATIVE (KYBER_Q + 1)  // poly_reduce() is in [0,..,KYBER_Q]
 #define NTT_BOUND_NATIVE (KYBER_Q + 1)     // poly_reduce() is in [0,..,KYBER_Q]
+
+static inline void poly_permute_bitrev_to_custom(poly *data) {
+  nttunpack_avx2((__m256i *)(data->coeffs), qdata.vec);
+}
 
 static inline int rej_uniform_native(int16_t *r, unsigned int len,
                                      const uint8_t *buf, unsigned int buflen) {
@@ -39,18 +45,13 @@ static inline int rej_uniform_native(int16_t *r, unsigned int len,
 
 static inline void ntt_native(poly *data) {
   ntt_avx2((__m256i *)data, qdata.vec);
-  nttpack_avx2((__m256i *)(data->coeffs), qdata.vec);
-  nttpack_avx2((__m256i *)(data->coeffs + KYBER_N / 2), qdata.vec);
-
   // TODO! Remove this after working out the bounds for
   // the output of the AVX2 NTT
   poly_reduce(data);
 }
 
 static inline void intt_native(poly *data) {
-  nttunpack_avx2((__m256i *)(data->coeffs), qdata.vec);
   invntt_avx2((__m256i *)data, qdata.vec);
-
   // TODO! Remove this after working out the bounds for
   // the output of the AVX2 invNTT
   poly_reduce(data);
@@ -79,18 +80,12 @@ static inline void polyvec_basemul_acc_montgomery_cached_native(
 
 static inline void poly_tobytes_native(uint8_t r[KYBER_POLYBYTES],
                                        const poly *a) {
-  poly tmp = *a;
-  // TODO! This needs to be removed once all AVX2 assembly is integrated
-  // and adjusted to the custom coefficient order in NTT domain
-  nttunpack_avx2((__m256i *)tmp.coeffs, qdata.vec);
-  ntttobytes_avx2(r, (const __m256i *)tmp.coeffs, qdata.vec);
+  ntttobytes_avx2(r, (const __m256i *)a->coeffs, qdata.vec);
 }
 
 static inline void poly_frombytes_native(poly *r,
                                          const uint8_t a[KYBER_POLYBYTES]) {
   nttfrombytes_avx2((__m256i *)r->coeffs, a, qdata.vec);
-  nttpack_avx2((__m256i *)(r->coeffs), qdata.vec);
-  nttpack_avx2((__m256i *)(r->coeffs + KYBER_N / 2), qdata.vec);
 }
 
 #endif /* MLKEM_ARITH_NATIVE_PROFILE_H */

--- a/mlkem/native/x86_64/shuffle.S
+++ b/mlkem/native/x86_64/shuffle.S
@@ -120,16 +120,6 @@ vmovdqa		160(%rsi),%ymm10
 vmovdqa		192(%rsi),%ymm11
 vmovdqa		224(%rsi),%ymm12
 
-#csubq
-csubq		5,13
-csubq		6,13
-csubq		7,13
-csubq		8,13
-csubq		9,13
-csubq		10,13
-csubq		11,13
-csubq		12,13
-
 #bitpack
 vpsllw		$12,%ymm6,%ymm4
 vpor		%ymm4,%ymm5,%ymm4


### PR DESCRIPTION
The AVX2 assembly routines use a custom coefficient ordering in NTT domain, but until now, we've always conjugated the routines with permutations to keep them in standard order. This commit removes those conjugations, switching to using the custom order throughout.