### PR TITLE
Smaller performance improvements of AVX2 backend

### DIFF
--- a/mlkem/native/x86_64/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/arith_native_x86_64.h
@@ -31,6 +31,7 @@ void polyvec_basemul_acc_montgomery_cached_avx2(
     const polyvec_mulcache *b_cache);
 void ntttobytes_avx2(uint8_t *r, const __m256i *a, const __m256i *qdata);
 void nttfrombytes_avx2(__m256i *r, const uint8_t *a, const __m256i *qdata);
+void tomont_avx2(__m256i *r, const __m256i *qdata);
 
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */
 

--- a/mlkem/native/x86_64/basemul.c
+++ b/mlkem/native/x86_64/basemul.c
@@ -15,6 +15,20 @@ static void poly_basemul_montgomery_avx2(poly *r, const poly *a,
                (const __m256i *)b->coeffs, qdata.vec);
 }
 
+// Implementation from Kyber reference repository
+// https://github.com/pq-crystals/kyber/blob/main/avx2
+static void poly_add_avx2(poly *r, const poly *a, const poly *b) {
+  unsigned int i;
+  __m256i f0, f1;
+
+  for (i = 0; i < KYBER_N; i += 16) {
+    f0 = _mm256_load_si256((const __m256i *)&a->coeffs[i]);
+    f1 = _mm256_load_si256((const __m256i *)&b->coeffs[i]);
+    f0 = _mm256_add_epi16(f0, f1);
+    _mm256_store_si256((__m256i *)&r->coeffs[i], f0);
+  }
+}
+
 void polyvec_basemul_acc_montgomery_cached_avx2(
     poly *r, const polyvec *a, const polyvec *b,
     const polyvec_mulcache *b_cache) {
@@ -28,7 +42,7 @@ void polyvec_basemul_acc_montgomery_cached_avx2(
   poly_basemul_montgomery_avx2(r, &a->vec[0], &b->vec[0]);
   for (i = 1; i < KYBER_K; i++) {
     poly_basemul_montgomery_avx2(&t, &a->vec[i], &b->vec[i]);
-    poly_add(r, r, &t);
+    poly_add_avx2(r, r, &t);
   }
 }
 

--- a/mlkem/native/x86_64/fq.S
+++ b/mlkem/native/x86_64/fq.S
@@ -69,4 +69,50 @@ add		$256,%rdi
 call		reduce128_avx2
 ret
 
+
+tomont128_avx2:
+#load
+vmovdqa		(%rdi),%ymm3
+vmovdqa		32(%rdi),%ymm4
+vmovdqa		64(%rdi),%ymm5
+vmovdqa		96(%rdi),%ymm6
+vmovdqa		128(%rdi),%ymm7
+vmovdqa		160(%rdi),%ymm8
+vmovdqa		192(%rdi),%ymm9
+vmovdqa		224(%rdi),%ymm10
+
+fqmulprecomp	1,2,3,11
+fqmulprecomp	1,2,4,12
+fqmulprecomp	1,2,5,13
+fqmulprecomp	1,2,6,14
+fqmulprecomp	1,2,7,15
+fqmulprecomp	1,2,8,11
+fqmulprecomp	1,2,9,12
+fqmulprecomp	1,2,10,13
+
+#store
+vmovdqa		%ymm3,(%rdi)
+vmovdqa		%ymm4,32(%rdi)
+vmovdqa		%ymm5,64(%rdi)
+vmovdqa		%ymm6,96(%rdi)
+vmovdqa		%ymm7,128(%rdi)
+vmovdqa		%ymm8,160(%rdi)
+vmovdqa		%ymm9,192(%rdi)
+vmovdqa		%ymm10,224(%rdi)
+
+ret
+
+.global tomont_avx2
+.global _tomont_avx2
+tomont_avx2:
+_tomont_avx2:
+#consts
+vmovdqa		_16XQ*2(%rsi),%ymm0
+vmovdqa		_16XMONTSQLO*2(%rsi),%ymm1
+vmovdqa		_16XMONTSQHI*2(%rsi),%ymm2
+call		tomont128_avx2
+add		$256,%rdi
+call		tomont128_avx2
+ret
+
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -21,6 +21,7 @@
 #define MLKEM_USE_NATIVE_NTT
 #define MLKEM_USE_NATIVE_INTT
 #define MLKEM_USE_NATIVE_POLY_REDUCE
+#define MLKEM_USE_NATIVE_POLY_TOMONT
 #define MLKEM_USE_NATIVE_POLYVEC_BASEMUL_ACC_MONTGOMERY_CACHED
 #define MLKEM_USE_NATIVE_POLY_MULCACHE_COMPUTE
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
@@ -55,6 +56,10 @@ static inline void intt_native(poly *data) {
 
 static inline void poly_reduce_native(poly *data) {
   reduce_avx2((__m256i *)data->coeffs, qdata.vec);
+}
+
+static inline void poly_tomont_native(poly *data) {
+  tomont_avx2((__m256i *)data->coeffs, qdata.vec);
 }
 
 static inline void poly_mulcache_compute_native(poly_mulcache *x,

--- a/mlkem/native/x86_64/profiles/default.h
+++ b/mlkem/native/x86_64/profiles/default.h
@@ -26,8 +26,10 @@
 #define MLKEM_USE_NATIVE_POLY_TOBYTES
 #define MLKEM_USE_NATIVE_POLY_FROMBYTES
 
-#define INVNTT_BOUND_NATIVE (KYBER_Q + 1)  // poly_reduce() is in [0,..,KYBER_Q]
-#define NTT_BOUND_NATIVE (KYBER_Q + 1)     // poly_reduce() is in [0,..,KYBER_Q]
+#define INVNTT_BOUND_NATIVE \
+  (14870 + 1)  // Bound from the official Kyber repository
+#define NTT_BOUND_NATIVE \
+  (16118 + 1)  // Bound from the official Kyber repository
 
 static inline void poly_permute_bitrev_to_custom(poly *data) {
   nttunpack_avx2((__m256i *)(data->coeffs), qdata.vec);
@@ -45,16 +47,10 @@ static inline int rej_uniform_native(int16_t *r, unsigned int len,
 
 static inline void ntt_native(poly *data) {
   ntt_avx2((__m256i *)data, qdata.vec);
-  // TODO! Remove this after working out the bounds for
-  // the output of the AVX2 NTT
-  poly_reduce(data);
 }
 
 static inline void intt_native(poly *data) {
   invntt_avx2((__m256i *)data, qdata.vec);
-  // TODO! Remove this after working out the bounds for
-  // the output of the AVX2 invNTT
-  poly_reduce(data);
 }
 
 static inline void poly_reduce_native(poly *data) {

--- a/scripts/tests
+++ b/scripts/tests
@@ -626,7 +626,7 @@ def bench(
 
                 lines = [line for line in r.splitlines() if "=" in line]
 
-                d = {k: int(v) for k, v in (l.split("=") for l in lines)}
+                d = {k.strip(): int(v) for k, v in (l.split("=") for l in lines)}
                 for primitive in ["keypair", "encaps", "decaps"]:
                     v.append(
                         {

--- a/test/bench_kyber.c
+++ b/test/bench_kyber.c
@@ -10,7 +10,7 @@
 
 #define NWARMUP 50
 #define NITERATIONS 300
-#define NTESTS 200
+#define NTESTS 500
 
 static int cmp_uint64_t(const void *a, const void *b) {
   return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));

--- a/test/bench_kyber.c
+++ b/test/bench_kyber.c
@@ -9,11 +9,31 @@
 #include "randombytes.h"
 
 #define NWARMUP 50
-#define NITERERATIONS 300
+#define NITERATIONS 300
 #define NTESTS 200
 
 static int cmp_uint64_t(const void *a, const void *b) {
   return (int)((*((const uint64_t *)a)) - (*((const uint64_t *)b)));
+}
+
+static void print_median(const char *txt, uint64_t cyc[NTESTS]) {
+  printf("%10s cycles = %" PRIu64 "\n", txt, cyc[NTESTS >> 1] / NITERATIONS);
+}
+
+static int percentiles[] = {1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 99};
+
+static void print_percentile_legend(void) {
+  printf("%21s", "percentile");
+  for (unsigned i = 0; i < sizeof(percentiles) / sizeof(percentiles[0]); i++)
+    printf("%7d", percentiles[i]);
+  printf("\n");
+}
+
+static void print_percentiles(const char *txt, uint64_t cyc[NTESTS]) {
+  printf("%10s percentiles:", txt);
+  for (unsigned i = 0; i < sizeof(percentiles) / sizeof(percentiles[0]); i++)
+    printf("%7" PRIu64, (cyc)[NTESTS * percentiles[i] / 100] / NITERATIONS);
+  printf("\n");
 }
 
 static int bench(void) {
@@ -39,7 +59,7 @@ static int bench(void) {
     }
 
     t0 = get_cyclecounter();
-    for (j = 0; j < NITERERATIONS; j++) {
+    for (j = 0; j < NITERATIONS; j++) {
       crypto_kem_keypair_derand(pk, sk, kg_rand);
     }
     t1 = get_cyclecounter();
@@ -51,7 +71,7 @@ static int bench(void) {
       crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
     }
     t0 = get_cyclecounter();
-    for (j = 0; j < NITERERATIONS; j++) {
+    for (j = 0; j < NITERATIONS; j++) {
       crypto_kem_enc_derand(ct, key_a, pk, enc_rand);
     }
     t1 = get_cyclecounter();
@@ -62,7 +82,7 @@ static int bench(void) {
       crypto_kem_dec(key_b, ct, sk);
     }
     t0 = get_cyclecounter();
-    for (j = 0; j < NITERERATIONS; j++) {
+    for (j = 0; j < NITERATIONS; j++) {
       crypto_kem_dec(key_b, ct, sk);
     }
     t1 = get_cyclecounter();
@@ -79,12 +99,17 @@ static int bench(void) {
   qsort(cycles_enc, NTESTS, sizeof(uint64_t), cmp_uint64_t);
   qsort(cycles_dec, NTESTS, sizeof(uint64_t), cmp_uint64_t);
 
-  printf("keypair cycles=%" PRIu64 "\n",
-         cycles_kg[NTESTS >> 1] / NITERERATIONS);
-  printf("encaps cycles=%" PRIu64 "\n",
-         cycles_enc[NTESTS >> 1] / NITERERATIONS);
-  printf("decaps cycles=%" PRIu64 "\n",
-         cycles_dec[NTESTS >> 1] / NITERERATIONS);
+  print_median("keypair", cycles_kg);
+  print_median("encaps", cycles_enc);
+  print_median("decaps", cycles_dec);
+
+  printf("\n");
+
+  print_percentile_legend();
+
+  print_percentiles("keypair", cycles_kg);
+  print_percentiles("encaps", cycles_enc);
+  print_percentiles("decaps", cycles_dec);
 
   return 0;
 }
@@ -93,10 +118,6 @@ int main(void) {
   enable_cyclecounter();
   bench();
   disable_cyclecounter();
-
-  printf("CRYPTO_SECRETKEYBYTES:  %d\n", CRYPTO_SECRETKEYBYTES);
-  printf("CRYPTO_PUBLICKEYBYTES:  %d\n", CRYPTO_PUBLICKEYBYTES);
-  printf("CRYPTO_CIPHERTEXTBYTES: %d\n", CRYPTO_CIPHERTEXTBYTES);
 
   return 0;
 }


### PR DESCRIPTION
Previously, the AVX2 NTT and invNTT assembly was suffixed by a call to `poly_reduce()` to ensure polynomial coefficients sufficiently small that the subsequent arithmetic would not overflow.

If we trust the bounds for the output of the NTT and invNTT [provided by the Kyber repository](https://github.com/pq-crystals/kyber/blob/main/avx2/poly.c#L387), those reductions are not necessary: The bounds are already below the contractual bounds for the C<->native interface on the basis of which correctness of the remaining code can be argued.

This PR therefore removes the reductions after the AVX2 NTT and invNTT.

It also modifies the vector-vector native code to use AVX2 intrinsics for the accumulation, and adds an AVX2 version for `poly_tomont()`.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
