### PR TITLE
Set C standard to C99

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -30,6 +30,7 @@ CFLAGS += \
 	-Wno-unknown-pragmas \
 	-O3 \
 	-fomit-frame-pointer \
+        -std=c99 \
 	-pedantic \
 	-MMD \
 	$(CPPFLAGS)

--- a/mlkem/debug/debug.h
+++ b/mlkem/debug/debug.h
@@ -3,6 +3,7 @@
 #define MLKEM_DEBUG_H
 
 #if defined(MLKEM_DEBUG)
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/randombytes/randombytes.c
+++ b/randombytes/randombytes.c
@@ -1,4 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
+
+#if defined(__linux__)
+#if !defined(_GNU_SOURCE)
+/* Ensure that syscall() is declared even when compiling with -std=c99 */
+#define _GNU_SOURCE
+#endif
+#endif
+
 #include "randombytes.h"
 #include <stddef.h>
 #include <stdint.h>
@@ -10,13 +18,8 @@
 #else
 #include <errno.h>
 #include <fcntl.h>
-#ifdef __linux__
-#define _GNU_SOURCE
 #include <sys/syscall.h>
 #include <unistd.h>
-#else
-#include <unistd.h>
-#endif
 #endif
 
 #ifdef _WIN32

--- a/test/hal/hal.c
+++ b/test/hal/hal.c
@@ -22,9 +22,18 @@
  * SOFTWARE.
  *
  */
+
+#if defined(__linux__)
+#if !defined(_GNU_SOURCE)
+/* Ensure that syscall() is declared even when compiling with -std=c99 */
+#define _GNU_SOURCE
+#endif
+#endif
+
 #include "hal.h"
 
 #if defined(PMU_CYCLES)
+
 void enable_cyclecounter(void) {
   uint64_t tmp;
   __asm __volatile(
@@ -56,11 +65,11 @@ uint64_t get_cyclecounter(void) {
 
 #include <asm/unistd.h>
 #include <linux/perf_event.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 static int perf_fd = 0;


### PR DESCRIPTION
MLKEM-C-AArch64 strives to be compatible with a wide range of (old) compilers. Force restriction to C99 to facilitate this.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
