### PR TITLE
Pin clang-tools version to 17.0.6 in nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718086528,
-        "narHash": "sha256-hoB7B7oPgypePz16cKWawPfhVvMSXj4G/qLsfFuhFjw=",
+        "lastModified": 1728740863,
+        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47b604b07d1e8146d5398b42d3306fdebd343986",
+        "rev": "a3f9ad65a0bf298ed5847629a57808b97e6e8077",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,12 @@
           cbmcpkg = pkgs.callPackage ./cbmc { }; # 6.3.1
 
           linters = builtins.attrValues {
+            clang-tools = pkgs.clang-tools.override {
+              clang-unwrapped = pkgs.llvmPackages_17.clang-unwrapped;
+            };
+
             inherit (pkgs)
               nixpkgs-fmt
-              clang-tools
               shfmt;
 
             inherit (pkgs.python3Packages)


### PR DESCRIPTION
Somehow nix clang-tools version control is off between linux and macOS, so we need to pin the clang-tools version for now.

According to the `clang-tools` source code, the version is determined by the parameter `clang-unwrapped`, which is why I do nix override `clang-unwrapped` instead of `version`.

By a quick check, using `llvmPackages_18` would results in quite a large size for the nix derivation, I'm not sure the reason of this, but anyway, sticking to `llvmPacakges_17` for now should be fine