### PR TITLE
Split nix shells to avoid `no more space left on disk` issue for benchmarking on some resource-limited machines

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: true
   nix-shell:
     description: Run in the specified Nix environment if exists
-    default: "ci"
+    default: "bench"
   nix-cache:
     description: Determine whether to enable nix cache
     default: 'true'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bench
         with:
+          nix-cache: false
           name: ${{ matrix.target.name }}
           cflags: ${{ matrix.target.cflags }}
           archflags: ${{ matrix.target.archflags }}

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bench
         with:
-          nix-shell: ci
+          nix-shell: bench
           nix-cache: false
           nix-verbose: ${{ inputs.verbose }}
           name: ${{ inputs.name }}


### PR DESCRIPTION
`Bench` shell is added, and `ci-cbmc` and `bench` shell are set to only
include the native gcc as cross gcc is not needed in these cases.

nix cache is disabled for all bench jobs, let's only used nix cache for cbmc to avoid cache hassels