### PR TITLE
Add 'out of the box' make to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  quickcheck:
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: pqcp-arm64
+           name: 'aarch64'
+         - runner: pqcp-x64
+           name: 'x86_64'
+        exclude:
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'aarch64'
+             }}
+          - {external: true,
+             target: {
+               runner: pqcp-x64,
+               name: 'x86_64'
+             }}
+    name: Quickcheck (${{ matrix.target.name }})
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: quickcheck
+        run: |
+          OPT=0 make quickcheck >/dev/null
+          make clean            >/dev/null
+          OPT=1 make quickcheck >/dev/null
   build_kat:
+    needs: quickcheck
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +107,7 @@ jobs:
           nix-shell: ci-linter
           cross-prefix: "aarch64-unknown-linux-gnu-"
   ec2_all:
+    needs: quickcheck
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-.PHONY: mlkem kat nistkat clean
+.PHONY: mlkem kat nistkat clean quickcheck buildall
+
+buildall:
+	$(Q)$(MAKE) mlkem
+	$(Q)$(MAKE) nistkat
+	$(Q)$(MAKE) kat
+	$(Q)echo "  ALL GOOD!"
 
 include mk/config.mk
 -include mk/$(MAKECMDGOALS).mk
 include mk/crypto.mk
 include mk/schemes.mk
 include mk/rules.mk
+
+quickcheck:
+	$(Q)$(MAKE) mlkem
+	$(MLKEM512_DIR)/bin/test_kyber512
+	$(MLKEM768_DIR)/bin/test_kyber768
+	$(MLKEM1024_DIR)/bin/test_kyber1024
+	$(Q)$(MAKE) nistkat
+	$(MLKEM512_DIR)/bin/gen_NISTKAT512
+	$(MLKEM768_DIR)/bin/gen_NISTKAT768
+	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024
+	$(Q)$(MAKE) kat
+	$(MLKEM512_DIR)/bin/gen_KAT512
+	$(MLKEM768_DIR)/bin/gen_KAT768
+	$(MLKEM1024_DIR)/bin/gen_KAT1024
+	$(Q)echo "  ALL GOOD!"
 
 mlkem: \
   $(MLKEM512_DIR)/bin/test_kyber512 \


### PR DESCRIPTION
This PR adds another job to the CI workflow which runs out of the box `make quickcheck`on aarch64-ubuntu
and x86_64-ubuntu. With the exception of `lint` which is always run, other jobs are only run if this succeeds.