### PR TITLE
Allow makefile to be compatible with make 3.8

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -1,5 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-$(BUILD_DIR)/%: $(LINKDEPS) $(CONFIG)
+$(BUILD_DIR)/mlkem512/bin/%: $(LINKDEPS) $(CONFIG)
+	$(Q)echo "  LD      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+
+$(BUILD_DIR)/mlkem768/bin/%: $(LINKDEPS) $(CONFIG)
+	$(Q)echo "  LD      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
+
+$(BUILD_DIR)/mlkem1024/bin/%: $(LINKDEPS) $(CONFIG)
 	$(Q)echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(LD) $(CFLAGS) -o $@ $(filter %.o,$^) $(LDLIBS)
@@ -12,6 +22,7 @@ $(LIB_DIR)/%.a: $(CONFIG)
 
 $(BUILD_DIR)/%.c.o: %.c $(CONFIG)
 	$(Q)echo "  CC      $@"
+	$(Q)echo "  CC      $(CFLAGS)"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
 


### PR DESCRIPTION
Make 3.8.1 has more restricted support for target pattern matching. By making the make rules more explicit, we ensure compatibility with different make versions and avoid ambiguity.
