### PR TITLE
Allow overwriting default values CC, CPP, AR, LD

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -41,19 +41,22 @@ runs:
         shell: bash
         run: |
           arch=$(uname -m)
-          if [[ $arch == "x86_64" ]]; then
+          _cross_prefix=
+          if [[ ${{ inputs.mode }} == "cross" && $arch == "x86_64" ]]; then
               _cross_prefix="aarch64-unknown-linux-gnu-"
-          elif [[ $arch == "aarch64" ]]; then
+          elif [[ ${{ inputs.mode }} == "cross" && $arch == "aarch64" ]]; then
               _cross_prefix="x86_64-unknown-linux-gnu-"
           fi
 
-          if [[ ${{ inputs.mode }} == "cross" ]]; then
-              cross_prefix="$_cross_prefix"
+          _cc=$CC
+          if [[ $_cc == "" ]]; then
+             _cc=gcc
           fi
-          echo _CROSS_PREFIX="$_cross_prefix" >> $GITHUB_ENV # this is for printing summary only, which doesn't depend on inputs.mode
-          echo CROSS_PREFIX="$cross_prefix" >> $GITHUB_ENV
-          echo OPT="${{ inputs.opt == 'true' && 'opt' || 'no-opt' }}" >> $GITHUB_ENV
 
+          echo _CROSS_PREFIX="$_cross_prefix" >> $GITHUB_ENV
+          echo _CC="$_cc" >> $GITHUB_ENV
+
+          echo OPT="${{ inputs.opt == 'true' && 'opt' || 'no-opt' }}" >> $GITHUB_ENV
           echo FUNC="${{ inputs.func == 'true' && 'func' || 'no-func' }}" >> $GITHUB_ENV
           echo KAT="${{ inputs.kat == 'true' && 'kat' || 'no-kat' }}" >> $GITHUB_ENV
           echo NISTKAT="${{ inputs.nistkat == 'true' && 'nistkat' || 'no-nistkat' }}" >> $GITHUB_ENV
@@ -74,23 +77,18 @@ runs:
               - $(uname -a)
               - $(nix --version)
               - $(bash --version | grep -m1 "")
-              - $(gcc --version | grep -m1 "")
+              - $(${_CROSS_PREFIX}${_CC} --version | grep -m1 "")
             EOF
-
-              # no cross gcc in darwin
-              if [[ $(uname -s) != "Darwin" ]]; then
-                echo "- $(${{ env._CROSS_PREFIX }}gcc --version | grep -m1 '')" >> $GITHUB_STEP_SUMMARY
-              fi
             fi
 
       - name: Compile ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
-          tests all  --cross-prefix="${{ env.CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --${{ env.OPT }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --compile --no-run -v
+          tests all  --cross-prefix="${{ env._CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --${{ env.OPT }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --compile --no-run -v
       - name: Run ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |
-          tests all  --cross-prefix="${{ env.CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --${{ env.OPT }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --no-compile --run -v
+          tests all  --cross-prefix="${{ env._CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --${{ env.OPT }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --no-compile --run -v
       - name: Post ${{ inputs.mode }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,10 @@
                 then [ ]
                 else
                   if cross
-                  then [ aarch64-gcc x86_64-gcc ]
+                  then
+                    if pkgs.stdenv.isAarch64
+                    then [ x86_64-gcc aarch64-gcc ]
+                    else [ aarch64-gcc x86_64-gcc ]
                   else
                     if pkgs.stdenv.isAarch64
                     then [ aarch64-gcc ]

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -7,21 +7,16 @@ SRCDIR := $(CURDIR)
 ##############
 # GCC config #
 ##############
+
 CROSS_PREFIX ?=
+CC  ?= gcc
+CPP ?= cpp
+AR  ?= ar
 
-ifeq ($(CC),)
-CC := $(CROSS_PREFIX)gcc
-endif
-
-ifeq ($(CPP),)
-CPP := $(CROSS_PREFIX)cpp
-endif
-
-ifeq ($(AR),)
-AR := $(CROSS_PREFIX)ar
-endif
-
-LD := $(CC)
+CC  := $(CROSS_PREFIX)$(CC)
+CPP := $(CROSS_PREFIX)$(CPP)
+AR  := $(CROSS_PREFIX)$(AR)
+LD  := $(CC)
 OBJCOPY := $(CROSS_PREFIX)objcopy
 SIZE := $(CROSS_PREFIX)size
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -8,9 +8,19 @@ SRCDIR := $(CURDIR)
 # GCC config #
 ##############
 CROSS_PREFIX ?=
+
+ifeq ($(CC),)
 CC := $(CROSS_PREFIX)gcc
+endif
+
+ifeq ($(CPP),)
 CPP := $(CROSS_PREFIX)cpp
+endif
+
+ifeq ($(AR),)
 AR := $(CROSS_PREFIX)ar
+endif
+
 LD := $(CC)
 OBJCOPY := $(CROSS_PREFIX)objcopy
 SIZE := $(CROSS_PREFIX)size

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -22,7 +22,7 @@ $(LIB_DIR)/%.a: $(CONFIG)
 
 $(BUILD_DIR)/%.c.o: %.c $(CONFIG)
 	$(Q)echo "  CC      $@"
-	$(Q)echo "  CC      $(CFLAGS)"
+	$(Q)echo "  $(CC) -c -o $@ $(CFLAGS) $<"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
 


### PR DESCRIPTION
This commit changes the Makefiles so that the developer can write

```
CC=XXX make ...
```

to overwrite the default compiler choice `gcc` with `XXX`.

This is useful for quick exploration of different compiler choices.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
