### PR TITLE
Add `tests func` to quickcheck CI

### DIFF
--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install base packages
       shell: bash
       run: |
-        sudo apt-get install python3-venv python3-pip make -y
+        sudo apt-get install python3-venv python3-pip make jq -y
     - name: Install additional packages
       if: ${{ inputs.packages != ''}}
       shell: bash

--- a/.github/actions/setup-ubuntu/action.yml
+++ b/.github/actions/setup-ubuntu/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Install base packages
       shell: bash
       run: |
-        sudo apt-get install python3-venv python3-pip make jq -y
+        sudo apt-get install python3-venv python3-pip make -y
     - name: Install additional packages
       if: ${{ inputs.packages != ''}}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,15 @@ jobs:
     runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@v4
-      - name: quickcheck
+      - name: make quickcheck
         run: |
           OPT=0 make quickcheck >/dev/null
           make clean            >/dev/null
           OPT=1 make quickcheck >/dev/null
+      - uses: ./.github/actions/setup-ubuntu
+      - name: tests func
+        run: |
+          ./scripts/tests func
   build_kat:
     needs: quickcheck
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ buildall:
 	$(Q)$(MAKE) mlkem
 	$(Q)$(MAKE) nistkat
 	$(Q)$(MAKE) kat
-	$(Q)echo "  ALL GOOD!"
+	$(Q)echo "  Everything builds fine!"
 
 include mk/config.mk
 -include mk/$(MAKECMDGOALS).mk
@@ -16,19 +16,16 @@ include mk/schemes.mk
 include mk/rules.mk
 
 quickcheck:
+        # Check that everything builds
 	$(Q)$(MAKE) mlkem
+	$(Q)$(MAKE) nistkat
+	$(Q)$(MAKE) kat
+	$(Q)echo "  Everything builds fine!"
+        # Run basic functionality checks
 	$(MLKEM512_DIR)/bin/test_kyber512
 	$(MLKEM768_DIR)/bin/test_kyber768
 	$(MLKEM1024_DIR)/bin/test_kyber1024
-	$(Q)$(MAKE) nistkat
-	$(MLKEM512_DIR)/bin/gen_NISTKAT512
-	$(MLKEM768_DIR)/bin/gen_NISTKAT768
-	$(MLKEM1024_DIR)/bin/gen_NISTKAT1024
-	$(Q)$(MAKE) kat
-	$(MLKEM512_DIR)/bin/gen_KAT512
-	$(MLKEM768_DIR)/bin/gen_KAT768
-	$(MLKEM1024_DIR)/bin/gen_KAT1024
-	$(Q)echo "  ALL GOOD!"
+	$(Q)echo "  Functionality tests passed!"
 
 mlkem: \
   $(MLKEM512_DIR)/bin/test_kyber512 \

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
                 qemu; # 8.2.4
 
               inherit (pkgs.python3Packages)
+                pyyaml
                 python
                 click;
             };

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 click
-yq==3.4.3
+pyyaml==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 click
 yq==3.4.3
-jq==1.8.0

--- a/scripts/tests
+++ b/scripts/tests
@@ -8,6 +8,7 @@ import subprocess
 import logging
 import click
 import hashlib
+import yaml
 import asyncio
 from functools import reduce
 from enum import IntEnum
@@ -100,21 +101,9 @@ class SCHEME(IntEnum):
 
 
 def parse_meta(scheme: SCHEME, field: str) -> str:
-    result = subprocess.run(
-        [
-            "yq",
-            "-r",
-            "--arg",
-            "scheme",
-            str(scheme),
-            f'.implementations.[] | select(.name == $scheme) | ."{field}"',
-            "./META.yml",
-        ],
-        capture_output=True,
-        encoding="utf-8",
-        universal_newlines=False,
-    )
-    return result.stdout.strip()
+    with open("META.yml", "r") as f:
+        meta = yaml.safe_load(f)
+    return meta["implementations"][int(scheme) - 1][field]
 
 
 def github_summary(title: str, test: TEST_TYPES, results: TypedDict):


### PR DESCRIPTION
Previously, the quickcheck CI (which guards other CI jobs)
would only run `make quickcheck`, but not exercise the `tests`
script.

This commit adds an invocation of `tests all` to the quickcheck CI,
after setting up the necessary dependencies via the newly introduced
`setup-ubuntu` action.
