### PR TITLE
Variant of "Nix cache enhancement in CI and ping clang-tools version to 17.0.6 "

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -34,7 +34,7 @@ inputs:
     default: "ci"
   nix-cache:
     description: Determine whether to enable nix cache
-    default: 'true'
+    default: 'false'
   nix-verbose:
     description: Determine wether to suppress nix log or not
     default: 'false'

--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: true
   nix-shell:
     description: Run in the specified Nix environment if exists
-    default: "bench"
+    default: "ci"
   nix-cache:
     description: Determine whether to enable nix cache
     default: 'true'

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: "ci"
   nix-cache:
     description: Determine whether to enable nix cache
-    default: 'true'
+    default: 'false'
   nix-verbose:
     description: Determine wether to suppress nix log or not
     default: 'false'

--- a/.github/actions/multi-functest/action.yml
+++ b/.github/actions/multi-functest/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "bash"
   nix-cache:
     description: Determine whether to enable nix cache
-    default: 'true'
+    default: 'false'
   nix-verbose:
     description: Determine wether to suppress nix log or not
     default: 'false'

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -12,10 +12,17 @@ inputs:
     required: true
   cache:
     description: Determine whether to enable nix cache
-    default: 'true'
+    default: 'false'
   verbose:
     description: Determine wether to suppress nix log or not
     default: 'false'
+  cache_prefix:
+    description: Fixed prefix of ID of Github cache entries that should be removed.
+    required: false
+  purge_cache:
+    description: Determine whether to purge cache with primary key or not
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -69,6 +76,26 @@ runs:
         EOF
         fi
 
+        if [[ ! -z $GH_TOKEN ]]; then
+           mkdir -p ~/.config/nix
+           echo "access-tokens = github.com=$GH_TOKEN" > ~/.config/nix/nix.conf
+        fi
+
+        if command -v gh >/dev/null 2>&1; then
+          limit=$(gh api rate_limit --jq '.rate.remaining')
+          reset=$(gh api rate_limit --jq '.rate.reset')
+          now=$(date +%s)
+          if [[ $limit < 10 ]]; then
+            wait=$(( reset - now ))
+            echo "Rate limit remaining is $limit less then 10, waiting for $wait secs to retry"
+            sleep $wait
+          else
+            echo "Rate limit remaining is $limit greater than 10, no need to wait"
+          fi
+        else
+            echo "GitHub CLI is not installed."
+        fi
+
         if [[ $NIX_INSTALL_MODE == 'multi' ]]; then
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
         else
@@ -78,19 +105,49 @@ runs:
         nix profile install nixpkgs/nixos-24.05#sqlite
         echo "::endgroup::"
     - name: Post-check nix
+      id: nix-post-check
       continue-on-error: true
       shell: bash -lo pipefail {0}
       run: |
+        echo "::group::nix config"
+        if [[ -z "${{ inputs.cache_prefix }}" ]]; then
+          cache_prefix="${{ runner.os }}-${{ runner.arch }}-${{ inputs.devShell }}"
+        else
+          cache_prefix="${{ inputs.cache_prefix }}"
+        fi
+        if [[ ! -z $NIX_INSTALL_MODE ]]; then
+          cache_prefix="$cache_prefix-$NIX_INSTALL_MODE"
+        fi
+
+        echo "cache_prefix=$cache_prefix" >> $GITHUB_OUTPUT
+
         nix config check
-    - uses: DeterminateSystems/magic-nix-cache-action@v8
-      if: ${{ env.NIX_SHELL == '' && inputs.cache == 'true' }}
+        nix config show
+        echo "::endgroup::"
+    - uses: nix-community/cache-nix-action@v5
+      id: cache
+      if: ${{ env.NIX_CACHE_ENABLED != 1 && inputs.cache == 'true' }}
       continue-on-error: true
+      with:
+        primary-key: ${{ steps.nix-post-check.outputs.cache_prefix }}-${{ hashFiles('**/*.nix') }}
+        restore-prefixes-first-match: ${{ steps.nix-post-check.outputs.cache_prefix }}
+        gc-max-store-size-linux: 536870912
+        purge: ${{ inputs.purge_cache == 'true' }}
+        purge-prefixes: cache-${{ steps.nix-post-check.outputs.cache_prefix }}
+        purge-created: 0
+        purge-primary-key: ${{ inputs.purge_cache == 'true' && 'always' || 'never' }}
     - name: Set Shell
       shell: bash -lo pipefail {0}
       run: |
+        echo "::group::set nix shell"
+        if [[ "${{ steps.cache.outputs.hit-primary-key }}" == "true" ]]; then
+          echo NIX_CACHE_ENABLED=1 >> $GITHUB_ENV
+        fi
+
         echo NIX_SHELL="${{ inputs.devShell }}" >> $GITHUB_ENV
         nix_extra_flags="${{ inputs.verbose == 'false' && '--quiet' || '' }}"
         echo SHELL="$(which nix) develop $nix_extra_flags .#${{ inputs.devShell }} -c bash -e {0}" >> $GITHUB_ENV
+        echo "::endgroup::"
     - name: Prepare nix dev shell
       shell: ${{ env.SHELL }}
       run: |

--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -20,8 +20,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Nix install mode
+      shell: bash
+      run: |
+        if [[ ${{ runner.os }} != 'Linux' || $USER == 'root' ]]; then
+          echo "NIX_INSTALL_MODE=multi" >> $GITHUB_ENV
+        fi
     - name: Pre-check nix
-      id: pre-check-nix
+      id: nix-pre-check
       if: ${{ env.NIX_SHELL == '' }}
       shell: bash -lo pipefail {0}
       run: |
@@ -29,37 +35,58 @@ runs:
           local exit_code="$?"
           local line_no="$1"
           echo "Nix check failed at $line_no: $exit_code"
-          echo "install-nix=true" >> $GITHUB_OUTPUT
+          echo "installed=false" >> $GITHUB_OUTPUT
           exit 0
         }
 
         trap 'suppress $LINENO' ERR
 
-        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
         nix --version
         nix config show | grep -E "^trusted-users = .*$USER"
         nix config show | grep -E "^experimental-features = .*flakes"
         nix config show | grep -E "^experimental-features = .*nix-command"
-
-    - name: Install nix
-      if: steps.pre-check-nix.outputs.install-nix
-      shell: bash -leo pipefail {0}
+    - name: Install Nix
+      shell: bash
+      if: ${{ steps.nix-pre-check.outputs.installed == 'false' }}
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
-        --extra-conf "trusted-users = root ${USER:-}" \
-        --extra-conf "experimental-features = nix-command flakes"
+        echo "::group::Nix installation"
+        mkdir -p ~/.config/nix
 
-        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        if [[ $NIX_INSTALL_MODE == 'multi' ]]; then
+          curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install \
+          --no-confirm \
+          --extra-conf "trusted-users = ${USER:-}" \
+          --extra-conf "experimental-features = nix-command flakes"
+        else
+          sh <(curl -L https://nixos.org/nix/install) --no-daemon
+
+        cat >> ~/.config/nix/nix.conf << EOF
+          trusted-users = ${USER:-}
+          experimental-features = nix-command flakes
+          substituters = https://cache.nixos.org/
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          max-jobs = auto
+        EOF
+        fi
+
+        if [[ $NIX_INSTALL_MODE == 'multi' ]]; then
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        else
+          . ~/.nix-profile/etc/profile.d/nix.sh
+        fi
+        echo "$(dirname $(which nix))" >> $GITHUB_PATH
+        nix profile install nixpkgs/nixos-24.05#sqlite
+        echo "::endgroup::"
     - name: Post-check nix
       continue-on-error: true
-      shell: bash -leo pipefail {0}
+      shell: bash -lo pipefail {0}
       run: |
         nix config check
     - uses: DeterminateSystems/magic-nix-cache-action@v8
       if: ${{ env.NIX_SHELL == '' && inputs.cache == 'true' }}
       continue-on-error: true
     - name: Set Shell
-      shell: bash -leo pipefail {0}
+      shell: bash -lo pipefail {0}
       run: |
         echo NIX_SHELL="${{ inputs.devShell }}" >> $GITHUB_ENV
         nix_extra_flags="${{ inputs.verbose == 'false' && '--quiet' || '' }}"

--- a/.github/actions/setup-shell/action.yml
+++ b/.github/actions/setup-shell/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 'ci'
   nix-cache:
     description: Determine whether to enable nix cache
-    default: 'true'
+    default: 'false'
   nix-verbose:
     description: Determine wether to suppress nix log or not
     default: 'false'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,7 +44,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bench
         with:
-          nix-cache: false
           name: ${{ matrix.target.name }}
           cflags: ${{ matrix.target.cflags }}
           archflags: ${{ matrix.target.archflags }}

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -111,7 +111,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bench
         with:
-          nix-cache: false
           nix-verbose: ${{ inputs.verbose }}
           name: ${{ inputs.name }}
           cflags: ${{ inputs.cflags }}

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -111,7 +111,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bench
         with:
-          nix-shell: bench
           nix-cache: false
           nix-verbose: ${{ inputs.verbose }}
           name: ${{ inputs.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,13 @@ jobs:
         target:
          - runner: pqcp-arm64
            name: 'aarch64'
-         - runner: pqcp-x64
+         - runner: ubuntu-latest
            name: 'x86_64'
         exclude:
           - {external: true,
              target: {
                runner: pqcp-arm64,
                name: 'aarch64'
-             }}
-          - {external: true,
-             target: {
-               runner: pqcp-x64,
-               name: 'x86_64'
              }}
     name: Quickcheck (${{ matrix.target.name }})
     runs-on: ${{ matrix.target.runner }}
@@ -80,19 +75,20 @@ jobs:
           compile_mode: native
           func: false
           nistkat: false
-          kat: falst
+          kat: false
       - name: native tests (+debug)
         uses: ./.github/actions/multi-functest
         with:
           compile_mode: native
           cflags: "-DMLKEM_DEBUG"
       - name: cross tests (opt only)
-        if: ${{ matrix.target.runner == 'pqcp-arm64' && (success() || failure()) }}
         uses: ./.github/actions/multi-functest
+        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
         with:
           nix-shell: ci-cross
           nix-cache: true
           compile_mode: cross
+          opt: opt
           func: false
           nistkat: false
 
@@ -151,6 +147,7 @@ jobs:
       ec2_ami_id: ${{ matrix.target.ec2_ami_id }}
       compile_mode: ${{ matrix.target.compile_mode }}
       opt: ${{ matrix.target.opt }}
-      kattest: ${{ matrix.target.kattest }}
+      lint: false
       cbmc: ${{ matrix.target.cbmc == 'true' }}
+      verbose: true
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         uses: ./.github/actions/multi-functest
         with:
           nix-shell: ci-cross
+          nix-cache: true
           compile_mode: cross
           func: false
           nistkat: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         if: ${{ matrix.target.runner == 'pqcp-arm64' && (success() || failure()) }}
         uses: ./.github/actions/multi-functest
         with:
+          nix-shell: ci-cross
           compile_mode: cross
           func: false
           nistkat: false

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -106,6 +106,13 @@ jobs:
     runs-on: ${{ needs.start-ec2-runner.outputs.label }}
     steps:
       - uses: actions/checkout@v4
+      - name: Linting
+        if: ${{ inputs.lint }}
+        uses: ./.github/actions/lint
+        with:
+          nix-shell: ci-linter
+          gh_token: ${{ secrets.AWS_GITHUB_TOKEN }}
+          nix-verbose: ${{ inputs.verbose }}
       - name: Preprocess
         id: preprocess
         shell: bash
@@ -123,12 +130,6 @@ jobs:
           func: ${{ inputs.functest }}
           kat: ${{ inputs.kattest }}
           nistkat: ${{ inputs.nistkattest }}
-      - name: Linting
-        if: ${{ inputs.lint && (success() || failure()) }}
-        uses: ./.github/actions/lint
-        with:
-          nix-shell: ci-linter
-          nix-verbose: ${{ inputs.verbose }}
       - name: CBMC
         if: ${{ inputs.cbmc && (success() || failure()) }}
         uses: ./.github/actions/cbmc

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -106,10 +106,16 @@ jobs:
     runs-on: ${{ needs.start-ec2-runner.outputs.label }}
     steps:
       - uses: actions/checkout@v4
+      - name: Preprocess
+        id: preprocess
+        shell: bash
+        run: |
+          echo "nix-shell=${{ inputs.cbmc && 'ci-cbmc' || 'ci' }}${{ inputs.compile_mode == 'cross' && '-cross' || '' }}" >> $GITHUB_OUTPUT
       - name: Functional Tests
         uses: ./.github/actions/multi-functest
         with:
-          nix-cache: false
+          nix-shell: ${{ steps.preprocess.outputs.nix-shell }}
+          nix-cache: ${{ inputs.cbmc || inputs.compile_mode == 'cross' }}
           nix-verbose: ${{ inputs.verbose }}
           cflags: ${{ inputs.cflags }}
           compile_mode: ${{ inputs.compile_mode }}
@@ -122,13 +128,12 @@ jobs:
         uses: ./.github/actions/lint
         with:
           nix-shell: ci-linter
-          nix-cache: false
           nix-verbose: ${{ inputs.verbose }}
       - name: CBMC
         if: ${{ inputs.cbmc && (success() || failure()) }}
         uses: ./.github/actions/cbmc
         with:
-          nix-shell: ci-cbmc
+          nix-shell: ${{ steps.preprocess.outputs.nix-shell }}
           nix-verbose: ${{ inputs.verbose }}
   stop-ec2-runner:
     name: Stop ${{ inputs.name }} (${{ inputs.ec2_instance_type }})

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718086528,
-        "narHash": "sha256-hoB7B7oPgypePz16cKWawPfhVvMSXj4G/qLsfFuhFjw=",
+        "lastModified": 1728740863,
+        "narHash": "sha256-u+rxA79a0lyhG+u+oPBRtTDtzz8kvkc9a6SWSt9ekVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47b604b07d1e8146d5398b42d3306fdebd343986",
+        "rev": "a3f9ad65a0bf298ed5847629a57808b97e6e8077",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,12 @@
           cbmcpkg = pkgs.callPackage ./cbmc { }; # 6.3.1
 
           linters = builtins.attrValues {
+            clang-tools = pkgs.clang-tools.overrideAttrs {
+              unwrapped = pkgs.llvmPackages_17.clang-unwrapped;
+            };
+
             inherit (pkgs)
               nixpkgs-fmt
-              clang-tools
               shfmt;
 
             inherit (pkgs.python3Packages)

--- a/flake.nix
+++ b/flake.nix
@@ -69,10 +69,10 @@
             gcc ++
             builtins.attrValues {
               inherit (pkgs)
-                yq
                 qemu; # 8.2.4
 
               inherit (pkgs.python3Packages)
+                yq
                 python
                 click;
             };
@@ -94,9 +94,10 @@
               };
           };
 
-          devShells.bench = wrapShell pkgs.mkShellNoCC { packages = core { cross = false; }; };
-          devShells.ci = wrapShell pkgs.mkShellNoCC { packages = core { }; };
+          devShells.ci = wrapShell pkgs.mkShellNoCC { packages = core { cross = false; }; };
+          devShells.ci-cross = wrapShell pkgs.mkShellNoCC { packages = core { }; };
           devShells.ci-cbmc = wrapShell pkgs.mkShellNoCC { packages = core { cross = false; } ++ cbmcpkg; };
+          devShells.ci-cbmc-cross = wrapShell pkgs.mkShellNoCC { packages = core { } ++ cbmcpkg; };
           devShells.ci-linter = wrapShell pkgs.mkShellNoCC { packages = linters; };
         };
       flake = {


### PR DESCRIPTION
This is an almost-copy of #233 removing the commit on propagation of GH access tokens which I don't yet understand and would like to discuss further merging. Opening this version to check whether the performance gains are still similarly pronounced, in which case this version can move forward and propagations of tokens follows in due cause.