### PR TITLE
Add gcc 4.8, 4.9, 7 tests to CI

### DIFF
--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -75,6 +75,14 @@ runs:
             # only summary on the first time
             if [[ "${{ env.SHELL }}" == '' ]]; then
               ARCH=$(uname -m)
+            echo <<-EOF
+              ## Setup
+              Architecture: $ARCH
+              - $(uname -a)
+              - $(nix --version)
+              - $(bash --version | grep -m1 "")
+              - $(${_CROSS_PREFIX}${_CC} --version | grep -m1 "")
+            EOF
             cat >> $GITHUB_STEP_SUMMARY <<-EOF
               ## Setup
               Architecture: $ARCH

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -72,9 +72,7 @@ runs:
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
           script: |
-            # only summary on the first time
-            if [[ "${{ env.SHELL }}" == '' ]]; then
-              ARCH=$(uname -m)
+            ARCH=$(uname -m)
             echo <<-EOF
               ## Setup
               Architecture: $ARCH
@@ -91,7 +89,6 @@ runs:
               - $(bash --version | grep -m1 "")
               - $(${_CROSS_PREFIX}${_CC} --version | grep -m1 "")
             EOF
-            fi
 
       - name: Compile ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -51,14 +51,7 @@ runs:
               _cross_prefix="x86_64-unknown-linux-gnu-"
           fi
 
-          _cc=$CC
-          if [[ $_cc == "" ]]; then
-             _cc=gcc
-          fi
-
           echo _CROSS_PREFIX="$_cross_prefix" >> $GITHUB_ENV
-          echo _CC="$_cc" >> $GITHUB_ENV
-
           echo OPT="${{ inputs.opt == 'true' && 'opt' || 'no-opt' }}" >> $GITHUB_ENV
           echo FUNC="${{ inputs.func == 'true' && 'func' || 'no-func' }}" >> $GITHUB_ENV
           echo KAT="${{ inputs.kat == 'true' && 'kat' || 'no-kat' }}" >> $GITHUB_ENV
@@ -71,25 +64,26 @@ runs:
           nix-verbose: ${{ inputs.nix-verbose }}
           gh_token: ${{ inputs.gh_token }}
           custom_shell: ${{ inputs.custom_shell }}
-          script: |
-            ARCH=$(uname -m)
-            echo <<-EOF
-              ## Setup
-              Architecture: $ARCH
-              - $(uname -a)
-              - $(nix --version)
-              - $(bash --version | grep -m1 "")
-              - $(${_CROSS_PREFIX}${_CC} --version | grep -m1 "")
-            EOF
-            cat >> $GITHUB_STEP_SUMMARY <<-EOF
-              ## Setup
-              Architecture: $ARCH
-              - $(uname -a)
-              - $(nix --version)
-              - $(bash --version | grep -m1 "")
-              - $(${_CROSS_PREFIX}${_CC} --version | grep -m1 "")
-            EOF
-
+      - name: System info
+        shell: ${{ env.SHELL }}
+        run: |
+          ARCH=$(uname -m)
+          echo <<-EOF
+            ## Setup
+            Architecture: $ARCH
+            - $(uname -a)
+            - $(nix --version)
+            - $(bash --version | grep -m1 "")
+            - $(${_CROSS_PREFIX}${CC} --version | grep -m1 "")
+          EOF
+          cat >> $GITHUB_STEP_SUMMARY <<-EOF
+            ## Setup
+            Architecture: $ARCH
+            - $(uname -a)
+            - $(nix --version)
+            - $(bash --version | grep -m1 "")
+            - $(${_CROSS_PREFIX}${CC} --version | grep -m1 "")
+          EOF
       - name: Compile ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
         shell: ${{ env.SHELL }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,24 @@ jobs:
           nistkat: false
           kat: false
           nix-shell: "ci_gcc7"
+      - name: native build+functest (gcc-11)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          nistkat: false
+          kat: false
+          nix-shell: "ci_gcc11"
+      - name: native build+functest (clang-18)
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          nistkat: false
+          kat: false
+          nix-shell: "ci_clang18"
   lint:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,28 @@ jobs:
           opt: opt
           func: false
           nistkat: false
+  compiler_tests:
+    name: Compiler tests (${{ matrix.target.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        external:
+         - ${{ github.repository_owner != 'pq-code-package' }}
+        target:
+         - runner: pqcp-arm64
+           name: 'aarch64'
+         - runner: ubuntu-latest
+           name: 'x86_64'
+        exclude:
+          - {external: true,
+             target: {
+               runner: pqcp-arm64,
+               name: 'aarch64'
+             }}
+    runs-on: ${{ matrix.target.runner }}
+    steps:
+      - uses: actions/checkout@v4
       - name: native build+functest (gcc-4.8)
-        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -109,7 +129,6 @@ jobs:
           kat: false
           nix-shell: "ci_gcc48"
       - name: native build+functest (gcc-4.9)
-        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -119,7 +138,6 @@ jobs:
           kat: false
           nix-shell: "ci_gcc49"
       - name: native build+functest (gcc-7)
-        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
@@ -128,7 +146,6 @@ jobs:
           nistkat: false
           kat: false
           nix-shell: "ci_gcc7"
-
   lint:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
-          compile_mode: nativ
+          compile_mode: native
           func: false
           nistkat: false
           kat: false
@@ -98,6 +98,36 @@ jobs:
           opt: opt
           func: false
           nistkat: false
+      - name: native build+functest (gcc-4.8)
+        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          nistkat: false
+          kat: false
+          nix-shell: "ci_gcc48"
+      - name: native build+functest (gcc-4.9)
+        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          nistkat: false
+          kat: false
+          nix-shell: "ci_gcc49"
+      - name: native build+functest (gcc-7)
+        if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}
+        uses: ./.github/actions/multi-functest
+        with:
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          compile_mode: native
+          func: true
+          nistkat: false
+          kat: false
+          nix-shell: "ci_gcc7"
 
   lint:
     strategy:

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,16 @@
               gcc7; #7
           };
 
+          core_gcc11 = base ++ builtins.attrValues {
+            inherit (pkgs)
+              gcc11; #11
+          };
+
+          core_clang18 = base ++ builtins.attrValues {
+            inherit (pkgs)
+              clang_18; #18
+          };
+
           wrapShell = mkShell: attrs:
             mkShell (attrs // {
               shellHook = ''
@@ -121,9 +131,11 @@
           devShells.ci-cbmc-cross = wrapShell pkgs.mkShellNoCC { packages = core { } ++ cbmcpkg; };
           devShells.ci-linter = wrapShell pkgs.mkShellNoCC { packages = linters; };
 
+          devShells.ci_clang18 = wrapShell pkgs.mkShellNoCC { packages = core_clang18; };
           devShells.ci_gcc48 = wrapShell pkgs.mkShellNoCC { packages = core_gcc48; };
           devShells.ci_gcc49 = wrapShell pkgs.mkShellNoCC { packages = core_gcc49; };
           devShells.ci_gcc7 = wrapShell pkgs.mkShellNoCC { packages = core_gcc7; };
+          devShells.ci_gcc11 = wrapShell pkgs.mkShellNoCC { packages = core_gcc11; };
         };
       flake = {
         # The usual flake attributes can be defined here, including system-

--- a/flake.nix
+++ b/flake.nix
@@ -49,8 +49,7 @@
           x86_64-gcc = wrap-gcc pkgs.pkgsCross.gnu64;
           aarch64-gcc = wrap-gcc pkgs.pkgsCross.aarch64-multiplatform;
 
-          # cross is for determining whether to install the cross toolchain or not
-          core = { cross ? true }:
+          default_gcc = { cross ? true }:
             let
               gcc =
                 if pkgs.stdenv.isDarwin
@@ -66,16 +65,38 @@
                     then [ aarch64-gcc ]
                     else [ x86_64-gcc ];
             in
-            gcc ++
-            builtins.attrValues {
-              inherit (pkgs)
-                qemu; # 8.2.4
+            gcc;
 
+          base =
+            builtins.attrValues {
               inherit (pkgs.python3Packages)
                 pyyaml
                 python
                 click;
             };
+
+          # cross is for determining whether to install the cross toolchain or not
+          core = { cross ? true }:
+            default_gcc { cross = cross; } ++ base ++
+            builtins.attrValues {
+              inherit (pkgs)
+                qemu; # 8.2.4
+            };
+
+          core_gcc48 = base ++ builtins.attrValues {
+            inherit (pkgs)
+              gcc48; #4.8
+          };
+
+          core_gcc49 = base ++ builtins.attrValues {
+            inherit (pkgs)
+              gcc49; #4.9
+          };
+
+          core_gcc7 = base ++ builtins.attrValues {
+            inherit (pkgs)
+              gcc7; #7
+          };
 
           wrapShell = mkShell: attrs:
             mkShell (attrs // {
@@ -99,6 +120,10 @@
           devShells.ci-cbmc = wrapShell pkgs.mkShellNoCC { packages = core { cross = false; } ++ cbmcpkg; };
           devShells.ci-cbmc-cross = wrapShell pkgs.mkShellNoCC { packages = core { } ++ cbmcpkg; };
           devShells.ci-linter = wrapShell pkgs.mkShellNoCC { packages = linters; };
+
+          devShells.ci_gcc48 = wrapShell pkgs.mkShellNoCC { packages = core_gcc48; };
+          devShells.ci_gcc49 = wrapShell pkgs.mkShellNoCC { packages = core_gcc49; };
+          devShells.ci_gcc7 = wrapShell pkgs.mkShellNoCC { packages = core_gcc7; };
         };
       flake = {
         # The usual flake attributes can be defined here, including system-


### PR DESCRIPTION
This PR adds nix shells for gcc 4.8, 4.9, 7, 11, and clang-18, and adds build+functest runs for them to CI.