### PR TITLE
Add namespacing 

### DIFF
--- a/.github/actions/bench/action.yml
+++ b/.github/actions/bench/action.yml
@@ -79,6 +79,10 @@ runs:
               --cflags="${{ inputs.cflags }}" --arch-flags="${{ inputs.archflags }}" \
               $([[ ${{ inputs.opt }} == "false" ]] && echo "--no-opt")  \
               -v --output=output.json ${{ inputs.bench_extra_args }}
+    - name: Check namespace
+      shell: ${{ env.SHELL }}
+      run: |
+        check-namespace
     - name: Store benchmark result
       if: ${{ inputs.store_results == 'true' }}
       uses: benchmark-action/github-action-benchmark@v1

--- a/.github/actions/functest/action.yml
+++ b/.github/actions/functest/action.yml
@@ -92,6 +92,10 @@ runs:
         shell: ${{ env.SHELL }}
         run: |
           tests all  --cross-prefix="${{ env._CROSS_PREFIX }}" --cflags="${{ inputs.cflags }}" --${{ env.OPT }} --${{ env.FUNC }} --${{ env.KAT }} --${{ env.NISTKAT }} --no-compile --run -v
+      - name: Check namespacing ${{ inputs.mode }} ${{ env.OPT }} tests (${{ env.FUNC }}, ${{ env.KAT }}, ${{ env.NISTKAT }})
+        shell: ${{ env.SHELL }}
+        run: |
+          check-namespace
       - name: Post ${{ inputs.mode }} Tests
         shell: ${{ env.SHELL }}
         if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: tests func
         run: |
           ./scripts/tests func
+      - name: check namespacing
+        run: |
+          ./scripts/ci/check-namespace
   build_kat:
     needs: quickcheck
     strategy:

--- a/cbmc/proofs/Makefile_params.common
+++ b/cbmc/proofs/Makefile_params.common
@@ -7,11 +7,11 @@ endif
 MLKEM_K ?= 3
 
 ifeq ($(MLKEM_K),2)
-     MLKEM_NAMESPACE = pqcrystals_mlkem512_ref_
+     MLKEM_NAMESPACE=PQCP_MLKEM_NATIVE_MLKEM512_
 else ifeq ($(MLKEM_K),3)
-     MLKEM_NAMESPACE=pqcrystals_mlkem768_ref_
+     MLKEM_NAMESPACE=PQCP_MLKEM_NATIVE_MLKEM768_
 else ifeq ($(MLKEM_K),4)
-     MLKEM_NAMESPACE=pqcrystals_mlkem1024_ref_
+     MLKEM_NAMESPACE=PQCP_MLKEM_NATIVE_MLKEM1024_
 else
      $(error Invalid value of MLKEM_K)
 endif

--- a/fips202/fips202.h
+++ b/fips202/fips202.h
@@ -4,6 +4,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "namespace.h"
 
 #define SHAKE128_RATE 168
 #define SHAKE256_RATE 136
@@ -36,35 +37,44 @@ typedef struct {
  * This function does not support being called multiple times
  * with the same state.
  */
+#define shake128_absorb FIPS202_NAMESPACE(shake128_absorb)
 void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen);
 /* Squeeze output out of the sponge.
  *
  * Supports being called multiple times
  */
+#define shake128_squeezeblocks FIPS202_NAMESPACE(shake128_squeezeblocks)
 void shake128_squeezeblocks(uint8_t *output, size_t nblocks,
                             shake128ctx *state);
 
 /* Initialize incremental hashing API */
+#define shake256_inc_init FIPS202_NAMESPACE(shake256_inc_init)
 void shake256_inc_init(shake256incctx *state);
+#define shake256_inc_absorb FIPS202_NAMESPACE(shake256_inc_absorb)
 void shake256_inc_absorb(shake256incctx *state, const uint8_t *input,
                          size_t inlen);
 /* Prepares for squeeze phase */
+#define shake256_inc_finalize FIPS202_NAMESPACE(shake256_inc_finalize)
 void shake256_inc_finalize(shake256incctx *state);
 
 /* Squeeze output out of the sponge.
  *
  * Supports being called multiple times
  */
+#define shake256_inc_squeeze FIPS202_NAMESPACE(shake256_inc_squeeze)
 void shake256_inc_squeeze(uint8_t *output, size_t outlen,
                           shake256incctx *state);
 
 /* One-stop SHAKE256 call */
+#define shake256 FIPS202_NAMESPACE(shake256)
 void shake256(uint8_t *output, size_t outlen, const uint8_t *input,
               size_t inlen);
 
 /* One-stop SHA3-256 shop */
+#define sha3_256 FIPS202_NAMESPACE(sha3_256)
 void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen);
 
 /* One-stop SHA3-512 shop */
+#define sha3_512 FIPS202_NAMESPACE(sha3_512)
 void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen);
 #endif

--- a/fips202/fips202x4.h
+++ b/fips202/fips202x4.h
@@ -5,25 +5,29 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "keccakf1600.h"
+#include "namespace.h"
 
+#define shake128x4_absorb FIPS202_NAMESPACE(shake128x4_absorb)
 void shake128x4_absorb(keccakx4_state *state, const uint8_t *in0,
                        const uint8_t *in1, const uint8_t *in2,
                        const uint8_t *in3, size_t inlen);
 
+#define shake256x4_absorb FIPS202_NAMESPACE(shake256x4_absorb)
 void shake256x4_absorb(keccakx4_state *state, const uint8_t *in0,
                        const uint8_t *in1, const uint8_t *in2,
                        const uint8_t *in3, size_t inlen);
 
-
+#define shake128x4_squeezeblocks FIPS202_NAMESPACE(shake128x4_squeezeblocks)
 void shake128x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                               uint8_t *out3, size_t nblocks,
                               keccakx4_state *state);
 
+#define shake256x4_squeezeblocks FIPS202_NAMESPACE(shake256x4_squeezeblocks)
 void shake256x4_squeezeblocks(uint8_t *out0, uint8_t *out1, uint8_t *out2,
                               uint8_t *out3, size_t nblocks,
                               keccakx4_state *state);
 
-
+#define shake256x4 FIPS202_NAMESPACE(shake256x4)
 void shake256x4(uint8_t *out0, uint8_t *out1, uint8_t *out2, uint8_t *out3,
                 size_t outlen, uint8_t *in0, uint8_t *in1, uint8_t *in2,
                 uint8_t *in3, size_t inlen);

--- a/fips202/keccakf1600.h
+++ b/fips202/keccakf1600.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "fips202_native.h"
+#include "namespace.h"
 
 #define KECCAK_WAY 4
 #define KECCAK_LANES 25
@@ -17,27 +18,38 @@
 //
 typedef uint64_t keccakx4_state[KECCAK_WAY * KECCAK_LANES] ALIGN;
 
+#define KeccakF1600_StateExtractBytes \
+  FIPS202_NAMESPACE(KeccakF1600_StateExtractBytes)
 void KeccakF1600_StateExtractBytes(uint64_t *state, unsigned char *data,
                                    unsigned int offset, unsigned int length);
+
+#define KeccakF1600_StateXORBytes FIPS202_NAMESPACE(KeccakF1600_StateXORBytes)
 void KeccakF1600_StateXORBytes(uint64_t *state, const unsigned char *data,
                                unsigned int offset, unsigned int length);
 
+#define KeccakF1600x4_StateExtractBytes \
+  FIPS202_NAMESPACE(KeccakF1600x4_StateExtractBytes)
 void KeccakF1600x4_StateExtractBytes(uint64_t *state, unsigned char *data0,
                                      unsigned char *data1, unsigned char *data2,
                                      unsigned char *data3, unsigned int offset,
                                      unsigned int length);
+
+#define KeccakF1600x4_StateXORBytes \
+  FIPS202_NAMESPACE(KeccakF1600x4_StateXORBytes)
 void KeccakF1600x4_StateXORBytes(uint64_t *state, const unsigned char *data0,
                                  const unsigned char *data1,
                                  const unsigned char *data2,
                                  const unsigned char *data3,
                                  unsigned int offset, unsigned int length);
 
+#define KeccakF1600x4_StatePermute FIPS202_NAMESPACE(KeccakF1600x4_StatePermute)
 void KeccakF1600x4_StatePermute(uint64_t *state);
 
 #if !defined(MLKEM_USE_FIPS202_X1_ASM)
+#define KeccakF1600_StatePermute FIPS202_NAMESPACE(KeccakF1600_StatePermute)
 void KeccakF1600_StatePermute(uint64_t *state);
 #else
-#define KeccakF1600_StatePermute keccak_f1600_x1_asm
+#define KeccakF1600_StatePermute FIPS202_NAMESPACE(keccak_f1600_x1_asm)
 #endif
 
 #endif

--- a/fips202/namespace.h
+++ b/fips202/namespace.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: CC0-1.0
+#ifndef NAMESPACE_H
+#define NAMESPACE_H
+
+#define FIPS202_NAMESPACE(s) PQCP_MLKEM_NATIVE_FIPS202_##s
+#define _FIPS202_NAMESPACE(s) _PQCP_MLKEM_NATIVE_FIPS202_##s
+
+#endif

--- a/fips202/native/aarch64/fips202_native_aarch64.h
+++ b/fips202/native/aarch64/fips202_native_aarch64.h
@@ -4,15 +4,36 @@
 
 #include <stdint.h>
 #include "config.h"
+#include "namespace.h"
 #include "params.h"
 
 #ifdef MLKEM_USE_NATIVE_AARCH64
+#define keccak_f1600_x1_scalar_asm_opt \
+  FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
 void keccak_f1600_x1_scalar_asm_opt(uint64_t *state);
+
+#define keccak_f1600_x1_v84a_asm_clean \
+  FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
 void keccak_f1600_x1_v84a_asm_clean(uint64_t *state);
+
+#define keccak_f1600_x2_v84a_asm_clean \
+  FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
 void keccak_f1600_x2_v84a_asm_clean(uint64_t *state);
+
+#define keccak_f1600_x2_v8a_v84a_asm_hybrid \
+  FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
 void keccak_f1600_x2_v8a_v84a_asm_hybrid(uint64_t *state);
+
+#define keccak_f1600_x4_scalar_v8a_asm_hybrid_opt \
+  FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
 void keccak_f1600_x4_scalar_v8a_asm_hybrid_opt(uint64_t *state);
+
+#define keccak_f1600_x4_scalar_v84a_asm_hybrid_opt \
+  FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
 void keccak_f1600_x4_scalar_v84a_asm_hybrid_opt(uint64_t *state);
+
+#define keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt \
+  FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
 void keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt(uint64_t *state);
 #endif /* MLKEM_USE_NATIVE_AARCH64 */
 

--- a/fips202/native/aarch64/keccak_f1600_x1_scalar_asm_opt.S
+++ b/fips202/native/aarch64/keccak_f1600_x1_scalar_asm_opt.S
@@ -32,6 +32,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "namespace.h"
 
 /********************** CONSTANTS *************************/
     .data
@@ -194,11 +195,11 @@ round_constants:
 
 .text
 .balign 16
-.global keccak_f1600_x1_scalar_asm_opt
-.global _keccak_f1600_x1_scalar_asm_opt
+.global FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
+.global _FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt)
 
-keccak_f1600_x1_scalar_asm_opt:
-_keccak_f1600_x1_scalar_asm_opt:
+FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
+_FIPS202_NAMESPACE(keccak_f1600_x1_scalar_asm_opt):
     alloc_stack
     save_gprs
 

--- a/fips202/native/aarch64/keccak_f1600_x1_v84a_asm_clean.S
+++ b/fips202/native/aarch64/keccak_f1600_x1_v84a_asm_clean.S
@@ -41,6 +41,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "namespace.h"
 
 #if defined(__ARM_FEATURE_SHA3)
 
@@ -339,11 +340,11 @@ round_constants:
 
 .text
 .align 4
-.global keccak_f1600_x1_v84a_asm_clean
-.global _keccak_f1600_x1_v84a_asm_clean
+.global FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
+.global _FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean)
 
-keccak_f1600_x1_v84a_asm_clean:
-_keccak_f1600_x1_v84a_asm_clean:
+FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean):
+_FIPS202_NAMESPACE(keccak_f1600_x1_v84a_asm_clean):
     alloc_stack
     save_vregs
     ASM_LOAD(const_addr, round_constants)

--- a/fips202/native/aarch64/keccak_f1600_x2_v84a_asm_clean.S
+++ b/fips202/native/aarch64/keccak_f1600_x2_v84a_asm_clean.S
@@ -41,6 +41,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "namespace.h"
 
 #if defined(__ARM_FEATURE_SHA3)
 
@@ -367,11 +368,11 @@ round_constants:
 
 .text
 .align 4
-.global keccak_f1600_x2_v84a_asm_clean
-.global _keccak_f1600_x2_v84a_asm_clean
+.global FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
+.global _FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean)
 
-keccak_f1600_x2_v84a_asm_clean:
-_keccak_f1600_x2_v84a_asm_clean:
+FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean):
+_FIPS202_NAMESPACE(keccak_f1600_x2_v84a_asm_clean):
     alloc_stack
     save_vregs
     ASM_LOAD(const_addr, round_constants)

--- a/fips202/native/aarch64/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
+++ b/fips202/native/aarch64/keccak_f1600_x2_v8a_v84a_asm_hybrid.S
@@ -41,6 +41,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "namespace.h"
 
 #if defined(__ARM_FEATURE_SHA3)
 
@@ -408,11 +409,11 @@ round_constants:
 
 .text
 .align 4
-.global keccak_f1600_x2_v8a_v84a_asm_hybrid
-.global _keccak_f1600_x2_v8a_v84a_asm_hybrid
+.global FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
+.global _FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid)
 
-keccak_f1600_x2_v8a_v84a_asm_hybrid:
-_keccak_f1600_x2_v8a_v84a_asm_hybrid:
+FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid):
+_FIPS202_NAMESPACE(keccak_f1600_x2_v8a_v84a_asm_hybrid):
     alloc_stack
     save_gprs
     save_vregs

--- a/fips202/native/aarch64/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
+++ b/fips202/native/aarch64/keccak_f1600_x4_scalar_v84a_asm_hybrid_opt.S
@@ -28,6 +28,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "namespace.h"
 
 #if defined(__ARM_FEATURE_SHA3)
 
@@ -906,13 +907,13 @@ round_constants:
     ror sAsu, sAsu,#(64-55)
 .endm
 
-.global keccak_f1600_x4_scalar_v84a_asm_hybrid_opt
-.global _keccak_f1600_x4_scalar_v84a_asm_hybrid_opt
+.global FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
+.global _FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt)
 .text
 .align 4
 
-keccak_f1600_x4_scalar_v84a_asm_hybrid_opt:
-_keccak_f1600_x4_scalar_v84a_asm_hybrid_opt:
+FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
+_FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v84a_asm_hybrid_opt):
     alloc_stack
     save_gprs
     save_vregs

--- a/fips202/native/aarch64/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
+++ b/fips202/native/aarch64/keccak_f1600_x4_v8a_scalar_hybrid_asm_opt.S
@@ -28,6 +28,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "namespace.h"
 
 #define KECCAK_F1600_ROUNDS 24
 
@@ -887,13 +888,13 @@ round_constants:
     ror sAsu, sAsu,#(64-55)
 .endm
 
-.global keccak_f1600_x4_scalar_v8a_asm_hybrid_opt
-.global _keccak_f1600_x4_scalar_v8a_asm_hybrid_opt
+.global FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
+.global _FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt)
 .text
 .align 4
 
-keccak_f1600_x4_scalar_v8a_asm_hybrid_opt:
-_keccak_f1600_x4_scalar_v8a_asm_hybrid_opt:
+FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
+_FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_asm_hybrid_opt):
     alloc_stack
     save_gprs
     save_vregs

--- a/fips202/native/aarch64/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
+++ b/fips202/native/aarch64/keccak_f1600_x4_v8a_v84a_scalar_hybrid_asm_opt.S
@@ -28,6 +28,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "namespace.h"
 
 #if defined(__ARM_FEATURE_SHA3)
 
@@ -904,13 +905,13 @@ round_constants:
     ror sAsu, sAsu,#(64-55)
 .endm
 
-.global keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt
-.global _keccak_f1600_x4_scalar_v8a_v84a_asm_hybrid_asm_opt
+.global FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
+.global _FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt)
 .text
 .align 4
 
-keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt:
-_keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt:
+FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
+_FIPS202_NAMESPACE(keccak_f1600_x4_scalar_v8a_v84a_hybrid_asm_opt):
     alloc_stack
     save_gprs
     save_vregs

--- a/fips202/native/x86_64/xkcp/KeccakP-1600-times4-SnP.h
+++ b/fips202/native/x86_64/xkcp/KeccakP-1600-times4-SnP.h
@@ -22,6 +22,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
  */
 
 #include "KeccakP-SIMD256-config.h"
+#include "namespace.h"
 
 #define KeccakP1600times4_implementation \
   "256-bit SIMD implementation (" KeccakP1600times4_implementation_config ")"
@@ -32,45 +33,85 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 #include <stddef.h>
 
+#define KeccakP1600times4_InitializeAll \
+  FIPS202_NAMESPACE(KeccakP1600times4_InitializeAll)
 void KeccakP1600times4_InitializeAll(void *states);
+
+#define KeccakP1600times4_AddBytes FIPS202_NAMESPACE(KeccakP1600times4_AddBytes)
 void KeccakP1600times4_AddBytes(void *states, unsigned int instanceIndex,
                                 const unsigned char *data, unsigned int offset,
                                 unsigned int length);
+
+#define KeccakP1600times4_AddLanesAll \
+  FIPS202_NAMESPACE(KeccakP1600times4_AddLanesAll)
 void KeccakP1600times4_AddLanesAll(void *states, const unsigned char *data,
                                    unsigned int laneCount,
                                    unsigned int laneOffset);
+
+#define KeccakP1600times4_OverwriteBytes \
+  FIPS202_NAMESPACE(KeccakP1600times4_OverwriteBytes)
 void KeccakP1600times4_OverwriteBytes(void *states, unsigned int instanceIndex,
                                       const unsigned char *data,
                                       unsigned int offset, unsigned int length);
+
+#define KeccakP1600times4_OverwriteLanesAll \
+  FIPS202_NAMESPACE(KeccakP1600times4_OverwriteLanesAll)
 void KeccakP1600times4_OverwriteLanesAll(void *states,
                                          const unsigned char *data,
                                          unsigned int laneCount,
                                          unsigned int laneOffset);
+
+#define KeccakP1600times4_OverwriteWithZeroes \
+  FIPS202_NAMESPACE(KeccakP1600times4_OverwriteWithZeroes)
 void KeccakP1600times4_OverwriteWithZeroes(void *states,
                                            unsigned int instanceIndex,
                                            unsigned int byteCount);
+
+#define KeccakP1600times4_PermuteAll_12rounds \
+  FIPS202_NAMESPACE(KeccakP1600times4_PermuteAll_12rounds)
 void KeccakP1600times4_PermuteAll_12rounds(void *states);
+
+#define KeccakP1600times4_PermuteAll_24rounds \
+  FIPS202_NAMESPACE(KeccakP1600times4_PermuteAll_24rounds)
 void KeccakP1600times4_PermuteAll_24rounds(void *states);
+
+#define KeccakP1600times4_ExtractBytes \
+  FIPS202_NAMESPACE(KeccakP1600times4_ExtractBytes)
 void KeccakP1600times4_ExtractBytes(const void *states,
                                     unsigned int instanceIndex,
                                     unsigned char *data, unsigned int offset,
                                     unsigned int length);
+
+#define KeccakP1600times4_ExtractLanesAll \
+  FIPS202_NAMESPACE(KeccakP1600times4_ExtractLanesAll)
 void KeccakP1600times4_ExtractLanesAll(const void *states, unsigned char *data,
                                        unsigned int laneCount,
                                        unsigned int laneOffset);
+
+#define KeccakP1600times4_ExtractAndAddBytes \
+  FIPS202_NAMESPACE(KeccakP1600times4_ExtractAndAddBytes)
 void KeccakP1600times4_ExtractAndAddBytes(
     const void *states, unsigned int instanceIndex, const unsigned char *input,
     unsigned char *output, unsigned int offset, unsigned int length);
+
+#define KeccakP1600times4_ExtractAndAddLanesAll \
+  FIPS202_NAMESPACE(KeccakP1600times4_ExtractAndAddLanesAll)
 void KeccakP1600times4_ExtractAndAddLanesAll(const void *states,
                                              const unsigned char *input,
                                              unsigned char *output,
                                              unsigned int laneCount,
                                              unsigned int laneOffset);
+
+#define KeccakF1600times4_FastLoop_Absorb \
+  FIPS202_NAMESPACE(KeccakF1600times4_FastLoop_Absorb)
 size_t KeccakF1600times4_FastLoop_Absorb(void *states, unsigned int laneCount,
                                          unsigned int laneOffsetParallel,
                                          unsigned int laneOffsetSerial,
                                          const unsigned char *data,
                                          size_t dataByteLen);
+
+#define KeccakP1600times4_12rounds_FastLoop_Absorb \
+  FIPS202_NAMESPACE(KeccakP1600times4_12rounds_FastLoop_Absorb)
 size_t KeccakP1600times4_12rounds_FastLoop_Absorb(
     void *states, unsigned int laneCount, unsigned int laneOffsetParallel,
     unsigned int laneOffsetSerial, const unsigned char *data,

--- a/mlkem/api.h
+++ b/mlkem/api.h
@@ -4,86 +4,56 @@
 
 #include <stdint.h>
 
-#define pqcrystals_mlkem512_SECRETKEYBYTES 1632
-#define pqcrystals_mlkem512_PUBLICKEYBYTES 800
-#define pqcrystals_mlkem512_CIPHERTEXTBYTES 768
-#define pqcrystals_mlkem512_KEYPAIRCOINBYTES 64
-#define pqcrystals_mlkem512_ENCCOINBYTES 32
-#define pqcrystals_mlkem512_BYTES 32
+#define PQCP_MLKEM_NATIVE_MLKEM512_SECRETKEYBYTES 1632
+#define PQCP_MLKEM_NATIVE_MLKEM512_PUBLICKEYBYTES 800
+#define PQCP_MLKEM_NATIVE_MLKEM512_CIPHERTEXTBYTES 768
+#define PQCP_MLKEM_NATIVE_MLKEM512_KEYPAIRCOINBYTES 64
+#define PQCP_MLKEM_NATIVE_MLKEM512_ENCCOINBYTES 32
+#define PQCP_MLKEM_NATIVE_MLKEM512_BYTES 32
 
-#define pqcrystals_mlkem512_ref_SECRETKEYBYTES \
-  pqcrystals_mlkem512_SECRETKEYBYTES
-#define pqcrystals_mlkem512_ref_PUBLICKEYBYTES \
-  pqcrystals_mlkem512_PUBLICKEYBYTES
-#define pqcrystals_mlkem512_ref_CIPHERTEXTBYTES \
-  pqcrystals_mlkem512_CIPHERTEXTBYTES
-#define pqcrystals_mlkem512_ref_KEYPAIRCOINBYTES \
-  pqcrystals_mlkem512_KEYPAIRCOINBYTES
-#define pqcrystals_mlkem512_ref_ENCCOINBYTES pqcrystals_mlkem512_ENCCOINBYTES
-#define pqcrystals_mlkem512_ref_BYTES pqcrystals_mlkem512_BYTES
+int PQCP_MLKEM_NATIVE_MLKEM512_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                              const uint8_t *coins);
+int PQCP_MLKEM_NATIVE_MLKEM512_keypair(uint8_t *pk, uint8_t *sk);
+int PQCP_MLKEM_NATIVE_MLKEM512_enc_derand(uint8_t *ct, uint8_t *ss,
+                                          const uint8_t *pk,
+                                          const uint8_t *coins);
+int PQCP_MLKEM_NATIVE_MLKEM512_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int PQCP_MLKEM_NATIVE_MLKEM512_dec(uint8_t *ss, const uint8_t *ct,
+                                   const uint8_t *sk);
 
-int pqcrystals_mlkem512_ref_keypair_derand(uint8_t *pk, uint8_t *sk,
+#define PQCP_MLKEM_NATIVE_MLKEM768_SECRETKEYBYTES 2400
+#define PQCP_MLKEM_NATIVE_MLKEM768_PUBLICKEYBYTES 1184
+#define PQCP_MLKEM_NATIVE_MLKEM768_CIPHERTEXTBYTES 1088
+#define PQCP_MLKEM_NATIVE_MLKEM768_KEYPAIRCOINBYTES 64
+#define PQCP_MLKEM_NATIVE_MLKEM768_ENCCOINBYTES 32
+#define PQCP_MLKEM_NATIVE_MLKEM768_BYTES 32
+
+int PQCP_MLKEM_NATIVE_MLKEM768_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                              const uint8_t *coins);
+int PQCP_MLKEM_NATIVE_MLKEM768_keypair(uint8_t *pk, uint8_t *sk);
+int PQCP_MLKEM_NATIVE_MLKEM768_enc_derand(uint8_t *ct, uint8_t *ss,
+                                          const uint8_t *pk,
+                                          const uint8_t *coins);
+int PQCP_MLKEM_NATIVE_MLKEM768_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
+int PQCP_MLKEM_NATIVE_MLKEM768_dec(uint8_t *ss, const uint8_t *ct,
+                                   const uint8_t *sk);
+
+#define PQCP_MLKEM_NATIVE_MLKEM1024_SECRETKEYBYTES 3168
+#define PQCP_MLKEM_NATIVE_MLKEM1024_PUBLICKEYBYTES 1568
+#define PQCP_MLKEM_NATIVE_MLKEM1024_CIPHERTEXTBYTES 1568
+#define PQCP_MLKEM_NATIVE_MLKEM1024_KEYPAIRCOINBYTES 64
+#define PQCP_MLKEM_NATIVE_MLKEM1024_ENCCOINBYTES 32
+#define PQCP_MLKEM_NATIVE_MLKEM1024_BYTES 32
+
+int PQCP_MLKEM_NATIVE_MLKEM1024_keypair_derand(uint8_t *pk, uint8_t *sk,
+                                               const uint8_t *coins);
+int PQCP_MLKEM_NATIVE_MLKEM1024_keypair(uint8_t *pk, uint8_t *sk);
+int PQCP_MLKEM_NATIVE_MLKEM1024_enc_derand(uint8_t *ct, uint8_t *ss,
+                                           const uint8_t *pk,
                                            const uint8_t *coins);
-int pqcrystals_mlkem512_ref_keypair(uint8_t *pk, uint8_t *sk);
-int pqcrystals_mlkem512_ref_enc_derand(uint8_t *ct, uint8_t *ss,
-                                       const uint8_t *pk, const uint8_t *coins);
-int pqcrystals_mlkem512_ref_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
-int pqcrystals_mlkem512_ref_dec(uint8_t *ss, const uint8_t *ct,
-                                const uint8_t *sk);
-
-#define pqcrystals_mlkem768_SECRETKEYBYTES 2400
-#define pqcrystals_mlkem768_PUBLICKEYBYTES 1184
-#define pqcrystals_mlkem768_CIPHERTEXTBYTES 1088
-#define pqcrystals_mlkem768_KEYPAIRCOINBYTES 64
-#define pqcrystals_mlkem768_ENCCOINBYTES 32
-#define pqcrystals_mlkem768_BYTES 32
-
-#define pqcrystals_mlkem768_ref_SECRETKEYBYTES \
-  pqcrystals_mlkem768_SECRETKEYBYTES
-#define pqcrystals_mlkem768_ref_PUBLICKEYBYTES \
-  pqcrystals_mlkem768_PUBLICKEYBYTES
-#define pqcrystals_mlkem768_ref_CIPHERTEXTBYTES \
-  pqcrystals_mlkem768_CIPHERTEXTBYTES
-#define pqcrystals_mlkem768_ref_KEYPAIRCOINBYTES \
-  pqcrystals_mlkem768_KEYPAIRCOINBYTES
-#define pqcrystals_mlkem768_ref_ENCCOINBYTES pqcrystals_mlkem768_ENCCOINBYTES
-#define pqcrystals_mlkem768_ref_BYTES pqcrystals_mlkem768_BYTES
-
-int pqcrystals_mlkem768_ref_keypair_derand(uint8_t *pk, uint8_t *sk,
-                                           const uint8_t *coins);
-int pqcrystals_mlkem768_ref_keypair(uint8_t *pk, uint8_t *sk);
-int pqcrystals_mlkem768_ref_enc_derand(uint8_t *ct, uint8_t *ss,
-                                       const uint8_t *pk, const uint8_t *coins);
-int pqcrystals_mlkem768_ref_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
-int pqcrystals_mlkem768_ref_dec(uint8_t *ss, const uint8_t *ct,
-                                const uint8_t *sk);
-
-#define pqcrystals_mlkem1024_SECRETKEYBYTES 3168
-#define pqcrystals_mlkem1024_PUBLICKEYBYTES 1568
-#define pqcrystals_mlkem1024_CIPHERTEXTBYTES 1568
-#define pqcrystals_mlkem1024_KEYPAIRCOINBYTES 64
-#define pqcrystals_mlkem1024_ENCCOINBYTES 32
-#define pqcrystals_mlkem1024_BYTES 32
-
-#define pqcrystals_mlkem1024_ref_SECRETKEYBYTES \
-  pqcrystals_mlkem1024_SECRETKEYBYTES
-#define pqcrystals_mlkem1024_ref_PUBLICKEYBYTES \
-  pqcrystals_mlkem1024_PUBLICKEYBYTES
-#define pqcrystals_mlkem1024_ref_CIPHERTEXTBYTES \
-  pqcrystals_mlkem1024_CIPHERTEXTBYTES
-#define pqcrystals_mlkem1024_ref_KEYPAIRCOINBYTES \
-  pqcrystals_mlkem1024_KEYPAIRCOINBYTES
-#define pqcrystals_mlkem1024_ref_ENCCOINBYTES pqcrystals_mlkem1024_ENCCOINBYTES
-#define pqcrystals_mlkem1024_ref_BYTES pqcrystals_mlkem1024_BYTES
-
-int pqcrystals_mlkem1024_ref_keypair_derand(uint8_t *pk, uint8_t *sk,
-                                            const uint8_t *coins);
-int pqcrystals_mlkem1024_ref_keypair(uint8_t *pk, uint8_t *sk);
-int pqcrystals_mlkem1024_ref_enc_derand(uint8_t *ct, uint8_t *ss,
-                                        const uint8_t *pk,
-                                        const uint8_t *coins);
-int pqcrystals_mlkem1024_ref_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk);
-int pqcrystals_mlkem1024_ref_dec(uint8_t *ss, const uint8_t *ct,
-                                 const uint8_t *sk);
+int PQCP_MLKEM_NATIVE_MLKEM1024_enc(uint8_t *ct, uint8_t *ss,
+                                    const uint8_t *pk);
+int PQCP_MLKEM_NATIVE_MLKEM1024_dec(uint8_t *ss, const uint8_t *ct,
+                                    const uint8_t *sk);
 
 #endif

--- a/mlkem/native/aarch64/arith_native_aarch64.h
+++ b/mlkem/native/aarch64/arith_native_aarch64.h
@@ -8,60 +8,97 @@
 
 #ifdef MLKEM_USE_NATIVE_AARCH64
 
+#define ntt_asm_clean MLKEM_NAMESPACE(ntt_asm_clean)
 void ntt_asm_clean(int16_t *);
+
+#define ntt_asm_opt MLKEM_NAMESPACE(ntt_asm_opt)
 void ntt_asm_opt(int16_t *);
+
+#define intt_asm_clean MLKEM_NAMESPACE(intt_asm_clean)
 void intt_asm_clean(int16_t *);
+
+#define intt_asm_opt MLKEM_NAMESPACE(intt_asm_opt)
 void intt_asm_opt(int16_t *);
 
+#define rej_uniform_asm_clean MLKEM_NAMESPACE(rej_uniform_asm_clean)
 unsigned int rej_uniform_asm_clean(int16_t *r, const uint8_t *buf,
                                    unsigned int buflen);
 
+#define poly_reduce_asm_clean MLKEM_NAMESPACE(poly_reduce_asm_clean)
 void poly_reduce_asm_clean(int16_t *);
+
+#define poly_reduce_asm_opt MLKEM_NAMESPACE(poly_reduce_asm_opt)
 void poly_reduce_asm_opt(int16_t *);
 
+#define poly_tomont_asm_clean MLKEM_NAMESPACE(poly_tomont_asm_clean)
 void poly_tomont_asm_clean(int16_t *);
+
+#define poly_tomont_asm_opt MLKEM_NAMESPACE(poly_tomont_asm_opt)
 void poly_tomont_asm_opt(int16_t *);
 
+#define poly_mulcache_compute_asm_clean \
+  MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean)
 void poly_mulcache_compute_asm_clean(int16_t *, const int16_t *,
                                      const int16_t *, const int16_t *);
+
+
+#define poly_mulcache_compute_asm_opt \
+  MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt)
 void poly_mulcache_compute_asm_opt(int16_t *, const int16_t *, const int16_t *,
                                    const int16_t *);
 
+#define poly_tobytes_asm_clean MLKEM_NAMESPACE(poly_tobytes_asm_clean)
 void poly_tobytes_asm_clean(uint8_t *r, const int16_t *a);
 
+#define polyvec_basemul_acc_montgomery_cached_asm_k2_clean \
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
 void polyvec_basemul_acc_montgomery_cached_asm_k2_clean(int16_t *r,
                                                         const int16_t *a,
                                                         const int16_t *b,
                                                         const int16_t *b_cache);
+
+#define polyvec_basemul_acc_montgomery_cached_asm_k3_clean \
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
 void polyvec_basemul_acc_montgomery_cached_asm_k3_clean(int16_t *r,
                                                         const int16_t *a,
                                                         const int16_t *b,
                                                         const int16_t *b_cache);
+
+#define polyvec_basemul_acc_montgomery_cached_asm_k4_clean \
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
 void polyvec_basemul_acc_montgomery_cached_asm_k4_clean(int16_t *r,
                                                         const int16_t *a,
                                                         const int16_t *b,
                                                         const int16_t *b_cache);
 
+#define polyvec_basemul_acc_montgomery_cached_asm_k2_opt \
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
 void polyvec_basemul_acc_montgomery_cached_asm_k2_opt(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
                                                       const int16_t *b_cache);
+
+#define polyvec_basemul_acc_montgomery_cached_asm_k3_opt \
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
 void polyvec_basemul_acc_montgomery_cached_asm_k3_opt(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
                                                       const int16_t *b_cache);
+
+#define polyvec_basemul_acc_montgomery_cached_asm_k4_opt \
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
 void polyvec_basemul_acc_montgomery_cached_asm_k4_opt(int16_t *r,
                                                       const int16_t *a,
                                                       const int16_t *b,
                                                       const int16_t *b_cache);
 
 #define _polyvec_basemul_acc_montgomery_cached_asm_clean_name(k) \
-  polyvec_basemul_acc_montgomery_cached_asm_k##k##_clean
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k##k##_clean)
 #define polyvec_basemul_acc_montgomery_cached_asm_clean_name(k) \
   _polyvec_basemul_acc_montgomery_cached_asm_clean_name(k)
 
 #define _polyvec_basemul_acc_montgomery_cached_asm_opt_name(k) \
-  polyvec_basemul_acc_montgomery_cached_asm_k##k##_opt
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k##k##_opt)
 #define polyvec_basemul_acc_montgomery_cached_asm_opt_name(k) \
   _polyvec_basemul_acc_montgomery_cached_asm_opt_name(k)
 

--- a/mlkem/native/aarch64/consts.h
+++ b/mlkem/native/aarch64/consts.h
@@ -4,8 +4,13 @@
 #define MLKEM_NATIVE_AARCH64_CONSTS
 
 #include <stdint.h>
+#include "params.h"
 
+#define zetas_mulcache_native MLKEM_NAMESPACE(zetas_mulcache_native)
 extern const int16_t zetas_mulcache_native[256];
+
+#define zetas_mulcache_twisted_native \
+  MLKEM_NAMESPACE(zetas_mulcache_twisted_native)
 extern const int16_t zetas_mulcache_twisted_native[256];
 
 #endif /* MLKEM_NATIVE_AARCH64_CONSTS */

--- a/mlkem/native/aarch64/intt_clean.S
+++ b/mlkem/native/aarch64/intt_clean.S
@@ -28,6 +28,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "params.h"
 
 // Bounds:
 // If C is chosen so that |src| < q * C, then |dst| < q * (0.0508 * C + 1/2)
@@ -148,8 +149,8 @@ roots:
 #include "intt_123_45_67_twiddles.S"
 .text
 
-        .global intt_asm_clean
-        .global _intt_asm_clean
+        .global MLKEM_NAMESPACE(intt_asm_clean)
+        .global _MLKEM_NAMESPACE(intt_asm_clean)
 
 .p2align 4
 const_addr:       .short 3329
@@ -177,8 +178,8 @@ ninv_tw_addr:     .short 5040
                   .short 5040
                   .short 5040
 
-intt_asm_clean:
-_intt_asm_clean:
+MLKEM_NAMESPACE(intt_asm_clean):
+_MLKEM_NAMESPACE(intt_asm_clean):
         push_stack
 
         in      .req x0

--- a/mlkem/native/aarch64/intt_opt.S
+++ b/mlkem/native/aarch64/intt_opt.S
@@ -28,6 +28,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "params.h"
 
 // Bounds:
 // If C is chosen so that |src| < q * C, then |dst| < q * (0.0508 * C + 1/2)
@@ -142,9 +143,8 @@
 roots:
 #include "intt_123_45_67_twiddles.S"
 .text
-
-        .global intt_asm_opt
-        .global _intt_asm_opt
+        .global MLKEM_NAMESPACE(intt_asm_opt)
+        .global _MLKEM_NAMESPACE(intt_asm_opt)
 
 .p2align 4
 const_addr:       .short 3329
@@ -172,8 +172,8 @@ ninv_tw_addr:     .short 5040
                   .short 5040
                   .short 5040
 
-intt_asm_opt:
-_intt_asm_opt:
+MLKEM_NAMESPACE(intt_asm_opt):
+_MLKEM_NAMESPACE(intt_asm_opt):
         push_stack
 
         in      .req x0

--- a/mlkem/native/aarch64/ntt_clean.S
+++ b/mlkem/native/aarch64/ntt_clean.S
@@ -28,6 +28,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "params.h"
 
 // Bounds:
 // If C is chosen so that |src| < q * C, then |dst| < q * (0.0508 * C + 1/2)
@@ -183,8 +184,8 @@ roots:
         t3  .req v28
 
         .text
-        .global ntt_asm_clean
-        .global _ntt_asm_clean
+        .global MLKEM_NAMESPACE(ntt_asm_clean)
+        .global _MLKEM_NAMESPACE(ntt_asm_clean)
 
 .p2align 4
 const_addr:
@@ -197,8 +198,8 @@ const_addr:
         .short 0
         .short 0
 
-ntt_asm_clean:
-_ntt_asm_clean:
+MLKEM_NAMESPACE(ntt_asm_clean):
+_MLKEM_NAMESPACE(ntt_asm_clean):
         push_stack
 
         ASM_LOAD(r_ptr0, roots)

--- a/mlkem/native/aarch64/ntt_opt.S
+++ b/mlkem/native/aarch64/ntt_opt.S
@@ -28,6 +28,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "params.h"
 
 // Bounds:
 // If C is chosen so that |src| < q * C, then |dst| < q * (0.0508 * C + 1/2)
@@ -183,8 +184,8 @@ roots:
         t3  .req v28
 
         .text
-        .global ntt_asm_opt
-        .global _ntt_asm_opt
+        .global MLKEM_NAMESPACE(ntt_asm_opt)
+        .global _MLKEM_NAMESPACE(ntt_asm_opt)
 
 .p2align 4
 const_addr:
@@ -197,8 +198,8 @@ const_addr:
         .short 0
         .short 0
 
-ntt_asm_opt:
-_ntt_asm_opt:
+MLKEM_NAMESPACE(ntt_asm_opt):
+_MLKEM_NAMESPACE(ntt_asm_opt):
         push_stack
 
         ASM_LOAD(r_ptr0, roots)

--- a/mlkem/native/aarch64/poly_clean.S
+++ b/mlkem/native/aarch64/poly_clean.S
@@ -5,6 +5,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "params.h"
 
 .macro barrett_reduce a
         sqdmulh t0.8h, \a\().8h, consts.h[1]
@@ -27,9 +28,8 @@
 /**********************************
  *          poly_reduce()         *
  **********************************/
-
-.global poly_reduce_asm_clean
-.global _poly_reduce_asm_clean
+.global MLKEM_NAMESPACE(poly_reduce_asm_clean)
+.global _MLKEM_NAMESPACE(poly_reduce_asm_clean)
 
 .p2align 4
 const_addr:
@@ -54,8 +54,8 @@ const_addr:
         mask    .req v3
         modulus .req v4
 
-poly_reduce_asm_clean:
-_poly_reduce_asm_clean:
+MLKEM_NAMESPACE(poly_reduce_asm_clean):
+_MLKEM_NAMESPACE(poly_reduce_asm_clean):
 
         ASM_LOAD(xtmp, const_addr)
         ld1 {consts.8h}, [xtmp]
@@ -104,9 +104,8 @@ loop_start:
 /********************************************
  *          poly_mulcache_compute()         *
  ********************************************/
-
-.global poly_mulcache_compute_asm_clean
-.global _poly_mulcache_compute_asm_clean
+.global MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean)
+.global _MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean)
 
         cache_ptr  .req x0
         data_ptr   .req x1
@@ -131,8 +130,8 @@ loop_start:
         dst     .req v7
         q_dst   .req q7
 
-poly_mulcache_compute_asm_clean:
-_poly_mulcache_compute_asm_clean:
+MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean):
+_MLKEM_NAMESPACE(poly_mulcache_compute_asm_clean):
         ASM_LOAD(xtmp, const_addr)
         ld1 {consts.8h}, [xtmp]
 
@@ -173,9 +172,8 @@ mulcache_compute_loop_start:
 /********************************************
  *             poly_tobytes()               *
  ********************************************/
-
-.global poly_tobytes_asm_clean
-.global _poly_tobytes_asm_clean
+.global MLKEM_NAMESPACE(poly_tobytes_asm_clean)
+.global _MLKEM_NAMESPACE(poly_tobytes_asm_clean)
 
         data0 .req v0
         data1 .req v1
@@ -190,8 +188,8 @@ mulcache_compute_loop_start:
         src   .req x1
         count .req x2
 
-poly_tobytes_asm_clean:
-_poly_tobytes_asm_clean:
+MLKEM_NAMESPACE(poly_tobytes_asm_clean):
+_MLKEM_NAMESPACE(poly_tobytes_asm_clean):
 
         mov count, #16
 poly_tobytes_asm_clean_asm_loop_start:
@@ -228,9 +226,8 @@ poly_tobytes_asm_clean_asm_loop_start:
 /**********************************
  *          poly_tomont()         *
  **********************************/
-
-.global poly_tomont_asm_clean
-.global _poly_tomont_asm_clean
+.global MLKEM_NAMESPACE(poly_tomont_asm_clean)
+.global _MLKEM_NAMESPACE(poly_tomont_asm_clean)
 
         src     .req x0
         count   .req x1
@@ -250,8 +247,8 @@ poly_tobytes_asm_clean_asm_loop_start:
 
         tmp0    .req v5
 
-poly_tomont_asm_clean:
-_poly_tomont_asm_clean:
+MLKEM_NAMESPACE(poly_tomont_asm_clean):
+_MLKEM_NAMESPACE(poly_tomont_asm_clean):
 
         ASM_LOAD(xtmp, const_addr)
         ld1 {consts.8h}, [xtmp]

--- a/mlkem/native/aarch64/poly_opt.S
+++ b/mlkem/native/aarch64/poly_opt.S
@@ -5,6 +5,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "params.h"
 
 .macro barrett_reduce a
         sqdmulh t0.8h, \a\().8h, consts.h[1]
@@ -27,9 +28,8 @@
 /**********************************
  *          poly_reduce()         *
  **********************************/
-
-.global poly_reduce_asm_opt
-.global _poly_reduce_asm_opt
+.global MLKEM_NAMESPACE(poly_reduce_asm_opt)
+.global _MLKEM_NAMESPACE(poly_reduce_asm_opt)
 
 .p2align 4
 const_addr:
@@ -54,8 +54,8 @@ const_addr:
         mask    .req v3
         modulus .req v4
 
-poly_reduce_asm_opt:
-_poly_reduce_asm_opt:
+MLKEM_NAMESPACE(poly_reduce_asm_opt):
+_MLKEM_NAMESPACE(poly_reduce_asm_opt):
 
         ASM_LOAD(xtmp, const_addr)
         ld1 {consts.8h}, [xtmp]
@@ -267,9 +267,8 @@ loop_start:
 /********************************************
  *          poly_mulcache_compute()         *
  ********************************************/
-
-.global poly_mulcache_compute_asm_opt
-.global _poly_mulcache_compute_asm_opt
+.global MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt)
+.global _MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt)
 
         cache_ptr  .req x0
         data_ptr   .req x1
@@ -294,8 +293,8 @@ loop_start:
         dst     .req v7
         q_dst   .req q7
 
-poly_mulcache_compute_asm_opt:
-_poly_mulcache_compute_asm_opt:
+MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt):
+_MLKEM_NAMESPACE(poly_mulcache_compute_asm_opt):
         ASM_LOAD(xtmp, const_addr)
         ld1 {consts.8h}, [xtmp]
 
@@ -419,9 +418,8 @@ mulcache_compute_loop_start:
 /********************************************
  *             poly_tobytes()               *
  ********************************************/
-
-.global poly_tobytes_asm_opt
-.global _poly_tobytes_asm_opt
+.global MLKEM_NAMESPACE(poly_tobytes_asm_opt)
+.global _MLKEM_NAMESPACE(poly_tobytes_asm_opt)
 
         data0 .req v0
         data1 .req v1
@@ -436,8 +434,8 @@ mulcache_compute_loop_start:
         src   .req x1
         count .req x2
 
-poly_tobytes_asm_opt:
-_poly_tobytes_asm_opt:
+MLKEM_NAMESPACE(poly_tobytes_asm_opt):
+_MLKEM_NAMESPACE(poly_tobytes_asm_opt):
 
         mov count, #16
 poly_tobytes_asm_opt_asm_loop_start:
@@ -474,9 +472,8 @@ poly_tobytes_asm_opt_asm_loop_start:
 /**********************************
  *          poly_tomont()         *
  **********************************/
-
-.global poly_tomont_asm_opt
-.global _poly_tomont_asm_opt
+.global MLKEM_NAMESPACE(poly_tomont_asm_opt)
+.global _MLKEM_NAMESPACE(poly_tomont_asm_opt)
 
         src     .req x0
         count   .req x1
@@ -496,8 +493,8 @@ poly_tobytes_asm_opt_asm_loop_start:
 
         tmp0    .req v5
 
-poly_tomont_asm_opt:
-_poly_tomont_asm_opt:
+MLKEM_NAMESPACE(poly_tomont_asm_opt):
+_MLKEM_NAMESPACE(poly_tomont_asm_opt):
 
         ASM_LOAD(xtmp, const_addr)
         ld1 {consts.8h}, [xtmp]

--- a/mlkem/native/aarch64/polyvec_clean.S
+++ b/mlkem/native/aarch64/polyvec_clean.S
@@ -140,12 +140,11 @@ const_addr:
         .short 0
 
 #if MLKEM_K == 2
+.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
+.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean)
 
-.global polyvec_basemul_acc_montgomery_cached_asm_k2_clean
-.global _polyvec_basemul_acc_montgomery_cached_asm_k2_clean
-
-polyvec_basemul_acc_montgomery_cached_asm_k2_clean:
-_polyvec_basemul_acc_montgomery_cached_asm_k2_clean:
+MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean):
+_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_clean):
         push_stack
 
         ASM_LOAD(xtmp, const_addr)
@@ -180,11 +179,11 @@ k2_loop_start:
 #endif /* MLKEM_K == 2 */
 
 #if MLKEM_K == 3
-.global polyvec_basemul_acc_montgomery_cached_asm_k3_clean
-.global _polyvec_basemul_acc_montgomery_cached_asm_k3_clean
+.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
+.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean)
 
-polyvec_basemul_acc_montgomery_cached_asm_k3_clean:
-_polyvec_basemul_acc_montgomery_cached_asm_k3_clean:
+MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean):
+_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_clean):
         push_stack
 
         ASM_LOAD(xtmp, const_addr)
@@ -224,11 +223,11 @@ k3_loop_start:
 #endif /* MLKEM_K == 3 */
 
 #if MLKEM_K == 4
-.global polyvec_basemul_acc_montgomery_cached_asm_k4_clean
-.global _polyvec_basemul_acc_montgomery_cached_asm_k4_clean
+.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
+.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean)
 
-polyvec_basemul_acc_montgomery_cached_asm_k4_clean:
-_polyvec_basemul_acc_montgomery_cached_asm_k4_clean:
+MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean):
+_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_clean):
         push_stack
 
         ASM_LOAD(xtmp, const_addr)

--- a/mlkem/native/aarch64/polyvec_opt.S
+++ b/mlkem/native/aarch64/polyvec_opt.S
@@ -136,12 +136,11 @@ const_addr:
         .short 0
 
 #if MLKEM_K == 2
+.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
+.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt)
 
-.global polyvec_basemul_acc_montgomery_cached_asm_k2_opt
-.global _polyvec_basemul_acc_montgomery_cached_asm_k2_opt
-
-polyvec_basemul_acc_montgomery_cached_asm_k2_opt:
-_polyvec_basemul_acc_montgomery_cached_asm_k2_opt:
+MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt):
+_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k2_opt):
         push_stack
 
         ASM_LOAD(xtmp, const_addr)
@@ -352,11 +351,11 @@ k2_loop_start:
 #endif /* MLKEM_K == 2 */
 
 #if MLKEM_K == 3
-.global polyvec_basemul_acc_montgomery_cached_asm_k3_opt
-.global _polyvec_basemul_acc_montgomery_cached_asm_k3_opt
+.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
+.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt)
 
-polyvec_basemul_acc_montgomery_cached_asm_k3_opt:
-_polyvec_basemul_acc_montgomery_cached_asm_k3_opt:
+MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt):
+_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k3_opt):
         push_stack
 
         ASM_LOAD(xtmp, const_addr)
@@ -702,11 +701,11 @@ k3_loop_start:
 #endif /* MLKEM_K == 3 */
 
 #if MLKEM_K == 4
-.global polyvec_basemul_acc_montgomery_cached_asm_k4_opt
-.global _polyvec_basemul_acc_montgomery_cached_asm_k4_opt
+.global MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
+.global _MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt)
 
-polyvec_basemul_acc_montgomery_cached_asm_k4_opt:
-_polyvec_basemul_acc_montgomery_cached_asm_k4_opt:
+MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt):
+_MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_asm_k4_opt):
         push_stack
 
         ASM_LOAD(xtmp, const_addr)

--- a/mlkem/native/aarch64/rej_uniform_asm_clean.S
+++ b/mlkem/native/aarch64/rej_uniform_asm_clean.S
@@ -21,6 +21,7 @@
 
 // Needed to provide ASM_LOAD directive
 #include "common.i"
+#include "params.h"
 
 .data
 table_data:
@@ -378,10 +379,10 @@ bit_table_data:
 
 .text
 .align 4
-.global     rej_uniform_asm_clean
-.global     _rej_uniform_asm_clean
-rej_uniform_asm_clean:
-_rej_uniform_asm_clean:
+.global MLKEM_NAMESPACE(rej_uniform_asm_clean)
+.global _MLKEM_NAMESPACE(rej_uniform_asm_clean)
+MLKEM_NAMESPACE(rej_uniform_asm_clean):
+_MLKEM_NAMESPACE(rej_uniform_asm_clean):
     push_stack
 
     ASM_LOAD(bit_table, bit_table_data)

--- a/mlkem/native/x86_64/arith_native_x86_64.h
+++ b/mlkem/native/x86_64/arith_native_x86_64.h
@@ -18,19 +18,41 @@
 #define REJ_UNIFORM_AVX_BUFLEN (REJ_UNIFORM_AVX_NBLOCKS * SHAKE128_RATE)
 
 // TODO: Document buffer constraints
+#define rej_uniform_avx2 MLKEM_NAMESPACE(rej_uniform_avx2)
 unsigned int rej_uniform_avx2(int16_t *r, const uint8_t *buf);
+
+#define ntt_avx2 MLKEM_NAMESPACE(ntt_avx2)
 void ntt_avx2(__m256i *r, const __m256i *qdata);
+
+#define invntt_avx2 MLKEM_NAMESPACE(invntt_avx2)
 void invntt_avx2(__m256i *r, const __m256i *qdata);
+
+#define nttpack_avx2 MLKEM_NAMESPACE(nttpack_avx2)
 void nttpack_avx2(__m256i *r, const __m256i *qdata);
+
+#define nttunpack_avx2 MLKEM_NAMESPACE(nttunpack_avx2)
 void nttunpack_avx2(__m256i *r, const __m256i *qdata);
+
+#define reduce_avx2 MLKEM_NAMESPACE(reduce_avx2)
 void reduce_avx2(__m256i *r, const __m256i *qdata);
+
+#define basemul_avx2 MLKEM_NAMESPACE(basemul_avx2)
 void basemul_avx2(__m256i *r, const __m256i *a, const __m256i *b,
                   const __m256i *qdata);
+
+#define polyvec_basemul_acc_montgomery_cached_avx2 \
+  MLKEM_NAMESPACE(polyvec_basemul_acc_montgomery_cached_avx2)
 void polyvec_basemul_acc_montgomery_cached_avx2(
     poly *r, const polyvec *a, const polyvec *b,
     const polyvec_mulcache *b_cache);
+
+#define ntttobytes_avx2 MLKEM_NAMESPACE(ntttobytes_avx2)
 void ntttobytes_avx2(uint8_t *r, const __m256i *a, const __m256i *qdata);
+
+#define nttfrombytes_avx2 MLKEM_NAMESPACE(nttfrombytes_avx2)
 void nttfrombytes_avx2(__m256i *r, const uint8_t *a, const __m256i *qdata);
+
+#define tomont_avx2 MLKEM_NAMESPACE(tomont_avx2)
 void tomont_avx2(__m256i *r, const __m256i *qdata);
 
 #endif /* MLKEM_USE_NATIVE_X86_64 && SYS_X86_64_AVX2 */

--- a/mlkem/native/x86_64/basemul.S
+++ b/mlkem/native/x86_64/basemul.S
@@ -8,6 +8,7 @@
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
 
 #include "consts.h"
+#include "params.h"
 
 .macro schoolbook off
 vmovdqa		_16XQINV*2(%rcx),%ymm0
@@ -92,10 +93,8 @@ vmovdqa		%ymm11,(64*\off+48)*2(%rdi)
 .endm
 
 .text
-.global basemul_avx2
-.global _basemul_avx2
-basemul_avx2:
-_basemul_avx2:
+.global MLKEM_NAMESPACE(basemul_avx2)
+MLKEM_NAMESPACE(basemul_avx2):
 mov		%rsp,%r8
 and		$-32,%rsp
 sub		$32,%rsp

--- a/mlkem/native/x86_64/fq.S
+++ b/mlkem/native/x86_64/fq.S
@@ -9,6 +9,7 @@
 //   semantics of poly_reduce().
 
 #include "config.h"
+#include "params.h"
 
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
 #include "consts.h"
@@ -57,10 +58,8 @@ vmovdqa		%ymm9,224(%rdi)
 
 ret
 
-.global reduce_avx2
-.global _reduce_avx2
-_reduce_avx2:
-reduce_avx2:
+.global MLKEM_NAMESPACE(reduce_avx2)
+MLKEM_NAMESPACE(reduce_avx2):
 #consts
 vmovdqa		_16XQ*2(%rsi),%ymm0
 vmovdqa		_16XV*2(%rsi),%ymm1
@@ -102,10 +101,8 @@ vmovdqa		%ymm10,224(%rdi)
 
 ret
 
-.global tomont_avx2
-.global _tomont_avx2
-tomont_avx2:
-_tomont_avx2:
+.global MLKEM_NAMESPACE(tomont_avx2)
+MLKEM_NAMESPACE(tomont_avx2):
 #consts
 vmovdqa		_16XQ*2(%rsi),%ymm0
 vmovdqa		_16XMONTSQLO*2(%rsi),%ymm1

--- a/mlkem/native/x86_64/intt.S
+++ b/mlkem/native/x86_64/intt.S
@@ -8,6 +8,7 @@
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
 
 #include "consts.h"
+#include "params.h"
 .include "shuffle.inc"
 .include "fq.inc"
 
@@ -190,10 +191,8 @@ vmovdqa		%ymm11,(64*\off+176)*2(%rdi)
 .endm
 
 .text
-.global invntt_avx2
-.global _invntt_avx2
-invntt_avx2:
-_invntt_avx2:
+.global MLKEM_NAMESPACE(invntt_avx2)
+MLKEM_NAMESPACE(invntt_avx2):
 vmovdqa         _16XQ*2(%rsi),%ymm0
 
 intt_levels0t5	0

--- a/mlkem/native/x86_64/ntt.S
+++ b/mlkem/native/x86_64/ntt.S
@@ -8,6 +8,8 @@
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
 
 #include "consts.h"
+#include "params.h"
+
 .include "shuffle.inc"
 
 .macro mul rh0,rh1,rh2,rh3,zl0=15,zl1=15,zh0=2,zh1=2
@@ -185,10 +187,8 @@ vmovdqa		%ymm11,(128*\off+112)*2(%rdi)
 .endm
 
 .text
-.global ntt_avx2
-.global _ntt_avx2
-ntt_avx2:
-_ntt_avx2:
+.global MLKEM_NAMESPACE(ntt_avx2)
+MLKEM_NAMESPACE(ntt_avx2):
 vmovdqa		_16XQ*2(%rsi),%ymm0
 
 level0		0

--- a/mlkem/native/x86_64/shuffle.S
+++ b/mlkem/native/x86_64/shuffle.S
@@ -8,13 +8,12 @@
 #if defined(MLKEM_USE_NATIVE_X86_64) && defined(SYS_X86_64_AVX2)
 
 #include "consts.h"
+#include "params.h"
 .include "fq.inc"
 .include "shuffle.inc"
 
-.global nttpack_avx2
-.global _nttpack_avx2
-nttpack_avx2:
-_nttpack_avx2:
+.global MLKEM_NAMESPACE(nttpack_avx2)
+MLKEM_NAMESPACE(nttpack_avx2):
 #load
 vmovdqa		(%rdi),%ymm4
 vmovdqa		32(%rdi),%ymm5
@@ -100,10 +99,8 @@ vmovdqa		%ymm11,224(%rdi)
 
 ret
 
-.global nttunpack_avx2
-.global _nttunpack_avx2
-nttunpack_avx2:
-_nttunpack_avx2:
+.global MLKEM_NAMESPACE(nttunpack_avx2)
+MLKEM_NAMESPACE(nttunpack_avx2):
 call		nttunpack128_avx2
 add		$256,%rdi
 call		nttunpack128_avx2
@@ -169,10 +166,8 @@ vmovdqu		%ymm9,160(%rdi)
 
 ret
 
-.global _ntttobytes_avx2
-.global ntttobytes_avx2
-ntttobytes_avx2:
-_ntttobytes_avx2:
+.global MLKEM_NAMESPACE(ntttobytes_avx2)
+MLKEM_NAMESPACE(ntttobytes_avx2):
 #consts
 vmovdqa		_16XQ*2(%rdx),%ymm0
 call		ntttobytes128_avx
@@ -247,10 +242,8 @@ vmovdqa		%ymm1,224(%rdi)
 
 ret
 
-.global nttfrombytes_avx2
-.global _nttfrombytes_avx2
-_nttfrombytes_avx2:
-nttfrombytes_avx2:
+.global MLKEM_NAMESPACE(nttfrombytes_avx2)
+MLKEM_NAMESPACE(nttfrombytes_avx2):
 #consts
 vmovdqa		_16XMASK*2(%rdx),%ymm0
 call		nttfrombytes128_avx

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -11,10 +11,10 @@
 #define zetas MLKEM_NAMESPACE(zetas)
 extern const int16_t zetas[128];
 
-#define ntt MLKEM_NAMESPACE(ntt)
+#define poly_ntt MLKEM_NAMESPACE(poly_ntt)
 void poly_ntt(poly *r);
 
-#define invntt MLKEM_NAMESPACE(invntt)
+#define poly_invntt_tomont MLKEM_NAMESPACE(poly_invntt_tomont)
 void poly_invntt_tomont(poly *r);
 
 // Absolute exclusive upper bound for the output of the inverse NTT

--- a/mlkem/params.h
+++ b/mlkem/params.h
@@ -11,11 +11,14 @@
 
 /* Don't change parameters below this line */
 #if (MLKEM_K == 2)
-#define MLKEM_NAMESPACE(s) pqcrystals_mlkem512_ref_##s
+#define MLKEM_NAMESPACE(s) PQCP_MLKEM_NATIVE_MLKEM512_##s
+#define _MLKEM_NAMESPACE(s) _PQCP_MLKEM_NATIVE_MLKEM512_##s
 #elif (MLKEM_K == 3)
-#define MLKEM_NAMESPACE(s) pqcrystals_mlkem768_ref_##s
+#define MLKEM_NAMESPACE(s) PQCP_MLKEM_NATIVE_MLKEM768_##s
+#define _MLKEM_NAMESPACE(s) _PQCP_MLKEM_NATIVE_MLKEM768_##s
 #elif (MLKEM_K == 4)
-#define MLKEM_NAMESPACE(s) pqcrystals_mlkem1024_ref_##s
+#define MLKEM_NAMESPACE(s) PQCP_MLKEM_NATIVE_MLKEM1024_##s
+#define _MLKEM_NAMESPACE(s) _PQCP_MLKEM_NATIVE_MLKEM1024_##s
 #else
 #error "MLKEM_K must be in {2,3,4}"
 #endif

--- a/scripts/ci/check-namespace
+++ b/scripts/ci/check-namespace
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+# This scripts runs nm on the object files (excluding test objects) and checks that all exported
+# symbols are properly namespaced.
+# It assumes that object files are present under test/build/mlkem{512,768,1024} and
+# test/build/fips202.
+
+# The checked namespaces are
+# PQCP_MLKEM_NATIVE_FIPS202_ for FIPS202 code
+# PQCP_MLKEM_NATIVE_MLKEM512_ for MLKEM512 code
+# PQCP_MLKEM_NATIVE_MLKEM768_ for MLKEM768 code
+# PQCP_MLKEM_NATIVE_MLKEM1024_ for MLKEM1024 code
+
+import subprocess
+import os
+
+def check_file(file_path, namespace):
+    if file_path.endswith("debug.c.o"):
+        print("skipping namespacing: {}".format(file_path))
+        return
+    print("checking namespacing: {}".format(file_path))
+    command = ['nm', '-g', file_path]
+
+    result = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT)
+
+    result = result.stdout.decode('utf-8')
+    lines = result.strip().split("\n")
+    symbols = []
+    for line in lines:
+        if line.startswith("00"):
+            symbols.append(line)
+
+    non_namespaced = []
+    for symbolstr in symbols:
+        *_, symtype, symbol = symbolstr.split()
+        if symtype in 'TDRS':
+            if not (symbol.startswith(namespace) or
+                symbol.startswith('_' + namespace)):
+                non_namespaced.append(symbol)
+
+    if non_namespaced:
+        print("Missing namespace literal {}".format(namespace))
+        for symbol in non_namespaced:
+            print("\tsymbol: {}".format(symbol))
+    assert not non_namespaced, "Literals with missing namespaces"
+
+
+def check_folder(folder, namespace):
+    checked = 0
+    # recursively go through folder and check all object files
+    for root, dirnames, filenames in os.walk(folder):
+        for filename in filenames:
+            if filename.endswith(".o"):
+                check_file(os.path.join(root, filename), namespace)
+                checked += 1
+    print("Checked {} files".format(checked))
+    assert checked > 0
+
+
+def run():
+    check_folder("test/build/mlkem512/mlkem", "PQCP_MLKEM_NATIVE_MLKEM512_")
+    check_folder("test/build/mlkem768/mlkem", "PQCP_MLKEM_NATIVE_MLKEM768_")
+    check_folder("test/build/mlkem1024/mlkem", "PQCP_MLKEM_NATIVE_MLKEM1024_")
+    check_folder("test/build/fips202", "PQCP_MLKEM_NATIVE_FIPS202_")
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Resolves #255 

Depends on #267.

This PR is adding namespacing and enforcing it in CI. 

All ML-KEM symbols are now namespaced with `PQCP_MLKEM_NATIVE_MLKEM{512,768,1024}`.
All FIPS202 symbols are namespaced with `PQCP_MLKEM_NATIVE_FIPS202_`.

Assuming libraries are going to link multiple parameter sets, we could consider using a shared namespace for the functions that are the same for all parameter sets (e.g., NTTs). Then you only need to link them once. But that would require more restructuring (e.g., `poly.c` contains both functions that are common and functions that are parameter-set-specific.).

