### PR TITLE
Fix CI: Re-enable functional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,9 @@ jobs:
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
-          func: false
-          nistkat: false
-          kat: false
+          func: true
+          nistkat: true
+          kat: true
       - name: native tests (+debug)
         uses: ./.github/actions/multi-functest
         with:
@@ -96,8 +96,9 @@ jobs:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: cross
           opt: opt
-          func: false
-          nistkat: false
+          func: true
+          nistkat: true
+          kat: true
   compiler_tests:
     name: Compiler tests (${{ matrix.target.name }})
     strategy:


### PR DESCRIPTION
Somehow our functional tests are not doing what they are supposed to do

For example: https://github.com/pq-code-package/mlkem-c-aarch64/actions/runs/11566834855/job/32196177392?pr=266

This is running:
```
tests all  --cross-prefix="" --cflags="" --opt --no-func --no-kat --no-nistkat --compile --no-run -v
tests all  --cross-prefix="" --cflags="" --opt --no-func --no-kat --no-nistkat --no-compile --run -v
```
Which are both no-ops. I am not quite sure what these are for, but this is an attempt to fix it. 