### PR TITLE
Add dependency-update tool dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-click
+click==8.1.7
 pyyaml==6.0.2


### PR DESCRIPTION
This adds a dependabot configruation that open pull requests if our github-actions or pip dependencies get updated.

This was flagged by the security code scanning: https://github.com/pq-code-package/mlkem-c-aarch64/security/code-scanning/2