### PR TITLE
CI: Set top-level workflow permissions to contents: read

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Bench
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/bench_ec2_any.yml
+++ b/.github/workflows/bench_ec2_any.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: bench-ec2-any
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/bench_ec2_reusable.yml
+++ b/.github/workflows/bench_ec2_reusable.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: bench-ec2-reusable
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: CI
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ci_ec2_any.yml
+++ b/.github/workflows/ci_ec2_any.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: ci-ec2-any
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ci_ec2_reusable.yml
+++ b/.github/workflows/ci_ec2_reusable.yml
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: ci-ec2-reusable
+permissions:
+  contents: read
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Most of our jobs don't need any extra permissions, and if they do, this is already set on the job level.

This was flagged by the security code scanning: e.g., https://github.com/pq-code-package/mlkem-c-aarch64/security/code-scanning/60
