### PR TITLE
Fix quoting of CFLAGS when fwding from `tests all` to `tests func/kat/nistkat`

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -669,17 +669,30 @@ def all(
     compile_mode = "cross" if state.cross_prefix else "native"
 
     def _cmd(cmd: str, compile_flag: str, run_flag: str) -> [str]:
-        return [
-            "tests",
-            f"{cmd}",
-            f"--cross-prefix={state.cross_prefix}",
-            *([f"--cflags={state.cflags}"] if state.cflags is not None else []),
-            f"--{opt_flag}",
-            f"--{auto_flag}",
-            f"--{compile_flag}",
-            f"--{run_flag}",
-            *(["--verbose"] if state.verbose else []),
-        ]
+        if compile_flag == "compile":
+            return [
+                "tests",
+                f"{cmd}",
+                f"--cross-prefix={state.cross_prefix}",
+                *(["--cflags", state.cflags] if state.cflags is not None else []),
+                f"--{opt_flag}",
+                f"--{auto_flag}",
+                f"--compile",
+                f"--no-run",
+                *(["--verbose"] if state.verbose else []),
+            ]
+        elif run_flag == "run":
+            # Omit CFLAGS here because quoting for CFLAGS breaks when there are
+            # multiple space-seperated components to it.
+            return [
+                "tests",
+                f"{cmd}",
+                f"--{opt_flag}",
+                f"--{auto_flag}",
+                f"--no-compile",
+                f"--run",
+                *(["--verbose"] if state.verbose else []),
+            ]
 
     def _cmds(compile_flag: str, run_flag: str) -> TypedDict:
         return {

--- a/scripts/tests
+++ b/scripts/tests
@@ -687,6 +687,7 @@ def all(
             return [
                 "tests",
                 f"{cmd}",
+                f"--cross-prefix={state.cross_prefix}",
                 f"--{opt_flag}",
                 f"--{auto_flag}",
                 f"--no-compile",


### PR DESCRIPTION
Previously, `tests all --cflags="A B"` would not work because the recursive call to `tests func/kat/nistkat` would not properly quote the CFLAGS, leading to an unrecognized option error.

Fixes #276.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
