### PR TITLE
Add address + UB sanitizer to CI debug tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,12 @@ jobs:
           func: true
           nistkat: true
           kat: true
-      - name: native tests (+debug)
+      - name: native tests (+debug+memsan+ubsan)
         uses: ./.github/actions/multi-functest
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           compile_mode: native
-          cflags: "-DMLKEM_DEBUG"
+          cflags: "-DMLKEM_DEBUG -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all"
       - name: cross tests (opt only)
         uses: ./.github/actions/multi-functest
         if: ${{ matrix.target.runner != 'macos-latest' && (success() || failure()) }}


### PR DESCRIPTION
This PR extends the native debug tests in the CI to enable the address and undefined-behaviour sanitizers in GCC.

Based on #277 

Fixes https://github.com/pq-code-package/mlkem-c-aarch64/issues/278