### PR TITLE
Add input validation for public key and secret key

### DIFF
--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -27,6 +27,7 @@ static int check_pk(const uint8_t pk[MLKEM_PUBLICKEYBYTES]) {
   polyvec_frombytes(&p, pk);
   polyvec_reduce(&p);
   polyvec_tobytes(p_reencoded, &p);
+  // Data is public, so a variable-time memcmp() is OK
   if (memcmp(pk, p_reencoded, MLKEM_POLYVECBYTES)) {
     return -1;
   }
@@ -48,6 +49,9 @@ static int check_pk(const uint8_t pk[MLKEM_PUBLICKEYBYTES]) {
  **************************************************/
 static int check_sk(const uint8_t sk[MLKEM_SECRETKEYBYTES]) {
   uint8_t test[MLKEM_SYMBYTES];
+  // The parts of `sk` being hashed and compared here are public, so
+  // no public information is leaked through the runtime or the return value
+  // of this function.
   hash_h(test, sk + MLKEM_INDCPA_SECRETKEYBYTES, MLKEM_PUBLICKEYBYTES);
   if (memcmp(sk + MLKEM_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, test,
              MLKEM_SYMBYTES)) {
@@ -120,7 +124,7 @@ int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
  *bytes)
  **
  * Returns 0 on success, and -1 if the public key modulus check (see Section 7.2
- *of FIPS203) fails.
+ * of FIPS203) fails.
  **************************************************/
 int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
                           const uint8_t *coins) {
@@ -159,7 +163,7 @@ int crypto_kem_enc_derand(uint8_t *ct, uint8_t *ss, const uint8_t *pk,
  *                (an already allocated array of MLKEM_PUBLICKEYBYTES bytes)
  *
  * Returns 0 on success, and -1 if the public key modulus check (see Section 7.2
- *of FIPS203) fails
+ * of FIPS203) fails.
  **************************************************/
 int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
   uint8_t coins[MLKEM_SYMBYTES] ALIGN;
@@ -181,7 +185,7 @@ int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
  *                (an already allocated array of MLKEM_SECRETKEYBYTES bytes)
  *
  * Returns 0 on success, and -1 if the secret key hash check (see Section 7.3 of
- *FIPS203) fails
+ * FIPS203) fails.
  *
  * On failure, ss will contain a pseudo-random value.
  **************************************************/


### PR DESCRIPTION
Resolves #210.

FIPS204 mandates input validation of the public key in encapsulation, and for the secret key in decapsulation.
This commit adds the input validation for both.

Input validation for the public key is described in Section 7.2 and ensures that coefficients in the public key are in the valid range [0, q-1]. We check this by decoding the public key, reducing to the canonical unsigned representative, re-encoding the reduced polynomial, and comparing it to the input public key.

Input validation for the secret key is described in Section 7.3 and ensures that the hash of the public key (that is part of the secret key) actually corresponds to the real hash of the public key.
We check this by re-computing the hash.
