### PR TITLE
CBMC: Add specs + proofs for poly_cbd_eta{1,2}

### DIFF
--- a/cbmc/proofs/poly_cbd_eta1/Makefile
+++ b/cbmc/proofs/poly_cbd_eta1/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_cbd_eta1_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_cbd_eta1
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/cbd.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)poly_cbd_eta1
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)poly_cbd_eta1
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/poly_cbd_eta1/cbmc-proof.txt
+++ b/cbmc/proofs/poly_cbd_eta1/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/poly_cbd_eta1/poly_cbd_eta1_harness.c
+++ b/cbmc/proofs/poly_cbd_eta1/poly_cbd_eta1_harness.c
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file poly_cbd_eta1_harness.c
+ * @brief Implements the proof harness for poly_cbd_eta1 function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <cbd.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4];
+  poly a;
+
+  poly_cbd_eta1(&a, buf);
+}

--- a/cbmc/proofs/poly_cbd_eta2/Makefile
+++ b/cbmc/proofs/poly_cbd_eta2/Makefile
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile_params.common
+
+HARNESS_ENTRY = harness
+HARNESS_FILE = poly_cbd_eta2_harness
+
+# This should be a unique identifier for this proof, and will appear on the
+# Litani dashboard. It can be human-readable and contain spaces if you wish.
+PROOF_UID = poly_cbd_eta2
+
+DEFINES +=
+INCLUDES +=
+
+REMOVE_FUNCTION_BODY +=
+UNWINDSET +=
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
+PROJECT_SOURCES += $(SRCDIR)/mlkem/cbd.c
+
+CHECK_FUNCTION_CONTRACTS=$(MLKEM_NAMESPACE)poly_cbd_eta2
+USE_FUNCTION_CONTRACTS=
+APPLY_LOOP_CONTRACTS=on
+USE_DYNAMIC_FRAMES=1
+
+# Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
+EXTERNAL_SAT_SOLVER=
+CBMCFLAGS=--smt2
+
+FUNCTION_NAME = $(MLKEM_NAMESPACE)poly_cbd_eta2
+
+# If this proof is found to consume huge amounts of RAM, you can set the
+# EXPENSIVE variable. With new enough versions of the proof tools, this will
+# restrict the number of EXPENSIVE CBMC jobs running at once. See the
+# documentation in Makefile.common under the "Job Pools" heading for details.
+# EXPENSIVE = true
+
+# This function is large enough to need...
+CBMC_OBJECT_BITS = 8
+
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("mlkem/poly.c") in PROJECT_SOURCES).
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include ../Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/mlkem/poly.c
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
+include ../Makefile.common

--- a/cbmc/proofs/poly_cbd_eta2/cbmc-proof.txt
+++ b/cbmc/proofs/poly_cbd_eta2/cbmc-proof.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks this directory as containing a CBMC proof.

--- a/cbmc/proofs/poly_cbd_eta2/poly_cbd_eta2_harness.c
+++ b/cbmc/proofs/poly_cbd_eta2/poly_cbd_eta2_harness.c
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+/*
+ * Insert copyright notice
+ */
+
+/**
+ * @file poly_cbd_eta2_harness.c
+ * @brief Implements the proof harness for poly_cbd_eta2 function.
+ */
+
+/*
+ * Insert project header files that
+ *   - include the declaration of the function
+ *   - include the types needed to declare function arguments
+ */
+#include <cbd.h>
+
+/**
+ * @brief Starting point for formal analysis
+ *
+ */
+void harness(void) {
+  uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4];
+  poly a;
+
+  poly_cbd_eta2(&a, buf);
+}

--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -54,21 +54,29 @@ static uint32_t load24_littleendian(const uint8_t x[3]) {
  *              - const uint8_t *buf: pointer to input byte array
  **************************************************/
 static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4]) {
-  unsigned int i, j;
+  int i, j;
   uint32_t t, d;
   int16_t a, b;
 
-  for (i = 0; i < MLKEM_N / 8; i++) {
-    t = load32_littleendian(buf + 4 * i);
-    d = t & 0x55555555;
-    d += (t >> 1) & 0x55555555;
+  for (i = 0; i < MLKEM_N / 8; i++)  // clang-format off
+    ASSIGNS(i, j, a, b, t, d, OBJECT_WHOLE(r))
+    INVARIANT(i >= 0 && i <= MLKEM_N / 8)
+    INVARIANT(ARRAY_IN_BOUNDS(int, k, 0, (8 * i - 1), r->coeffs, -2, +2))  // clang-format on
+    {
+      t = load32_littleendian(buf + 4 * i);
+      d = t & 0x55555555;
+      d += (t >> 1) & 0x55555555;
 
-    for (j = 0; j < 8; j++) {
-      a = (d >> (4 * j + 0)) & 0x3;
-      b = (d >> (4 * j + 2)) & 0x3;
-      r->coeffs[8 * i + j] = a - b;
+      for (j = 0; j < 8; j++)  // clang-format off
+        ASSIGNS(j, a, b, OBJECT_WHOLE(r))
+        INVARIANT(i >= 0 && i <= MLKEM_N / 8 && j >= 0 && j <= 8)
+        INVARIANT(ARRAY_IN_BOUNDS(int, k, 0, 8 * i + j - 1, r->coeffs, -2, +2))  // clang-format on
+        {
+          a = (d >> (4 * j + 0)) & 0x3;
+          b = (d >> (4 * j + 2)) & 0x3;
+          r->coeffs[8 * i + j] = a - b;
+        }
     }
-  }
 }
 
 /*************************************************
@@ -84,22 +92,30 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4]) {
  **************************************************/
 #if MLKEM_ETA1 == 3
 static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4]) {
-  unsigned int i, j;
+  int i, j;
   uint32_t t, d;
   int16_t a, b;
 
-  for (i = 0; i < MLKEM_N / 4; i++) {
-    t = load24_littleendian(buf + 3 * i);
-    d = t & 0x00249249;
-    d += (t >> 1) & 0x00249249;
-    d += (t >> 2) & 0x00249249;
+  for (i = 0; i < MLKEM_N / 4; i++)  // clang-format off
+    ASSIGNS(i, j, a, b, t, d, OBJECT_WHOLE(r))
+    INVARIANT(i >= 0 && i <= MLKEM_N / 4)
+    INVARIANT(ARRAY_IN_BOUNDS(int, k, 0, (4 * i - 1), r->coeffs, -3, +3))  // clang-format on
+    {
+      t = load24_littleendian(buf + 3 * i);
+      d = t & 0x00249249;
+      d += (t >> 1) & 0x00249249;
+      d += (t >> 2) & 0x00249249;
 
-    for (j = 0; j < 4; j++) {
-      a = (d >> (6 * j + 0)) & 0x7;
-      b = (d >> (6 * j + 3)) & 0x7;
-      r->coeffs[4 * i + j] = a - b;
+      for (j = 0; j < 4; j++)  // clang-format off
+        ASSIGNS(j, a, b, OBJECT_WHOLE(r))
+        INVARIANT(i >= 0 && i <= MLKEM_N / 4 && j >= 0 && j <= 4)
+        INVARIANT(ARRAY_IN_BOUNDS(int, k, 0, 4 * i + j - 1, r->coeffs, -3, +3))  // clang-format on
+        {
+          a = (d >> (6 * j + 0)) & 0x7;
+          b = (d >> (6 * j + 3)) & 0x7;
+          r->coeffs[4 * i + j] = a - b;
+        }
     }
-  }
 }
 #endif
 

--- a/mlkem/cbd.h
+++ b/mlkem/cbd.h
@@ -7,9 +7,41 @@
 #include "poly.h"
 
 #define poly_cbd_eta1 MLKEM_NAMESPACE(poly_cbd_eta1)
-void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4]);
+/*************************************************
+ * Name:        poly_cbd_eta1
+ *
+ * Description: Given an array of uniformly random bytes, compute
+ *              polynomial with coefficients distributed according to
+ *              a centered binomial distribution with parameter MLKEM_ETA1.
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *buf: pointer to input byte array
+ **************************************************/
+void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4])
+    // clang-format off
+REQUIRES(r != NULL && IS_FRESH(r, sizeof(poly)))
+REQUIRES(buf != NULL && IS_FRESH(buf, MLKEM_ETA1 * MLKEM_N / 4))
+ASSIGNS(OBJECT_WHOLE(r))
+ENSURES(ARRAY_IN_BOUNDS(int, k, 0, MLKEM_N - 1, r->coeffs, -MLKEM_ETA1, MLKEM_ETA1));
+// clang-format on
 
 #define poly_cbd_eta2 MLKEM_NAMESPACE(poly_cbd_eta2)
-void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4]);
+/*************************************************
+ * Name:        poly_cbd_eta1
+ *
+ * Description: Given an array of uniformly random bytes, compute
+ *              polynomial with coefficients distributed according to
+ *              a centered binomial distribution with parameter MLKEM_ETA2.
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *buf: pointer to input byte array
+ **************************************************/
+void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4])
+    // clang-format off
+REQUIRES(r != NULL && IS_FRESH(r, sizeof(poly)))
+REQUIRES(buf != NULL && IS_FRESH(buf, MLKEM_ETA2 * MLKEM_N / 4))
+ASSIGNS(OBJECT_WHOLE(r))
+ENSURES(ARRAY_IN_BOUNDS(int, k, 0, MLKEM_N - 1, r->coeffs, -MLKEM_ETA2, MLKEM_ETA2));
+// clang-format on
 
 #endif


### PR DESCRIPTION
This commit adds proofs of type safety, memory safety, and output bounds for poly_cbd_eta1 and poly_cbd_eta2.

Resolves #309

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
