### PR TITLE
Hoist core of gen_matrix() into helper functions

### DIFF
--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -173,6 +173,7 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES],
         seedxy[j][MLKEM_SYMBYTES + 0] = y;
         seedxy[j][MLKEM_SYMBYTES + 1] = x;
       }
+      vec[j] = a[x].vec[y].coeffs;
     }
 
     shake128x4_absorb(&statex, seedxy[0], seedxy[1], seedxy[2], seedxy[3],
@@ -181,9 +182,6 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES],
                              GEN_MATRIX_NBLOCKS, &statex);
 
     for (unsigned int j = 0; j < KECCAK_WAY; j++) {
-      x = (i + j) / MLKEM_K;
-      y = (i + j) % MLKEM_K;
-      vec[j] = a[x].vec[y].coeffs;
       buflen = GEN_MATRIX_NBLOCKS * SHAKE128_RATE;
       ctr[j] = rej_uniform(vec[j], MLKEM_N, bufx[j], buflen);
     }


### PR DESCRIPTION
Previously, the matrix generation was done in a single routine, gen_matrix.
This routine is among the most complex in MLKEM. In particular, verification
is likely going to be challenging with the monolithic structure and up to
three nested loops.

This commit aims to facilitate readability and verifiability by hoisting
the core of the matrix generation into separate helper functions:

- gen_matrix_entry(), generating a single matrix entry from a seed buffer
- gen_matrix_entry_x4(), generating 4 matrix entries from 4 seed buffers

Apart from splitting the code between gen_matrix and the new helper
functions, some more comments have been added.