### PR TITLE
Speed up CBMC proof of polyvec_tobytes()

### DIFF
--- a/cbmc/proofs/polyvec_tobytes/Makefile
+++ b/cbmc/proofs/polyvec_tobytes/Makefile
@@ -13,7 +13,7 @@ DEFINES +=
 INCLUDES +=
 
 REMOVE_FUNCTION_BODY +=
-UNWINDSET += $(MLKEM_NAMESPACE)polyvec_tobytes.0:4 # Largest value of MLKEM_K
+UNWINDSET +=
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c
 PROJECT_SOURCES += $(SRCDIR)/mlkem/polyvec.c
@@ -25,7 +25,7 @@ USE_DYNAMIC_FRAMES=1
 
 # Disable any setting of EXTERNAL_SAT_SOLVER, and choose SMT backend instead
 EXTERNAL_SAT_SOLVER=
-CBMCFLAGS=--bitwuzla
+CBMCFLAGS=--smt2
 
 FUNCTION_NAME = $(MLKEM_NAMESPACE)polyvec_tobytes
 

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -140,13 +140,16 @@ void polyvec_decompress(polyvec *r,
 
 void polyvec_tobytes(uint8_t r[MLKEM_POLYVECBYTES], const polyvec *a) {
   unsigned int i;
-  for (i = 0; i < MLKEM_K; i++) {
+  for (i = 0; i < MLKEM_K; i++) // clang-format off
+    ASSIGNS(i, OBJECT_WHOLE(r))
+    INVARIANT(i <= MLKEM_K) // clang-format on
+  {
     poly_tobytes(r + i * MLKEM_POLYBYTES, &a->vec[i]);
   }
 }
 
 void polyvec_frombytes(polyvec *r, const uint8_t a[MLKEM_POLYVECBYTES]) {
-  unsigned int i;
+  int i;
   for (i = 0; i < MLKEM_K; i++) {
     poly_frombytes(&r->vec[i], a + i * MLKEM_POLYBYTES);
   }


### PR DESCRIPTION
This was running very slowly. This commit reduces the runtime from minutes to seconds by switching to smt2 and using a loop invariant.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
