### PR TITLE
Fix bench_components

### DIFF
--- a/test/bench_components_mlkem.c
+++ b/test/bench_components_mlkem.c
@@ -54,10 +54,10 @@ static int bench(void) {
   BENCH("keccak-f1600-x1", KeccakF1600_StatePermute(data0));
   BENCH("keccak-f1600-x4", KeccakF1600x4_StatePermute(data0));
   BENCH("rej_uniform (bulk)",
-        rej_uniform((int16_t *)data0, MLKEM_N, (const uint8_t *)data1,
+        rej_uniform((int16_t *)data0, MLKEM_N, 0, (const uint8_t *)data1,
                     3 * SHAKE128_RATE));
   BENCH("rej_uniform (residue)",
-        rej_uniform((int16_t *)data0, MLKEM_N / 2, (const uint8_t *)data1,
+        rej_uniform((int16_t *)data0, MLKEM_N / 2, 0, (const uint8_t *)data1,
                     1 * SHAKE128_RATE));
 
 #if defined(MLKEM_USE_NATIVE_AARCH64)


### PR DESCRIPTION
https://github.com/pq-code-package/mlkem-c-aarch64/pull/348 changed the signature of rej_uniform, but missed to adjust the component benchmarks and, hence, benchmarking fails.
This PR fixes that.

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review. -->
